### PR TITLE
coordinates table on actor if no bone is selected

### DIFF
--- a/Ktisis/Overlay/SkeletonEditor.cs
+++ b/Ktisis/Overlay/SkeletonEditor.cs
@@ -148,6 +148,13 @@ namespace Ktisis.Overlay {
 			BoneSelector.ResetState();
 		}
 
+		public void SelectActorTarget()
+		{
+			ResetState();
+
+			// TODO: place and render gizmo on actor
+		}
+
 		// Draw
 
 		public unsafe void Draw() {
@@ -261,11 +268,7 @@ namespace Ktisis.Overlay {
 						// TODO: Streamline this.
 
 						//BoneMod.SnapshotBone(bone, model);
-
-						var delta = BoneMod.GetDelta();
-
-						bone.Transform.Rotation *= delta.Rotation;
-						bone.TransformBone(delta, Skeleton);
+						BoneMod.ApplyDelta(bone, Skeleton);
 
 					} else if (Ktisis.Configuration.IsBoneVisible(bone)) { // Dot
 						var dist = *(float*)((IntPtr)cam + 0x17c); // https://github.com/aers/FFXIVClientStructs/pull/254

--- a/Ktisis/Structs/Bones/BoneMod.cs
+++ b/Ktisis/Structs/Bones/BoneMod.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 
 using ImGuizmoNET;
@@ -113,6 +114,14 @@ namespace Ktisis.Structs.Bones {
 			// :D
 
 			return delta;
+		}
+
+		public void ApplyDelta(Bone bone, List<BoneList> skeleton)
+		{
+			Transform delta = GetDelta();
+
+			bone.Transform.Rotation *= delta.Rotation;
+			bone.TransformBone(delta, skeleton);
 		}
 	}
 }

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -6,6 +6,8 @@ using Dalamud.Interface;
 using Dalamud.Interface.Components;
 
 using Ktisis.Helpers;
+using Ktisis.Structs;
+using Ktisis.Structs.Actor;
 
 namespace Ktisis.Util
 {
@@ -54,6 +56,44 @@ namespace Ktisis.Util
 			bool modified = ImGui.DragFloat3(label, ref euler, speed);
 			quaternion = MathHelpers.ToQuaternion(euler);
 			return modified;
+		}
+		public static bool DrawBoneNode(string? str_id, ImGuiTreeNodeFlags flag, string fmt, System.Action? executeIfClicked = null)
+		{
+			bool show = ImGui.TreeNodeEx(str_id, flag, fmt);
+
+			var rectMin = ImGui.GetItemRectMin() + new Vector2(ImGui.GetTreeNodeToLabelSpacing(), 0);
+			var rectMax = ImGui.GetItemRectMax();
+
+			var mousePos = ImGui.GetMousePos();
+			if (
+				ImGui.IsMouseClicked(ImGuiMouseButton.Left)
+				&& mousePos.X > rectMin.X && mousePos.X < rectMax.X
+				&& mousePos.Y > rectMin.Y && mousePos.Y < rectMax.Y
+			)
+			{
+				executeIfClicked?.Invoke();
+			}
+			return show;
+		}
+		public static unsafe bool CoordinatesTable(ActorModel* actorModel, System.Action? doAfter = null)
+		{
+			bool active = false;
+			active |= ImGui.DragFloat3("Position", ref actorModel->Position, 0.005f);
+			active |= GuiHelpers.DragQuatIntoEuler("Rotation", ref actorModel->Rotation, 0.1f);
+			active |= ImGui.DragFloat3("Scale", ref actorModel->Scale, 0.005f);
+
+			doAfter?.Invoke();
+			return active;
+		}
+		public static bool CoordinatesTable(Transform transform, System.Action? doAfter = null)
+		{
+			bool active = false;
+			active |= GuiHelpers.DragVec4intoVec3("Position", ref transform.Position, 0.0001f);
+			active |= GuiHelpers.DragQuatIntoEuler("Rotation", ref transform.Rotation, 0.1f);
+			active |= GuiHelpers.DragVec4intoVec3("Scale", ref transform.Scale, 0.01f);
+
+			doAfter?.Invoke();
+			return active;
 		}
 	}
 }


### PR DESCRIPTION

- show actor coordinate table if no bone is selected
- added an 'actor' bone in the bone tree (fake bone)
- moved some other code to avoid repetition for the above changes

Note: the coordinates table is still on raw `Transform`, so as for a bone, it will not take world/local and will still clamp on -90° and +90°.