### PR TITLE
implemented coordinate table

### DIFF
--- a/Ktisis/Interface/KtisisGui.cs
+++ b/Ktisis/Interface/KtisisGui.cs
@@ -50,7 +50,7 @@ namespace Ktisis.Interface {
 
 			ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10, 10));
 
-			if (ImGui.Begin("Ktisis (Alpha)", ref Visible, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoResize)) {
+			if (ImGui.Begin("Ktisis (Alpha)", ref Visible, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.AlwaysAutoResize)) {
 				ImGui.BeginGroup();
 				ImGui.AlignTextToFramePadding();
 
@@ -95,6 +95,10 @@ namespace Ktisis.Interface {
 				ImGui.SameLine();
 				if (ImGuiComponents.IconButton(FontAwesomeIcon.Cog))
 					Plugin.ConfigGui.Show();
+
+				ImGui.Separator();
+
+				Coordinates();
 
 				ImGui.Separator();
 
@@ -146,6 +150,26 @@ namespace Ktisis.Interface {
 
 			ImGui.PopStyleVar(1);
 			ImGui.End();
+		}
+
+		// Coordinates table
+		private void Coordinates()
+		{
+			Bone? selectedBone = Plugin.SkeletonEditor.GetSelectedBone();
+			if (Plugin.SkeletonEditor.Skeleton == null || selectedBone == null)
+			{
+				ImGuiComponents.HelpMarker("Select a bone to spawn Coordinates table.");
+				return;
+			};
+
+			GuiHelpers.DragVec4intoVec3("Position", ref selectedBone.Transform.Position, 0.0001f);
+			GuiHelpers.DragQuatIntoEuler("Rotation", ref selectedBone.Transform.Rotation, 0.1f);
+			GuiHelpers.DragVec4intoVec3("Scale", ref selectedBone.Transform.Scale, 0.01f);
+
+			// Use the same functions found in SkeletonEditor.Draw()
+			var delta = Plugin.SkeletonEditor.BoneMod.GetDelta();
+			selectedBone.Transform.Rotation *= delta.Rotation;
+			selectedBone.TransformBone(delta, Plugin.SkeletonEditor.Skeleton);
 		}
 
 		// Bone Tree

--- a/Ktisis/Overlay/SkeletonEditor.cs
+++ b/Ktisis/Overlay/SkeletonEditor.cs
@@ -89,6 +89,20 @@ namespace Ktisis.Overlay {
 			BoneMod.SnapshotBone(bone, model, Gizmode);
 		}
 
+
+		public unsafe Bone? GetSelectedBone()
+		{
+			(int ListId, int Index) = BoneSelector.Current;
+
+			if (Skeleton == null) return null;
+			foreach (BoneList boneList in Skeleton)
+				if(boneList.Id == ListId)
+					foreach (Bone bone in boneList)
+						if (bone.Index == Index) return bone;
+
+			return null;
+		}
+
 		// Build skeleton
 
 		public unsafe void BuildSkeleton() {

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -2,6 +2,8 @@ using ImGuiNET;
 
 using Dalamud.Interface;
 using Dalamud.Interface.Components;
+using Ktisis.Helpers;
+using System.Numerics;
 
 namespace Ktisis.Util
 {
@@ -34,6 +36,22 @@ namespace Ktisis.Util
 				ImGui.EndTooltip();
 			}
 
+		}
+
+		public static bool DragVec4intoVec3(string label, ref Vector4 vector4, float speed = 0.1f)
+		{
+			Vector3 vector3 = new(vector4.X, vector4.Y, vector4.Z);
+			bool modified = ImGui.DragFloat3(label, ref vector3, speed);
+			vector4.X = vector3.X;
+			vector4.Y = vector3.Y;
+			vector4.Z = vector3.Z;
+			return modified;
+		}
+		public static bool DragQuatIntoEuler(string label, ref Quaternion quaternion, float speed = 0.1f) {
+			Vector3 euler = MathHelpers.ToEuler(quaternion);
+			bool modified = ImGui.DragFloat3(label, ref euler, speed);
+			quaternion = MathHelpers.ToQuaternion(euler);
+			return modified;
 		}
 	}
 }


### PR DESCRIPTION
Adds a simple coordinate 3x3 grid in KtisisGui.
![image](https://user-images.githubusercontent.com/107635249/190692324-60147fd9-43bc-4eab-917c-d49c7a9288aa.png)

The current purpose is debugging the coordinate to understand the rotation issue.

Problem 1:
The coordinates are directly taken from `Bone.Transform`, so I think it's related to local and not world, but i didn't confirm.

Problem 2:
I don't get why the children bone aren't transformed, the `Bone.TransformBone(Transform t, List<BoneList> skeleton)` should achieve that, as far as I understand.
```c#
selectedBone.TransformBone(delta, Plugin.SkeletonEditor.Skeleton);
```
