### PR TITLE
Transform Table fix

### DIFF
--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -4,7 +4,9 @@ using ImGuiNET;
 using FFXIVClientStructs.Havok;
 
 using Ktisis.Helpers;
+using Ktisis.Overlay;
 using Ktisis.Structs;
+using Ktisis.Structs.Bones;
 
 namespace Ktisis.Interface.Components {
 	// Thanks to Emyka for the original code:
@@ -36,6 +38,33 @@ namespace Ktisis.Interface.Components {
 			return result;
 		}
 
+		public bool Draw(Bone bone)
+		{
+			var result = false;
+			var gizmo = OverlayWindow.GetGizmo(bone.UniqueName);
+			if (gizmo != null)
+			{
+				(var savedPosition, var savedRotation, var savedScale) = gizmo.Decompose();
+				(var position, var rotation, var scale) = (savedPosition, savedRotation, savedScale);
+				if (Draw(ref position, ref rotation, ref scale))
+				{
+					(var deltaPosition, var deltaRotation, var deltaScale) = (savedPosition - position, savedRotation - rotation, savedScale - scale);
+					gizmo.InsertEulerDeltaMatrix(deltaPosition, deltaRotation, deltaScale);
+					result = true;
+				}
+			}
+			IsEditing = result;
+			return result;
+		}
+		public bool Draw(ref Vector3 position, ref Vector3 rotation, ref Vector3 scale)
+		{
+			var result = false;
+			result |= ImGui.DragFloat3("Position", ref position, 0.0005f, -10000f, 10000f, "%.5f");
+			result |= ImGui.DragFloat3("Rotation", ref rotation, 0.1f);
+			result |= ImGui.DragFloat3("Scale", ref scale, 0.01f);
+			IsEditing = result;
+			return result;
+		}
 		public bool Draw(ref Vector3 pos, ref Quaternion rot, ref Vector3 scale) {
 			if (!IsEditing)
 				Update(pos, rot, scale);

--- a/Ktisis/Interface/Windows/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace.cs
@@ -192,13 +192,7 @@ namespace Ktisis.Interface.Windows {
 
 			ImGui.TextDisabled($"{title}'s {Locale.GetBoneName(bone.HkaBone.Name.String)}");
 
-			var trans = bone.Transform;
-			if (Transform.Draw(select.Update, ref trans.Translation, ref trans.Rotation, ref trans.Scale)) {
-				bone.Transform = trans;
-				return true;
-			}
-
-			return false;
+			return Transform.Draw(bone);
 		}
 
 		// Bone Tree

--- a/Ktisis/Overlay/Gizmo.cs
+++ b/Ktisis/Overlay/Gizmo.cs
@@ -71,7 +71,7 @@ namespace Ktisis.Overlay {
 			ImGuizmo.AllowAxisFlip(Ktisis.Configuration.AllowAxisFlip);
 		}
 
-		internal void InsertEulerDeltaMatrix(Vector3 posDelta,Vector3 rotDelta,Vector3 scaDelta)
+		public void InsertEulerDeltaMatrix(Vector3 posDelta,Vector3 rotDelta,Vector3 scaDelta)
 		{
 			EulerDeltaMatrix = new(
 				posDelta.X, posDelta.Y, posDelta.Z,

--- a/Ktisis/Overlay/Skeleton.cs
+++ b/Ktisis/Overlay/Skeleton.cs
@@ -128,7 +128,7 @@ namespace Ktisis.Overlay {
 						gizmo.Matrix.Translation += model->Position;
 
 						// Draw the gizmo. This returns true if it has been moved.
-						if (gizmo.Draw()) {
+						if (gizmo.Draw() || gizmo.ManipulateEuler()) {
 							BoneSelect.Update = true;
 
 							// Reverse the previous transform we did.


### PR DESCRIPTION
This change makes the Transform Table to uses the Gizmo to apply transformations.

It is not bug-free, but as it uses the gizmo methods, it's easier to blend with the "path" chirp has made for gizmo manipulation.