### PR TITLE
categories and thickness tweaks

### DIFF
--- a/Ktisis/Overlay/SkeletonEditor.cs
+++ b/Ktisis/Overlay/SkeletonEditor.cs
@@ -224,6 +224,7 @@ namespace Ktisis.Overlay {
 
 							Dalamud.GameGui.WorldToScreen(parentPos, out var pPos);
 							uint lineColor = boneColor;
+							if (bone.Category != parent.Category) lineColor = ImGui.GetColorU32(Ktisis.Configuration.GetCategoryColor(parent));
 							float lineThickness = Math.Max(0.01f, Ktisis.Configuration.SkeletonLineThickness / cam->Distance * 2.0f);
 
 							draw.AddLine(pos, pPos, lineColor, lineThickness);

--- a/Ktisis/Overlay/SkeletonEditor.cs
+++ b/Ktisis/Overlay/SkeletonEditor.cs
@@ -223,7 +223,10 @@ namespace Ktisis.Overlay {
 							var parentPos = model->Position + parent.Rotate(model->Rotation) * model->Height;
 
 							Dalamud.GameGui.WorldToScreen(parentPos, out var pPos);
-							draw.AddLine(pos, pPos, boneColor, Ktisis.Configuration.SkeletonLineThickness);
+							uint lineColor = boneColor;
+							float lineThickness = Math.Max(0.01f, Ktisis.Configuration.SkeletonLineThickness / cam->Distance * 2.0f);
+
+							draw.AddLine(pos, pPos, lineColor, lineThickness);
 						}
 					}
 
@@ -267,7 +270,8 @@ namespace Ktisis.Overlay {
 						bone.TransformBone(delta, Skeleton);
 
 					} else if (Ktisis.Configuration.IsBoneVisible(bone)) { // Dot
-						var radius = Math.Max(3.0f, 10.0f - cam->Distance);
+						var radius = Math.Max(3.0f, (10.0f - cam->Distance) * (Ktisis.Configuration.SkeletonLineThickness / 5f));
+						var dotRadius = Math.Max(2.0f, (8.0f - cam->Distance) * (Ktisis.Configuration.SkeletonLineThickness / 5f));
 
 						var area = new Vector2(radius, radius);
 						var rectMin = pos - area;
@@ -277,7 +281,7 @@ namespace Ktisis.Overlay {
 						if (hovered)
 							hoveredBones.Add(pair);
 
-						draw.AddCircleFilled(pos, Math.Max(2.0f, 8.0f - cam->Distance), hovered ? (boneColor | 0xff000000) : boneColor, 100);
+						draw.AddCircleFilled(pos, dotRadius, hovered ? (boneColor | 0xff000000) : boneColor, 100);
 					}
 				}
 

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -152,12 +152,6 @@ namespace Ktisis.Structs.Bones
 				"j_sk_f_b_r",     // ClothFrontBRight
 				"j_sk_s_b_l",     // ClothSideBLeft
 				"j_sk_s_b_r",     // ClothSideBRight
-				"j_buki_sebo_l",  // ScabbardLeft
-				"j_buki_sebo_r",  // ScabbardRight
-				"j_buki2_kosi_l", // HolsterLeft
-				"j_buki2_kosi_r", // HolsterRight
-				"j_buki_kosi_l",  // SheatheLeft
-				"j_buki_kosi_r",  // SheatheRight
 				"j_sk_b_a_l",     // ClothBackALeft
 				"j_sk_b_a_r",     // ClothBackARight
 				"j_sk_f_a_l",     // ClothFrontALeft
@@ -174,14 +168,24 @@ namespace Ktisis.Structs.Bones
 				"n_hizasoubi_r",  // PoleynRight
 				"n_kataarmor_l",  // PauldronLeft
 				"n_kataarmor_r",  // PauldronRight
-				"n_buki_tate_l",  // ShieldLeft
-				"n_buki_tate_r",  // ShieldRight
 				"n_hijisoubi_l",  // CouterLeft
 				"n_hijisoubi_r",  // CouterRight
 				"n_ear_a_l",      // EarringALeft
 				"n_ear_a_r",      // EarringARight
 				"n_ear_b_l",      // EarringBLeft
 				"n_ear_b_r"       // EarringBRight
+			});
+			CreateCategory("weapons", new Vector4(1.0F, 0.0F, 1.0F, 0.5647059F), new List<string> {
+				"j_buki_sebo_l",  // ScabbardLeft
+				"j_buki_sebo_r",  // ScabbardRight
+				"j_buki2_kosi_l", // HolsterLeft
+				"j_buki2_kosi_r", // HolsterRight
+				"j_buki_kosi_l",  // SheatheLeft
+				"j_buki_kosi_r",  // SheatheRight
+				"n_buki_r",       // WeaponRight
+				"n_buki_l",       // WeaponLeft
+				"n_buki_tate_l",  // ShieldLeft
+				"n_buki_tate_r",  // ShieldRight
 			});
 			CreateCategory("right hand", new Vector4(1.0F, 0.0F, 1.0F, 0.5647059F), new List<string> {
 				"n_hte_r",    // WristRight
@@ -190,7 +194,6 @@ namespace Ktisis.Structs.Bones
 				"j_kusu_a_r", // RingARight
 				"j_naka_a_r", // MiddleARight
 				"j_oya_a_r",  // ThumbARight
-				"n_buki_r",   // WeaponRight
 				"j_hito_b_r", // IndexBRight
 				"j_ko_b_r",   // PinkyBRight
 				"j_kusu_b_r", // RingBRight
@@ -204,7 +207,6 @@ namespace Ktisis.Structs.Bones
 				"j_kusu_a_l", // RingALeft
 				"j_naka_a_l", // MiddleALeft
 				"j_oya_a_l",  // ThumbALeft
-				"n_buki_l",   // WeaponLeft
 				"j_hito_b_l", // IndexBLeft
 				"j_ko_b_l",   // PinkyBLeft
 				"j_kusu_b_l", // RingBLeft


### PR DESCRIPTION
Bundled PR with various tweaks:

1. new category 'weapons' and moved the respective bones in it
2. lines thickness changes according to zoom level
3. dot radius now changes according to line thickness configuration
4. attempt to fix color category overlap

There are issues I couldn't resolve:

- Line thickness and Dot radius math are a bit weird, it somehow works for me, but if anyone has a better idea, it's welcome
- the parenting seems to have a strange effect on the category overlap fix, as if it's jumping from child to grand-parent

