### PR TITLE
Category overlap fix rollback + fix

### DIFF
--- a/Ktisis/Overlay/SkeletonEditor.cs
+++ b/Ktisis/Overlay/SkeletonEditor.cs
@@ -223,11 +223,9 @@ namespace Ktisis.Overlay {
 							var parentPos = model->Position + parent.Rotate(model->Rotation) * model->Height;
 
 							Dalamud.GameGui.WorldToScreen(parentPos, out var pPos);
-							uint lineColor = boneColor;
-							if (bone.Category != parent.Category) lineColor = ImGui.GetColorU32(Ktisis.Configuration.GetCategoryColor(parent));
 							float lineThickness = Math.Max(0.01f, Ktisis.Configuration.SkeletonLineThickness / cam->Distance * 2.0f);
 
-							draw.AddLine(pos, pPos, lineColor, lineThickness);
+							draw.AddLine(pos, pPos, boneColor, lineThickness);
 						}
 					}
 

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -65,7 +65,7 @@ namespace Ktisis.Structs.Bones
 			CreateCategory("body", new Vector4(1.0F, 0.0F, 0.0F, 0.5647059F), new List<string> {
 				"n_root",
 				"n_hara",    // Abdomen
-				"n_throw",
+				// "n_throw",// Throw, this is moving when using /throw with a snowball, so it goes into "other" bones for now
 				"j_kosi",    // Waist
 				"j_sebo_a",  // SpineA
 				"j_asi_a_l", // LegLeft
@@ -88,6 +88,8 @@ namespace Ktisis.Structs.Bones
 				"j_ude_a_r", // ArmRight
 				"j_asi_e_l", // ToesLeft
 				"j_asi_e_r", // ToesRight
+				"n_hte_r",   // WristRight
+				"n_hte_l",   // WristLeft
 				"j_ude_b_l", // ForearmLeft
 				"j_ude_b_r", // ForearmRight
 				"n_hkata_l", // ShoulderLeft
@@ -96,6 +98,8 @@ namespace Ktisis.Structs.Bones
 				"j_te_r",    // HandRight
 				"n_hhiji_l", // ElbowLeft
 				"n_hhiji_r"  // ElbowRight
+
+
 			});
 			CreateCategory("head", new Vector4(0.0F, 1.0F, 0.0F, 0.5647059F), new List<string> {
 				"j_kao", // RootHead
@@ -188,7 +192,6 @@ namespace Ktisis.Structs.Bones
 				"n_buki_tate_r",  // ShieldRight
 			});
 			CreateCategory("right hand", new Vector4(1.0F, 0.0F, 1.0F, 0.5647059F), new List<string> {
-				"n_hte_r",    // WristRight
 				"j_hito_a_r", // IndexARight
 				"j_ko_a_r",   // PinkyARight
 				"j_kusu_a_r", // RingARight
@@ -201,7 +204,6 @@ namespace Ktisis.Structs.Bones
 				"j_oya_b_r"   // ThumbBRight
 			});
 			CreateCategory("left hand", new Vector4(0.0F, 1.0F, 1.0F, 0.5647059F), new List<string> {
-				"n_hte_l",    // WristLeft
 				"j_hito_a_l", // IndexALeft
 				"j_ko_a_l",   // PinkyALeft
 				"j_kusu_a_l", // RingALeft


### PR DESCRIPTION
- rollback the previously category overlap fix attempt, sorry about that
- move the overlapping wrist bones into body category, as the wrists are mostly affecting the forearms
- move throw bone into "other" category, as it doesn't seem to react to transformations
