### PR TITLE
Tooltip (with confirmation) helper functions

### DIFF
--- a/Ktisis/Interface/ConfigGui.cs
+++ b/Ktisis/Interface/ConfigGui.cs
@@ -7,6 +7,7 @@ using Dalamud.Interface;
 
 using Ktisis.Localization;
 using Ktisis.Structs.Bones;
+using Ktisis.Util;
 
 namespace Ktisis.Interface {
 	internal class ConfigGui {
@@ -110,7 +111,7 @@ namespace Ktisis.Interface {
 			ImGui.Text(linkBoneCategoriesColors ? "Unlink bones colors" : "Link bones colors");
 
 			ImGui.SameLine();
-			if (ImGuiComponents.IconButton(FontAwesomeIcon.Eraser))
+			if (GuiHelpers.IconButtonHoldConfirm(FontAwesomeIcon.Eraser, "Hold Control and Shift to erase colors.", ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift))
 			{
 				Vector4 eraseColor = new(1.0F, 1.0F, 1.0F, 0.5647059F);
 				if (linkBoneCategoriesColors) {
@@ -135,7 +136,7 @@ namespace Ktisis.Interface {
 			} else {
 
 				ImGui.SameLine();
-				if (ImGuiComponents.IconButton(FontAwesomeIcon.Rainbow))
+				if (GuiHelpers.IconButtonHoldConfirm(FontAwesomeIcon.Rainbow, "Hold Control and Shift to reset colors to their default values.", ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift))
 				{
 					foreach ((string categoryName, Category category) in Category.Categories)
 					{

--- a/Ktisis/Interface/KtisisGui.cs
+++ b/Ktisis/Interface/KtisisGui.cs
@@ -7,6 +7,7 @@ using Dalamud.Interface;
 using Dalamud.Interface.Components;
 
 using Ktisis.Structs.Bones;
+using Ktisis.Util;
 
 namespace Ktisis.Interface {
 	internal class KtisisGui {
@@ -78,11 +79,12 @@ namespace Ktisis.Interface {
 				// Second row
 
 				var gizmode = Plugin.SkeletonEditor.Gizmode;
-				if (ImGuiComponents.IconButton(gizmode == MODE.WORLD ? FontAwesomeIcon.Globe : FontAwesomeIcon.Home))
+				if (GuiHelpers.IconButtonTooltip(
+					gizmode == MODE.WORLD ? FontAwesomeIcon.Globe : FontAwesomeIcon.Home, "Local / World orientation mode switch."))
 					Plugin.SkeletonEditor.Gizmode = gizmode == MODE.WORLD ? MODE.LOCAL : MODE.WORLD;
 
 				ImGui.SameLine();
-				if (ImGuiComponents.IconButton(FontAwesomeIcon.PencilAlt)) {
+				if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.PencilAlt,"Edit targeted Actor's appearance.")) {
 					Plugin.CustomizeGui.Show(Plugin.SkeletonEditor.Subject);
 				}
 

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -1,0 +1,39 @@
+using ImGuiNET;
+
+using Dalamud.Interface;
+using Dalamud.Interface.Components;
+
+namespace Ktisis.Util
+{
+	internal class GuiHelpers
+	{
+		public static bool IconButtonHoldConfirm(FontAwesomeIcon icon, string tooltip, bool isHoldingKey)
+		{
+			if (!isHoldingKey) ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+			bool accepting = ImGuiComponents.IconButton(icon);
+			if (!isHoldingKey) ImGui.PopStyleVar();
+
+			Tooltip(tooltip);
+
+			return accepting && isHoldingKey;
+		}
+		public static bool IconButtonTooltip(FontAwesomeIcon icon, string tooltip)
+		{
+			bool accepting = ImGuiComponents.IconButton(icon);
+			Tooltip(tooltip);
+			return accepting;
+		}
+		public static void Tooltip(string text)
+		{
+			if (ImGui.IsItemHovered())
+			{
+				ImGui.BeginTooltip();
+				ImGui.PushTextWrapPos(ImGui.GetFontSize() * 35.0f);
+				ImGui.TextUnformatted(text);
+				ImGui.PopTextWrapPos();
+				ImGui.EndTooltip();
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
The main purpose of this PR is to offer the method `IconButtonHoldConfirm()`, which simply replaces a button, but it won't have any effect if a key combination is not hold when clicking on it.

This is result of a suggestion by @Fayti1703, where a confirmation before erasing color settings would be better.

By-products of this PR are the methods `IconButtonTooltip()` and `Tooltip()` and the class `GuiHelpers` which offer ways to draw Gui stuff easier, and sort Gui functions in its own place.