### PR TITLE
Sets browse + QoL for item search lists

### DIFF
--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -199,7 +199,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 
 				LoopHoverPopupWindow(
 					HoverPopupWindowFlags.SelectorList,
-					sets,
+					sets.Cast<dynamic>(),
 					(i) => { // draw Before Line
 
 						return false; // return true to select

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -7,10 +7,15 @@ using ImGuiNET;
 using ImGuiScene;
 
 using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using FFXIVClientStructs.FFXIV.Client.Game;
 
 using Ktisis.GameData;
 using Ktisis.GameData.Excel;
 using Ktisis.Structs.Actor;
+using System.Text;
+using Ktisis.Util;
+using Dalamud.Interface;
 
 namespace Ktisis.Interface.Windows.ActorEdit {
 	public class EditEquip {
@@ -32,6 +37,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		public static IEnumerable<Item>? SlotItems;
 		public static string ItemSearch = "";
 		public static int? LastSelectedItemKey = null;
+		public static bool DrawSetSelection = false;
 
 		// Helper stuff. Will move if there's ever a need for this elsewhere.
 
@@ -43,8 +49,10 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		// UI Code
 
 		public unsafe static void Draw() {
+			FindSets();
 			if (Items == null)
 				Items = Sheets.GetSheet<Item>().Where(i => i.IsEquippable());
+
 
 			ImGui.BeginGroup();
 			for (var i = 2; i < 13; i++) {
@@ -113,6 +121,11 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 			SelectPos = ImGui.GetMousePos();
 		}
 
+		public static void OpenSetSelector() {
+			DrawSetSelection = true;
+			SelectPos = ImGui.GetMousePos();
+		}
+
 		public unsafe static void DrawSelectorList(EquipIndex index, EquipItem equip) {
 			if (SlotItems == null)
 				return;
@@ -169,6 +182,217 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 			}
 
 			ImGui.End();
+		}
+
+		public static unsafe void FindSets()
+		{
+			List<SetLookup> sets = new();
+			var raptureGearsetModule = RaptureGearsetModule.Instance();
+
+			// build sets list
+			for (var i = 0; i < 101; i++)
+			{
+				var gearset = raptureGearsetModule->Gearset[i];
+				if (gearset->ID != i) break;
+				if (!gearset->Flags.HasFlag(RaptureGearsetModule.GearsetFlag.Exists)) continue;
+				sets.Add(new(i, Encoding.UTF8.GetString(gearset->Name, 0x2F), SetSource.GearSet));
+			}
+
+			if(GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Tshirt, "Look up for a set."))
+				OpenSetSelector();
+
+			if (DrawSetSelection)
+				DrawSetSelectorList(sets);
+
+			ImGui.Separator();
+		}
+
+		// dirty shameless copy paste of DrawSelectorList() TODO: merge common code?
+		public unsafe static void DrawSetSelectorList(List<SetLookup> sets)
+		{
+			if (sets.Count == 0)
+				return;
+
+			var size = new Vector2(-1, -1);
+			ImGui.SetNextWindowSize(size, ImGuiCond.Always);
+
+			ImGui.SetNextWindowPos(SelectPos);
+			ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10, 10));
+
+			if (ImGui.Begin("Set Select", ImGuiWindowFlags.NoDecoration))
+			{
+				var focus = ImGui.IsWindowFocused() || ImGui.IsWindowHovered();
+
+				ImGui.PushItemWidth(400);
+				string setSearch = "";
+				ImGui.InputTextWithHint("##equip_search", "Search...", ref setSearch, 32);
+				ImGui.BeginListBox("##equip_items", new Vector2(-1, 300));
+				// TODO: scroll the list to the currently selected item when using ImGuiKey
+
+				if (setSearch.Length > 0)
+					sets = sets.Where(s => s.Name.Contains(setSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+
+				int itemKey = 0;
+				bool isAnItemSelected = false; // allows one selection per foreach
+
+				foreach (var item in sets)
+				{
+					itemKey++;
+					// TODO: Icon?
+
+					// TODO: mark the currently selected item
+					bool selecting = false;
+
+					selecting |= ImGui.Selectable($"{item.Name}");
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isAnItemSelected && itemKey == LastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isAnItemSelected && itemKey == LastSelectedItemKey + 1;
+
+					if (selecting)
+					{
+						EquipSet(item);
+
+						LastSelectedItemKey = itemKey;
+						isAnItemSelected = true;
+					}
+					focus |= ImGui.IsItemFocused();
+				}
+				ImGui.EndListBox();
+				focus |= ImGui.IsItemActive();
+				ImGui.PopItemWidth();
+
+				if (!focus)
+				{
+					DrawSetSelection = false;
+				}
+			}
+
+			ImGui.End();
+		}
+		
+		public static unsafe void EquipSet(SetLookup setLookup)
+		{
+			PluginLog.Verbose("equipping set");
+
+			List<(EquipIndex index, EquipItem equip)> itemsToEquip = new();
+			switch (setLookup.Source)
+			{
+				case SetSource.GearSet        : itemsToEquip = EquipSetGearset(setLookup);        break;
+				case SetSource.GlamourDresser : itemsToEquip = EquipSetGlamourDresser(setLookup); break;
+			}
+
+			foreach((EquipIndex i, EquipItem e) in itemsToEquip)
+			{
+				Target->Equip(i, e);
+			}
+		}
+		public static unsafe List<(EquipIndex index, EquipItem equip)> EquipSetGearset(SetLookup setLookup)
+		{
+			List<(EquipIndex index, EquipItem equip)> itemsToEquip = new();
+			var gearset = RaptureGearsetModule.Instance()->Gearset[setLookup.ID];
+
+			if(gearset->GlamourSetLink > 0)
+				// TODO: implement glamour plates for:   return EquipSetGlamourDresser(setLookup);
+				PluginLog.Warning("Gearset Linked to Glamour Plate " + gearset->GlamourSetLink + ", Glamour Plate support not implemented");
+
+
+			// find inventory containers
+			InventoryType[] inventoryTypes =
+			{
+				InventoryType.EquippedItems,
+				InventoryType.ArmoryHead,
+				InventoryType.ArmoryBody,
+				InventoryType.ArmoryHands,
+				InventoryType.ArmoryLegs,
+				InventoryType.ArmoryFeets,
+				InventoryType.ArmoryEar,
+				InventoryType.ArmoryNeck,
+				InventoryType.ArmoryWrist,
+				InventoryType.ArmoryRings
+
+			};
+			InventoryContainer*[] Armouries = new InventoryContainer *[inventoryTypes.Length];
+			for (int j = 0; j < inventoryTypes.Length; j++)
+				Armouries[j] = InventoryManager.Instance()->GetInventoryContainer(inventoryTypes[j]);
+
+			// generate a list of all combined inventories
+			List<InventoryItem> inventoryItems = new();
+			foreach (InventoryContainer* Armoury in Armouries)
+				for (int i = 0; i < Armoury->Size; i++)
+					inventoryItems.Add(Armoury->Items[i]);
+
+			// get item IDs from gearset
+			List<(uint id, EquipIndex ind)> itemsToRemodel = new()
+			{
+				(gearset->Head.ItemID, EquipIndex.Head),
+				(gearset->Body.ItemID, EquipIndex.Chest),
+				(gearset->Hands.ItemID, EquipIndex.Hands),
+				(gearset->Legs.ItemID, EquipIndex.Legs),
+				(gearset->Feet.ItemID, EquipIndex.Feet),
+				(gearset->Ears.ItemID, EquipIndex.Earring),
+				(gearset->Neck.ItemID, EquipIndex.Necklace),
+				(gearset->Wrists.ItemID, EquipIndex.Bracelet),
+				(gearset->RingRight.ItemID, EquipIndex.RingRight),
+				(gearset->RightLeft.ItemID, EquipIndex.RingLeft) // rightleft? :x
+			};
+
+			foreach ((uint id, EquipIndex ind) in itemsToRemodel)
+			{
+
+				Item? item = null;
+				InventoryItem? invItem = null;
+
+				if (id != 0)
+				{
+					// get the inventory item by the gearset item id
+					var invItems = inventoryItems.Where(i => i.ItemID == id );
+					if (!invItems.Any()) invItems = inventoryItems.Where(i => i.ItemID == uint.Parse(id.ToString()[2..])); // not sure why, sometimes item IDs have numbers prepended to them (mostly "10")
+					if (invItems.Any())	invItem = invItems.First();
+
+					// get the Item that contains the model Id
+					var items = Sheets.GetSheet<Item>().Where(i => i.RowId == (invItem?.GlamourID == 0 ? invItem?.ItemID: invItem?.GlamourID));
+					if (items.Any()) item = items.First();
+				}
+
+				// if no item found, choose "The Emperor's New ..." in this slot
+				item ??= GetEmperorNewItemForSlot(ind);
+				byte dye = (invItem?.Stain) ?? default;
+
+
+				EquipItem newItem = new()
+				{
+					Id = (item?.Model.Id)??0,
+					Variant = (byte)((item?.Model.Variant)??0),
+					Dye = dye,
+				};
+				itemsToEquip.Add((ind, newItem));
+			}
+
+			return itemsToEquip;
+		}
+		public static unsafe List<(EquipIndex index, EquipItem equip)> EquipSetGlamourDresser(SetLookup setLookup)
+		{
+			throw new NotImplementedException();
+		}
+		public static Item GetEmperorNewItemForSlot(EquipIndex equipIndex) => Items!.Where(i => i.IsEquippable(Equipment.EquipIndexToItemSlot(equipIndex)) && i.Name.Contains("Emperor's New")).First();
+
+	}
+	public enum SetSource
+	{
+		GearSet,
+		GlamourDresser,
+		Glamaholic,
+		Glamourer,
+	};
+
+	public class SetLookup {
+		public int ID;
+		public SetSource Source;
+		public string Name;
+		public SetLookup(int iD, string name, SetSource source)
+		{
+			ID = iD;
+			Name = name;
+			Source = source;
 		}
 	}
 

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -38,7 +38,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		public static IEnumerable<Item>? SlotItems;
 		public static string ItemSearch = "";
 		public static string SetSearch = "";
-		public static int? LastSelectedItemKey = null;
+		public static int LastSelectedItemKey = 0;
 		public static bool DrawSetSelection = false;
 		public static EquipmentSets? Sets = null;
 
@@ -156,22 +156,26 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 
 				int indexKey = 0;
 				bool isOneSelected = false; // allows one selection per foreach
+				if (LastSelectedItemKey >= items.Count()) LastSelectedItemKey = items.Count() - 1;
 
 				foreach (var item in items) {
-					indexKey++;
 					// TODO: Icon?
 
 					bool selecting = false;
 
 					selecting |= ImGui.Selectable($"{item.Name}", indexKey == LastSelectedItemKey);
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUpFast) && !isOneSelected && indexKey == LastSelectedItemKey - FastScrollLineJump;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDownFast) && !isOneSelected && indexKey == LastSelectedItemKey + FastScrollLineJump;
-					selecting |= pressedEnter && !isOneSelected;
+					if (!isOneSelected)
+					{
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && indexKey == LastSelectedItemKey - 1;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && indexKey == LastSelectedItemKey + 1;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseUpFast) && indexKey == LastSelectedItemKey - FastScrollLineJump;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseDownFast) && indexKey == LastSelectedItemKey + FastScrollLineJump;
+						selecting |= pressedEnter;
+					}
 
 					if (selecting) {
-						if (ImGui.IsKeyPressed(KeyBindBrowseUp) || ImGui.IsKeyPressed(KeyBindBrowseDown) || ImGui.IsKeyPressed(KeyBindBrowseUpFast) || ImGui.IsKeyPressed(KeyBindBrowseDownFast)) ImGui.SetScrollY(ImGui.GetCursorPosY() - 60);
+						if (ImGui.IsKeyPressed(KeyBindBrowseUp) || ImGui.IsKeyPressed(KeyBindBrowseDown) || ImGui.IsKeyPressed(KeyBindBrowseUpFast) || ImGui.IsKeyPressed(KeyBindBrowseDownFast))
+							ImGui.SetScrollY(ImGui.GetCursorPosY() - (ImGui.GetWindowHeight() /2));
 						equip.Id = item.Model.Id;
 						equip.Variant = (byte)item.Model.Variant;
 						Target->Equip(index, equip);
@@ -179,6 +183,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 						isOneSelected = true;
 					}
 					focus |= ImGui.IsItemFocused();
+					indexKey++;
 				}
 				ImGui.EndListBox();
 				focus |= ImGui.IsItemActive();
@@ -242,10 +247,10 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 
 				int indexKey = 0;
 				bool isOneSelected = false; // allows one selection per foreach
+				if (LastSelectedItemKey >= sets.Count) LastSelectedItemKey = sets.Count -1;
 
 				foreach (var set in sets)
 				{
-					indexKey++;
 					bool selecting = false;
 
 					selecting |= ImGui.Selectable($"{set.Name}", indexKey == LastSelectedItemKey);
@@ -256,21 +261,26 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 					GuiHelpers.TextCentered($"{set.Source}");
 					ImGui.PopStyleVar();
 
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUpFast) && !isOneSelected && indexKey == LastSelectedItemKey - 10;
-					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDownFast) && !isOneSelected && indexKey == LastSelectedItemKey + 10;
-					selecting |= pressedEnter && !isOneSelected;
+					if (!isOneSelected)
+					{
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && indexKey == LastSelectedItemKey - 1;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && indexKey == LastSelectedItemKey + 1;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseUpFast) && indexKey == LastSelectedItemKey - 10;
+						selecting |= ImGui.IsKeyPressed(KeyBindBrowseDownFast) && indexKey == LastSelectedItemKey + 10;
+						selecting |= pressedEnter;
+					}
 
 					if (selecting)
 					{
-						if (ImGui.IsKeyPressed(KeyBindBrowseUp) || ImGui.IsKeyPressed(KeyBindBrowseDown) || ImGui.IsKeyPressed(KeyBindBrowseUpFast) || ImGui.IsKeyPressed(KeyBindBrowseDownFast)) ImGui.SetScrollY(ImGui.GetCursorPosY() - 60);
+						if (ImGui.IsKeyPressed(KeyBindBrowseUp) || ImGui.IsKeyPressed(KeyBindBrowseDown) || ImGui.IsKeyPressed(KeyBindBrowseUpFast) || ImGui.IsKeyPressed(KeyBindBrowseDownFast))
+							ImGui.SetScrollY(ImGui.GetCursorPosY() - (ImGui.GetWindowHeight() / 2));
 						Target->Equip(Sets.GetItems(set));
 
 						LastSelectedItemKey = indexKey;
 						isOneSelected = true;
 					}
 					focus |= ImGui.IsItemFocused();
+					indexKey++;
 				}
 				ImGui.EndListBox();
 				focus |= ImGui.IsItemActive();

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -6,14 +6,9 @@ using System.Collections.Generic;
 using ImGuiNET;
 using ImGuiScene;
 
-using Dalamud.Logging;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Client.Game;
-
 using Ktisis.GameData;
 using Ktisis.GameData.Excel;
 using Ktisis.Structs.Actor;
-using System.Text;
 using Ktisis.Util;
 using Dalamud.Interface;
 
@@ -38,6 +33,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		public static string ItemSearch = "";
 		public static int? LastSelectedItemKey = null;
 		public static bool DrawSetSelection = false;
+		public static EquipmentSets? Sets = null;
 
 		// Helper stuff. Will move if there's ever a need for this elsewhere.
 
@@ -49,7 +45,8 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		// UI Code
 
 		public unsafe static void Draw() {
-			FindSets();
+			DrawControls();
+
 			if (Items == null)
 				Items = Sheets.GetSheet<Item>().Where(i => i.IsEquippable());
 
@@ -142,32 +139,32 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 				ImGui.PushItemWidth(400);
 				ImGui.InputTextWithHint("##equip_search", "Search...", ref ItemSearch, 32);
 				ImGui.BeginListBox("##equip_items", new Vector2(-1, 300));
-				// TODO: scroll the list to the currently selected item when using ImGuiKey
+				// TODO: scroll the list to the currently selected set when using ImGuiKey
 
 				var items = SlotItems;
 				if (ItemSearch.Length > 0)
 					items = items.Where(i => i.Name.Contains(ItemSearch, StringComparison.OrdinalIgnoreCase));
 
-				int itemKey = 0;
-				bool isAnItemSelected = false; // allows one selection per foreach
+				int indexKey = 0;
+				bool isOneSelected = false; // allows one selection per foreach
 
 				foreach (var item in items) {
-					itemKey++;
+					indexKey++;
 					// TODO: Icon?
 
-					// TODO: mark the currently selected item
+					// TODO: mark the currently selected set
 					bool selecting = false;
 
 					selecting |= ImGui.Selectable($"{item.Name}");
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isAnItemSelected && itemKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isAnItemSelected && itemKey == LastSelectedItemKey + 1;
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
 
 					if (selecting) {
 						equip.Id = item.Model.Id;
 						equip.Variant = (byte)item.Model.Variant;
 						Target->Equip(index, equip);
-						LastSelectedItemKey = itemKey;
-						isAnItemSelected = true;
+						LastSelectedItemKey = indexKey;
+						isOneSelected = true;
 					}
 					focus |= ImGui.IsItemFocused();
 				}
@@ -183,33 +180,30 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 
 			ImGui.End();
 		}
-
-		public static unsafe void FindSets()
+		public static void DrawControls()
 		{
-			List<SetLookup> sets = new();
-			var raptureGearsetModule = RaptureGearsetModule.Instance();
+			Sets = EquipmentSets.Init(Items);
 
-			// build sets list
-			for (var i = 0; i < 101; i++)
-			{
-				var gearset = raptureGearsetModule->Gearset[i];
-				if (gearset->ID != i) break;
-				if (!gearset->Flags.HasFlag(RaptureGearsetModule.GearsetFlag.Exists)) continue;
-				sets.Add(new(i, Encoding.UTF8.GetString(gearset->Name, 0x2F), SetSource.GearSet));
-			}
-
-			if(GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Tshirt, "Look up for a set."))
+			if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Tshirt, "Look up for a set."))
 				OpenSetSelector();
 
 			if (DrawSetSelection)
-				DrawSetSelectorList(sets);
+				DrawSetSelectorList();
 
 			ImGui.Separator();
 		}
 
-		// dirty shameless copy paste of DrawSelectorList() TODO: merge common code?
-		public unsafe static void DrawSetSelectorList(List<SetLookup> sets)
+
+
+
+		// dirty shameless copy paste of DrawSelectorList(), merge common code?
+		public unsafe static void DrawSetSelectorList()
 		{
+			if (Sets?.LoadSources() == null)
+				Sets = EquipmentSets.InitAndLoadSources(Items);
+
+			List<EquipmentSet> sets = Sets.GetSets();
+
 			if (sets.Count == 0)
 				return;
 
@@ -224,35 +218,38 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 				var focus = ImGui.IsWindowFocused() || ImGui.IsWindowHovered();
 
 				ImGui.PushItemWidth(400);
-				string setSearch = "";
-				ImGui.InputTextWithHint("##equip_search", "Search...", ref setSearch, 32);
+				string searchInput = "";
+				ImGui.InputTextWithHint("##equip_search", "Search...", ref searchInput, 32);
 				ImGui.BeginListBox("##equip_items", new Vector2(-1, 300));
-				// TODO: scroll the list to the currently selected item when using ImGuiKey
+				// TODO: scroll the list to the currently selected set when using ImGuiKey
 
-				if (setSearch.Length > 0)
-					sets = sets.Where(s => s.Name.Contains(setSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+				if (searchInput.Length > 0)
+					sets = sets.Where(s => s.Name.Contains(searchInput, StringComparison.OrdinalIgnoreCase)).ToList();
 
-				int itemKey = 0;
-				bool isAnItemSelected = false; // allows one selection per foreach
+				int indexKey = 0;
+				bool isOneSelected = false; // allows one selection per foreach
 
-				foreach (var item in sets)
+				foreach (var set in sets)
 				{
-					itemKey++;
-					// TODO: Icon?
-
-					// TODO: mark the currently selected item
+					indexKey++;
+					// TODO: mark the currently selected set
 					bool selecting = false;
 
-					selecting |= ImGui.Selectable($"{item.Name}");
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isAnItemSelected && itemKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isAnItemSelected && itemKey == LastSelectedItemKey + 1;
+					selecting |= ImGui.Selectable($"{set.Name}");
+					ImGui.SameLine();
+					ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+					GuiHelpers.TextCentered($"{set.Source}");
+					ImGui.PopStyleVar();
+
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
 
 					if (selecting)
 					{
-						EquipSet(item);
+						Target->Equip(Sets.GetItems(set));
 
-						LastSelectedItemKey = itemKey;
-						isAnItemSelected = true;
+						LastSelectedItemKey = indexKey;
+						isOneSelected = true;
 					}
 					focus |= ImGui.IsItemFocused();
 				}
@@ -261,138 +258,10 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 				ImGui.PopItemWidth();
 
 				if (!focus)
-				{
 					DrawSetSelection = false;
-				}
 			}
 
 			ImGui.End();
-		}
-		
-		public static unsafe void EquipSet(SetLookup setLookup)
-		{
-			PluginLog.Verbose("equipping set");
-
-			List<(EquipIndex index, EquipItem equip)> itemsToEquip = new();
-			switch (setLookup.Source)
-			{
-				case SetSource.GearSet        : itemsToEquip = EquipSetGearset(setLookup);        break;
-				case SetSource.GlamourDresser : itemsToEquip = EquipSetGlamourDresser(setLookup); break;
-			}
-
-			foreach((EquipIndex i, EquipItem e) in itemsToEquip)
-			{
-				Target->Equip(i, e);
-			}
-		}
-		public static unsafe List<(EquipIndex index, EquipItem equip)> EquipSetGearset(SetLookup setLookup)
-		{
-			List<(EquipIndex index, EquipItem equip)> itemsToEquip = new();
-			var gearset = RaptureGearsetModule.Instance()->Gearset[setLookup.ID];
-
-			if(gearset->GlamourSetLink > 0)
-				// TODO: implement glamour plates for:   return EquipSetGlamourDresser(setLookup);
-				PluginLog.Warning("Gearset Linked to Glamour Plate " + gearset->GlamourSetLink + ", Glamour Plate support not implemented");
-
-
-			// find inventory containers
-			InventoryType[] inventoryTypes =
-			{
-				InventoryType.EquippedItems,
-				InventoryType.ArmoryHead,
-				InventoryType.ArmoryBody,
-				InventoryType.ArmoryHands,
-				InventoryType.ArmoryLegs,
-				InventoryType.ArmoryFeets,
-				InventoryType.ArmoryEar,
-				InventoryType.ArmoryNeck,
-				InventoryType.ArmoryWrist,
-				InventoryType.ArmoryRings
-
-			};
-			InventoryContainer*[] Armouries = new InventoryContainer *[inventoryTypes.Length];
-			for (int j = 0; j < inventoryTypes.Length; j++)
-				Armouries[j] = InventoryManager.Instance()->GetInventoryContainer(inventoryTypes[j]);
-
-			// generate a list of all combined inventories
-			List<InventoryItem> inventoryItems = new();
-			foreach (InventoryContainer* Armoury in Armouries)
-				for (int i = 0; i < Armoury->Size; i++)
-					inventoryItems.Add(Armoury->Items[i]);
-
-			// get item IDs from gearset
-			List<(uint id, EquipIndex ind)> itemsToRemodel = new()
-			{
-				(gearset->Head.ItemID, EquipIndex.Head),
-				(gearset->Body.ItemID, EquipIndex.Chest),
-				(gearset->Hands.ItemID, EquipIndex.Hands),
-				(gearset->Legs.ItemID, EquipIndex.Legs),
-				(gearset->Feet.ItemID, EquipIndex.Feet),
-				(gearset->Ears.ItemID, EquipIndex.Earring),
-				(gearset->Neck.ItemID, EquipIndex.Necklace),
-				(gearset->Wrists.ItemID, EquipIndex.Bracelet),
-				(gearset->RingRight.ItemID, EquipIndex.RingRight),
-				(gearset->RightLeft.ItemID, EquipIndex.RingLeft) // rightleft? :x
-			};
-
-			foreach ((uint id, EquipIndex ind) in itemsToRemodel)
-			{
-
-				Item? item = null;
-				InventoryItem? invItem = null;
-
-				if (id != 0)
-				{
-					// get the inventory item by the gearset item id
-					var invItems = inventoryItems.Where(i => i.ItemID == id );
-					if (!invItems.Any()) invItems = inventoryItems.Where(i => i.ItemID == uint.Parse(id.ToString()[2..])); // not sure why, sometimes item IDs have numbers prepended to them (mostly "10")
-					if (invItems.Any())	invItem = invItems.First();
-
-					// get the Item that contains the model Id
-					var items = Sheets.GetSheet<Item>().Where(i => i.RowId == (invItem?.GlamourID == 0 ? invItem?.ItemID: invItem?.GlamourID));
-					if (items.Any()) item = items.First();
-				}
-
-				// if no item found, choose "The Emperor's New ..." in this slot
-				item ??= GetEmperorNewItemForSlot(ind);
-				byte dye = (invItem?.Stain) ?? default;
-
-
-				EquipItem newItem = new()
-				{
-					Id = (item?.Model.Id)??0,
-					Variant = (byte)((item?.Model.Variant)??0),
-					Dye = dye,
-				};
-				itemsToEquip.Add((ind, newItem));
-			}
-
-			return itemsToEquip;
-		}
-		public static unsafe List<(EquipIndex index, EquipItem equip)> EquipSetGlamourDresser(SetLookup setLookup)
-		{
-			throw new NotImplementedException();
-		}
-		public static Item GetEmperorNewItemForSlot(EquipIndex equipIndex) => Items!.Where(i => i.IsEquippable(Equipment.EquipIndexToItemSlot(equipIndex)) && i.Name.Contains("Emperor's New")).First();
-
-	}
-	public enum SetSource
-	{
-		GearSet,
-		GlamourDresser,
-		Glamaholic,
-		Glamourer,
-	};
-
-	public class SetLookup {
-		public int ID;
-		public SetSource Source;
-		public string Name;
-		public SetLookup(int iD, string name, SetSource source)
-		{
-			ID = iD;
-			Name = name;
-			Source = source;
 		}
 	}
 

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -52,11 +52,11 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		// UI Code
 
 		public unsafe static void Draw() {
-			DrawControls();
 
 			if (Items == null)
 				Items = Sheets.GetSheet<Item>().Where(i => i.IsEquippable());
 
+			DrawControls();
 
 			ImGui.BeginGroup();
 			for (var i = 2; i < 13; i++) {

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -133,7 +133,8 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 
 				var items = SlotItems;
 				if (ItemSearch.Length > 0)
-					items = items.Where(i => i.Name.Contains(ItemSearch));
+					items = items.Where(i => i.Name.Contains(ItemSearch, StringComparison.OrdinalIgnoreCase));
+
 				int itemKey = 0;
 				bool isAnItemSelected = false; // allows one selection per foreach
 

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -199,7 +199,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		}
 		public static void DrawControls()
 		{
-			Sets = EquipmentSets.Init(Items);
+			Sets = new EquipmentSets(Items!);
 
 			if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Tshirt, "Look up for a set."))
 				OpenSetSelector();
@@ -217,7 +217,7 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		public unsafe static void DrawSetSelectorList()
 		{
 			if (Sets?.LoadSources() == null)
-				Sets = EquipmentSets.InitAndLoadSources(Items);
+				Sets = EquipmentSets.InitAndLoadSources(Items!);
 
 			List<EquipmentSet> sets = Sets.GetSets();
 

--- a/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditEquip.cs
@@ -19,6 +19,9 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 		public const int _IconSize = 36;
 		public static Vector2 IconSize = new(_IconSize, _IconSize);
 
+		public static ImGuiKey KeyBindBrowseUp = ImGuiKey.RightShift;
+		public static ImGuiKey KeyBindBrowseDown = ImGuiKey.RightCtrl;
+
 		// Properties
 
 		public unsafe static Actor* Target => EditActor.Target;
@@ -156,8 +159,8 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 					bool selecting = false;
 
 					selecting |= ImGui.Selectable($"{item.Name}");
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
 
 					if (selecting) {
 						equip.Id = item.Model.Id;
@@ -241,8 +244,8 @@ namespace Ktisis.Interface.Windows.ActorEdit {
 					GuiHelpers.TextCentered($"{set.Source}");
 					ImGui.PopStyleVar();
 
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightShift) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
-					selecting |= ImGui.IsKeyPressed(ImGuiKey.RightCtrl) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && !isOneSelected && indexKey == LastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && !isOneSelected && indexKey == LastSelectedItemKey + 1;
 
 					if (selecting)
 					{

--- a/Ktisis/Structs/Actor/Actor.cs
+++ b/Ktisis/Structs/Actor/Actor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
@@ -54,6 +55,10 @@ namespace Ktisis.Structs.Actor {
 		public unsafe void Equip(EquipIndex index, EquipItem item) {
 			if (ActorHooks.ChangeEquip == null) return;
 			ActorHooks.ChangeEquip(GetAddress() + 0x6D0, index, item);
+		}
+		public void Equip(List<(EquipIndex, EquipItem)> items) {
+			foreach((EquipIndex index, EquipItem item) in items)
+				Equip(index, item);
 		}
 
 		// Change customize - no redraw method

--- a/Ktisis/Structs/Actor/Equipment.cs
+++ b/Ktisis/Structs/Actor/Equipment.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
+using Ktisis.GameData.Excel;
+
 namespace Ktisis.Structs.Actor {
 	[StructLayout(LayoutKind.Explicit)]
 	public struct Equipment {
@@ -16,6 +18,25 @@ namespace Ktisis.Structs.Actor {
 		[FieldOffset(0x1C)] public EquipItem Bracelet;
 		[FieldOffset(0x20)] public EquipItem RingRight;
 		[FieldOffset(0x24)] public EquipItem RingLeft;
+
+		public static EquipSlot EquipIndexToItemSlot(EquipIndex equipIndex) // sorry, I don't know where to put this
+		{
+			EquipSlot[] slots =
+			{
+				EquipSlot.Head,
+				EquipSlot.Chest,
+				EquipSlot.Hands,
+				EquipSlot.Legs,
+				EquipSlot.Feet,
+				EquipSlot.Earring,
+				EquipSlot.Necklace,
+				EquipSlot.Bracelet,
+				EquipSlot.RingRight,
+				EquipSlot.RingLeft
+			};
+			return slots[(uint)equipIndex];
+		}
+
 	}
 
 	[StructLayout(LayoutKind.Explicit, Size = 0x4)]

--- a/Ktisis/Structs/Actor/EquipmentSet.cs
+++ b/Ktisis/Structs/Actor/EquipmentSet.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using Ktisis.GameData;
+using Ktisis.GameData.Excel;
+
+namespace Ktisis.Structs.Actor {
+	public struct EquipmentSet
+	{
+		public int ID;
+		public SetSource Source;
+		public string Name;
+		public EquipmentSet(int iD, string name, SetSource source)
+		{
+			ID = iD;
+			Name = name;
+			Source = source;
+		}
+	}
+
+	public class EquipmentSets
+	{
+		public List<EquipmentSet> Sets;
+		private IEnumerable<Item>? ItemsSheet;
+
+		public EquipmentSets(IEnumerable<Item>? itemsSheet)
+		{
+			ItemsSheet = itemsSheet;
+			Sets = new();
+		}
+
+		// helpers
+		private Item GetEmperorNewItemForSlot(EquipIndex equipIndex) => ItemsSheet!.Where(i => i.IsEquippable(Equipment.EquipIndexToItemSlot(equipIndex)) && i.Name.Contains("Emperor's New")).First(); // TODO: improve performances, maybe cache them in constructor
+
+		// public managers
+		public static EquipmentSets Init(IEnumerable<Item>? itemsSheet) => new EquipmentSets(itemsSheet);
+		public static EquipmentSets InitAndLoadSources(IEnumerable<Item>? itemsSheet)
+		{
+			var sets = Init(itemsSheet);
+			sets.LoadSources();
+			return sets;
+		}
+		public bool LoadSources()
+		{
+			Sets = FindSets();
+			if(Sets.Any()) return true;
+			return false;
+		}
+		public List<EquipmentSet> GetSets() => Sets;
+		public void RefreshItemSheet(IEnumerable<Item>? itemsSheet) => ItemsSheet = itemsSheet;
+
+
+		// Set Finders
+		private List<EquipmentSet> FindSets()
+		{
+			return      FindSetsGearSet()
+				.Concat(FindSetsGlamourPlate())
+				.Concat(FindSetsGlamourer())
+				.Concat(FindSetsGlamaholic())
+				.ToList();
+		}
+		private unsafe List<EquipmentSet> FindSetsGearSet()
+		{
+			List<EquipmentSet> sets = new();
+			var raptureGearsetModule = RaptureGearsetModule.Instance();
+
+			// build sets list
+			for (var i = 0; i < 101; i++)
+			{
+				var gearset = raptureGearsetModule->Gearset[i];
+				if (gearset->ID != i) break;
+				if (!gearset->Flags.HasFlag(RaptureGearsetModule.GearsetFlag.Exists)) continue;
+				sets.Add(new(i, Encoding.UTF8.GetString(gearset->Name, 0x2F), SetSource.GearSet));
+			}
+
+			return sets;
+		}
+		private List<EquipmentSet> FindSetsGlamourPlate()
+		{
+			return new List<EquipmentSet>();
+		}
+		private List<EquipmentSet> FindSetsGlamourer()
+		{
+			return new List<EquipmentSet>();
+		}
+		private List<EquipmentSet> FindSetsGlamaholic()
+		{
+			return new List<EquipmentSet>();
+		}
+
+
+		// Find items of the selected set
+		public List<(EquipIndex, EquipItem)> GetItems(EquipmentSet set)
+		{
+			List<(EquipIndex index, EquipItem equip)> items = new();
+			switch (set.Source)
+			{
+				case SetSource.GearSet: items = GetItemsGearset(set); break;
+				case SetSource.GlamourDresser: items = GetItemsGlamourDresser(set); break;
+			}
+			return items;
+		}
+		private unsafe List<(EquipIndex index, EquipItem equip)> GetItemsGearset(EquipmentSet set)
+		{
+			List<(EquipIndex index, EquipItem equip)> itemsToEquip = new();
+			var gearset = RaptureGearsetModule.Instance()->Gearset[set.ID];
+
+			if (gearset->GlamourSetLink > 0)
+				// TODO: implement glamour plates for:   return GetItemsGlamourDresser(set);
+				PluginLog.Warning("Gearset Linked to Glamour Plate " + gearset->GlamourSetLink + ", Glamour Plate support not implemented");
+
+
+			// find inventory containers
+			InventoryType[] inventoryTypes =
+			{
+				InventoryType.EquippedItems,
+				InventoryType.ArmoryHead,
+				InventoryType.ArmoryBody,
+				InventoryType.ArmoryHands,
+				InventoryType.ArmoryLegs,
+				InventoryType.ArmoryFeets,
+				InventoryType.ArmoryEar,
+				InventoryType.ArmoryNeck,
+				InventoryType.ArmoryWrist,
+				InventoryType.ArmoryRings
+
+			};
+
+			InventoryContainer*[] Armouries = new InventoryContainer*[inventoryTypes.Length];
+			for (int j = 0; j < inventoryTypes.Length; j++)
+				Armouries[j] = InventoryManager.Instance()->GetInventoryContainer(inventoryTypes[j]);
+
+			// generate a list of all combined inventories
+			List<InventoryItem> inventoryItems = new();
+			foreach (InventoryContainer* Armoury in Armouries)
+				for (int i = 0; i < Armoury->Size; i++)
+					inventoryItems.Add(Armoury->Items[i]);
+
+			// get item IDs from gearset
+			List<(uint id, EquipIndex ind)> itemsToRemodel = new()
+			{
+				(gearset->Head.ItemID, EquipIndex.Head),
+				(gearset->Body.ItemID, EquipIndex.Chest),
+				(gearset->Hands.ItemID, EquipIndex.Hands),
+				(gearset->Legs.ItemID, EquipIndex.Legs),
+				(gearset->Feet.ItemID, EquipIndex.Feet),
+				(gearset->Ears.ItemID, EquipIndex.Earring),
+				(gearset->Neck.ItemID, EquipIndex.Necklace),
+				(gearset->Wrists.ItemID, EquipIndex.Bracelet),
+				(gearset->RingRight.ItemID, EquipIndex.RingRight),
+				(gearset->RightLeft.ItemID, EquipIndex.RingLeft) // rightleft? :x
+			};
+
+			foreach ((uint id, EquipIndex ind) in itemsToRemodel)
+			{
+
+				Item? item = null;
+				InventoryItem? invItem = null;
+
+				if (id != 0)
+				{
+					// get the inventory item by the gearset item id
+					var invItems = inventoryItems.Where(i => i.ItemID == id);
+					if (!invItems.Any()) invItems = inventoryItems.Where(i => i.ItemID == uint.Parse(id.ToString()[2..])); // not sure why, sometimes item IDs have numbers prepended to them (mostly "10")
+					if (invItems.Any()) invItem = invItems.First();
+
+					// get the Item that contains the model Id
+					var items = Sheets.GetSheet<Item>().Where(i => i.RowId == (invItem?.GlamourID == 0 ? invItem?.ItemID : invItem?.GlamourID));
+					if (items.Any()) item = items.First();
+				}
+
+				// if no item found, choose "The Emperor's New ..." in this slot
+				item ??= GetEmperorNewItemForSlot(ind);
+				byte dye = (invItem?.Stain) ?? default;
+
+
+				EquipItem newItem = new()
+				{
+					Id = (item?.Model.Id) ?? 0,
+					Variant = (byte)((item?.Model.Variant) ?? 0),
+					Dye = dye,
+				};
+				itemsToEquip.Add((ind, newItem));
+			}
+
+			return itemsToEquip;
+		}
+		private List<(EquipIndex index, EquipItem equip)> GetItemsGlamourDresser(EquipmentSet set)
+		{
+			throw new NotImplementedException();
+		}
+
+	}
+
+	public enum SetSource
+	{
+		GearSet,
+		GlamourDresser,
+		Glamaholic,
+		Glamourer,
+	};
+
+}

--- a/Ktisis/Structs/Actor/EquipmentSet.cs
+++ b/Ktisis/Structs/Actor/EquipmentSet.cs
@@ -26,9 +26,9 @@ namespace Ktisis.Structs.Actor {
 	public class EquipmentSets
 	{
 		public List<EquipmentSet> Sets;
-		private IEnumerable<Item>? ItemsSheet;
+		private IEnumerable<Item> ItemsSheet;
 
-		public EquipmentSets(IEnumerable<Item>? itemsSheet)
+		public EquipmentSets(IEnumerable<Item> itemsSheet)
 		{
 			ItemsSheet = itemsSheet;
 			Sets = new();
@@ -38,10 +38,9 @@ namespace Ktisis.Structs.Actor {
 		private Item GetEmperorNewItemForSlot(EquipIndex equipIndex) => ItemsSheet!.Where(i => i.IsEquippable(Equipment.EquipIndexToItemSlot(equipIndex)) && i.Name.Contains("Emperor's New")).First(); // TODO: improve performances, maybe cache them in constructor
 
 		// public managers
-		public static EquipmentSets Init(IEnumerable<Item>? itemsSheet) => new EquipmentSets(itemsSheet);
-		public static EquipmentSets InitAndLoadSources(IEnumerable<Item>? itemsSheet)
+		public static EquipmentSets InitAndLoadSources(IEnumerable<Item> itemsSheet)
 		{
-			var sets = Init(itemsSheet);
+			var sets = new EquipmentSets(itemsSheet!);
 			sets.LoadSources();
 			return sets;
 		}
@@ -52,7 +51,7 @@ namespace Ktisis.Structs.Actor {
 			return false;
 		}
 		public List<EquipmentSet> GetSets() => Sets;
-		public void RefreshItemSheet(IEnumerable<Item>? itemsSheet) => ItemsSheet = itemsSheet;
+		public void RefreshItemSheet(IEnumerable<Item> itemsSheet) => ItemsSheet = itemsSheet;
 
 
 		// Set Finders

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -8,6 +8,9 @@ using Dalamud.Interface.Components;
 using Ktisis.Helpers;
 using Ktisis.Structs;
 using Ktisis.Structs.Actor;
+using System.Collections.Generic;
+using System;
+using System.Linq;
 
 namespace Ktisis.Util
 {
@@ -104,5 +107,150 @@ namespace Ktisis.Util
 			ImGui.SetCursorPosX((windowWidth - textWidth) * 0.5f);
 			ImGui.Text(text);
 		}
+
+
+
+
+
+		// HoverPopupWindow Method
+		// Constants
+		private const ImGuiKey KeyBindBrowseUp = ImGuiKey.UpArrow;
+		private const ImGuiKey KeyBindBrowseDown = ImGuiKey.DownArrow;
+		private const ImGuiKey KeyBindBrowseUpFast = ImGuiKey.PageUp;
+		private const ImGuiKey KeyBindBrowseDownFast = ImGuiKey.PageDown;
+		private const int HoverPopupWindowFastScrollLineJump = 8; // number of lines on the screen?
+
+		// Properties
+		private static Vector2 HoverPopupWindowSelectPos = Vector2.Zero;
+		private static bool HoverPopupWindowIsBegan = false;
+		private static bool HoverPopupWindowFocus = false;
+		private static bool HoverPopupWindowSearchBarValidated = false;
+		private static int HoverPopupWindowLastSelectedItemKey = 0;
+
+
+		public enum HoverPopupWindowFlags
+		{
+			None,
+			SelectorList,
+			SearchBar,
+		}
+
+		public static void HoverPopupWindow(
+			HoverPopupWindowFlags flags,
+			IEnumerable<dynamic> enumerable,
+			Func<dynamic, bool> drawBeforeLine,
+			Func<dynamic, string> lineLabel,
+			Func<dynamic, bool> drawAfterLine,
+			Action<dynamic> onSelect,
+			Action onClose,
+			ref string InputSearch,
+			string windowLabel = "",
+			string listLabel = "",
+			string searchBarLabel = "##search",
+			string searchBarHint = "Search..."
+			)
+		{
+			if (BeginHoverPopupWindow(flags, ref InputSearch, windowLabel, listLabel, searchBarLabel, searchBarHint))
+			{
+				if (flags.HasFlag(HoverPopupWindowFlags.SearchBar))
+					if (InputSearch.Length > 0)
+					{
+						var inputSearch = InputSearch;
+						enumerable = enumerable.Where(s => lineLabel(s).Contains(inputSearch, StringComparison.OrdinalIgnoreCase));
+					}
+
+				LoopHoverPopupWindow(flags, enumerable, drawBeforeLine, drawAfterLine, onSelect, lineLabel);
+			}
+			EndHoverPopupWindow(flags, onClose);
+		}
+
+
+
+		private static bool BeginHoverPopupWindow(HoverPopupWindowFlags flags, ref string InputSearch, string windowLabel, string listLabel, string searchBarLabel, string searchBarHint)
+		{
+			var size = new Vector2(-1, -1);
+			ImGui.SetNextWindowSize(size, ImGuiCond.Always);
+
+			if(HoverPopupWindowSelectPos == Vector2.Zero) HoverPopupWindowSelectPos = ImGui.GetMousePos();
+			ImGui.SetNextWindowPos(HoverPopupWindowSelectPos);
+			ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10, 10));
+
+			HoverPopupWindowIsBegan = ImGui.Begin(windowLabel, ImGuiWindowFlags.NoDecoration);
+			if (HoverPopupWindowIsBegan)
+			{
+
+				HoverPopupWindowFocus = ImGui.IsWindowFocused() || ImGui.IsWindowHovered();
+				ImGui.PushItemWidth(400);
+				if (flags.HasFlag(HoverPopupWindowFlags.SearchBar))
+					HoverPopupWindowSearchBarValidated = ImGui.InputTextWithHint(searchBarLabel, searchBarHint, ref InputSearch, 32, ImGuiInputTextFlags.EnterReturnsTrue);
+
+				if (ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows) && !ImGui.IsAnyItemActive() && !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+					ImGui.SetKeyboardFocusHere(flags.HasFlag(HoverPopupWindowFlags.SearchBar) ? -1 : 0); // TODO: verify the keyboarf focus behaviour when searchbar is disabled
+
+				if (flags.HasFlag(HoverPopupWindowFlags.SelectorList))
+					ImGui.BeginListBox(listLabel, new Vector2(-1, 300));
+
+			}
+			return HoverPopupWindowIsBegan;
+		}
+		private static void EndHoverPopupWindow(HoverPopupWindowFlags flags, Action onClose)
+		{
+			if (HoverPopupWindowIsBegan)
+			{
+				if (flags.HasFlag(HoverPopupWindowFlags.SelectorList))
+					ImGui.EndListBox();
+				HoverPopupWindowFocus |= ImGui.IsItemActive();
+				ImGui.PopItemWidth();
+
+				if (!HoverPopupWindowFocus || ImGui.IsKeyPressed(ImGuiKey.Escape))
+				{
+					onClose();
+					HoverPopupWindowSelectPos = Vector2.Zero;
+				}
+			}
+
+			ImGui.End();
+		}
+		private static void LoopHoverPopupWindow(HoverPopupWindowFlags flags, IEnumerable<dynamic> enumerable, Func<dynamic, bool> drawBeforeLine, Func<dynamic, bool> drawAfterLine, Action<dynamic> onSelect, Func<dynamic, string> lineLabel)
+		{
+			if (!HoverPopupWindowIsBegan) return;
+
+			int indexKey = 0;
+			bool isOneSelected = false; // allows one selection per foreach
+			if (HoverPopupWindowLastSelectedItemKey >= enumerable.Count()) HoverPopupWindowLastSelectedItemKey = enumerable.Count() - 1;
+
+			foreach (var i in enumerable)
+			{
+				bool selecting = false;
+
+				selecting |= drawBeforeLine(i);
+				if (flags.HasFlag(HoverPopupWindowFlags.SelectorList))
+					selecting |= ImGui.Selectable(lineLabel(i), indexKey == HoverPopupWindowLastSelectedItemKey);
+				HoverPopupWindowFocus |= ImGui.IsItemFocused();
+				selecting |= drawAfterLine(i);
+
+				if (!isOneSelected)
+				{
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUp) && indexKey == HoverPopupWindowLastSelectedItemKey - 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDown) && indexKey == HoverPopupWindowLastSelectedItemKey + 1;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseUpFast) && indexKey == HoverPopupWindowLastSelectedItemKey - HoverPopupWindowFastScrollLineJump;
+					selecting |= ImGui.IsKeyPressed(KeyBindBrowseDownFast) && indexKey == HoverPopupWindowLastSelectedItemKey + HoverPopupWindowFastScrollLineJump;
+					selecting |= HoverPopupWindowSearchBarValidated;
+				}
+
+				if (selecting)
+				{
+					if (ImGui.IsKeyPressed(KeyBindBrowseUp) || ImGui.IsKeyPressed(KeyBindBrowseDown) || ImGui.IsKeyPressed(KeyBindBrowseUpFast) || ImGui.IsKeyPressed(KeyBindBrowseDownFast))
+						ImGui.SetScrollY(ImGui.GetCursorPosY() - (ImGui.GetWindowHeight() / 2));
+
+					onSelect(i);
+					HoverPopupWindowLastSelectedItemKey = indexKey;
+					isOneSelected = true;
+				}
+				HoverPopupWindowFocus |= ImGui.IsItemFocused();
+				indexKey++;
+			}
+		}
+
 	}
 }

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -95,5 +95,14 @@ namespace Ktisis.Util
 			doAfter?.Invoke();
 			return active;
 		}
+
+		public static void TextCentered(string text)
+		{
+			var windowWidth = ImGui.GetWindowSize().X;
+			var textWidth = ImGui.CalcTextSize(text).X;
+
+			ImGui.SetCursorPosX((windowWidth - textWidth) * 0.5f);
+			ImGui.Text(text);
+		}
 	}
 }


### PR DESCRIPTION
This is mostly a lot of QoL changes in `EditEquip` window.

Implements:
 - gives the possibility to browse Gear sets (Glamour plate not implemented yet).

Qol:
- keyboard focus the input search box when opening a search list (`DrawSelectorList` and `DrawSetSelectorList`).
- up/down to browse, page up/down to browse faster
- escape to close the search list
- apply the first choice on press enter after typing
- the window is scrolled automatically to follow the current selection when using keys
- the current selection is highlighted
- search input text is case insensitive

Additional info:
Created a new struct for `EquipmentSet`, this is where the sets (GearSet, Glam Plates, etc)   data collection is made.
There is a subclass `EquipmentSets` (plural) in the same file. I'm not sure it was very smart, but I didn't want to create too much files for this.
`EquipmentSets` is used as instance in `EditEquip` for various reasons.

`DrawSetSelectorList` is copy pasted from `DrawSelectorList`. I tried to combine the common code, but I figured they were quite different despite their similarities, and they could grow even more different in time.
