### PR TITLE
Fix alt color list not popping in customize

### DIFF
--- a/Ktisis/Interface/Windows/ActorEdit/EditCustomize.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditCustomize.cs
@@ -343,7 +343,7 @@ namespace Ktisis.Interface.Windows {
 				var altIndex = custom.Bytes[(uint)color.AltIndex];
 				var altRgb = color.Colors[altIndex];
 				ImGui.SameLine();
-				if (DrawColorButton($"{altIndex}##{color.Name}", altRgb))
+				if (DrawColorButton($"{altIndex}##{color.Name}##alt", altRgb))
 					selecting = color.AltIndex;
 			}
 


### PR DESCRIPTION
The bug appears when both eyes have the same color, the second color picker would not show up when clicked.