### PR TITLE
Transform Table ctrl & shift speed multiplier

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -23,6 +23,14 @@ namespace Ktisis {
 
 		public bool DisplayCharName = true;
 
+		public bool TransformTableDisplayMultiplierInputs { get; set; } = false;
+		public float TransformTableBaseSpeedPos { get; set; } = 0.0005f;
+		public float TransformTableBaseSpeedRot { get; set; } = 0.1f;
+		public float TransformTableBaseSpeedSca { get; set; } = 0.001f;
+		public float TransformTableModifierMultCtrl { get; set; } = 0.1f;
+		public float TransformTableModifierMultShift { get; set; } = 10f;
+		public int TransformTableDigitPrecision { get; set; } = 3;
+
 		// Overlay
 
 		public bool DrawLinesOnSkeleton { get; set; } = true;

--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -60,9 +60,9 @@ namespace Ktisis.Interface.Components {
 
 			var multiplier = 1f;
 			if (ImGui.GetIO().KeyCtrl) multiplier *= ModifierMultCtrl;
-			if (ImGui.GetIO().KeyShift) multiplier *= ModifierMultShift;
+			if (ImGui.GetIO().KeyShift) multiplier *= ModifierMultShift / 10; //divide by 10 cause of the native *10 when holding shift on DragFloat
 
-			// Attempt to find the exact size for any font and font size.
+ 			// Attempt to find the exact size for any font and font size.
 			float[] sizes = new float[3];
 			sizes[0] = GuiHelpers.CalcIconSize(iconPos).X;
 			sizes[1] = GuiHelpers.CalcIconSize(iconRot).X;
@@ -87,9 +87,11 @@ namespace Ktisis.Interface.Components {
 			if (Ktisis.Configuration.TransformTableDisplayMultiplierInputs) {
 				var cellWidth = inputsWidth / 3 - (ImGui.GetStyle().ItemSpacing.X / 2);
 				ImGui.PushItemWidth(cellWidth);
-				ImGui.DragFloat("##SpeedMult##shift", ref ModifierMultShift, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+				if (ImGui.DragFloat("##SpeedMult##shift", ref ModifierMultShift, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic))
+					Ktisis.Configuration.TransformTableModifierMultShift = ModifierMultShift;
 				ImGui.SameLine();
-				ImGui.DragFloat("##SpeedMult##ctrl", ref ModifierMultCtrl, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+				if(ImGui.DragFloat("##SpeedMult##ctrl", ref ModifierMultCtrl, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic))
+					Ktisis.Configuration.TransformTableModifierMultCtrl = ModifierMultCtrl;
 				ImGui.PopItemWidth();
 				ImGui.SameLine();
 				GuiHelpers.IconTooltip(FontAwesomeIcon.Running, "Ctrl and Shift speed multipliers");

--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using System.Linq;
 using ImGuiNET;
 
@@ -18,12 +18,12 @@ namespace Ktisis.Interface.Components {
 	public class TransformTable {
 		public bool IsEditing = false;
 
-		const float BaseSpeedPos = 0.0005f;
-		const float BaseSpeedRot = 0.1f;
-		const float BaseSpeedSca = 0.001f;
-		const float ModifierMultCtrl = 0.1f;
-		const float ModifierMultShift = 10f;
-		const string DigitPrecision = "%.3f";
+		private float BaseSpeedPos = 0.0005f;
+		private float BaseSpeedRot = 0.1f;
+		private float BaseSpeedSca = 0.001f;
+		private float ModifierMultCtrl = 0.1f;
+		private float ModifierMultShift = 10f;
+		private string DigitPrecision = "%.3f";
 
 		public Vector3 Position;
 		public Vector3 Rotation;
@@ -70,6 +70,16 @@ namespace Ktisis.Interface.Components {
 			GuiHelpers.IconTooltip(iconSca, "Scale", true);
 			ImGui.PopItemWidth();
 			IsEditing = result;
+
+			var cellWidth = inputsWidth / 3 - (ImGui.GetStyle().ItemSpacing.X / 2);
+			ImGui.PushItemWidth(cellWidth);
+			ImGui.DragFloat("##SpeedMult##shift", ref ModifierMultShift, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+			ImGui.SameLine();
+			ImGui.DragFloat("##SpeedMult##ctrl", ref ModifierMultCtrl, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+			ImGui.PopItemWidth();
+			ImGui.SameLine();
+			GuiHelpers.IconTooltip(FontAwesomeIcon.Running, "Ctrl and Shift speed multipliers");
+
 			return result;
 		}
 		public bool Draw(Bone bone) {

--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -18,6 +18,13 @@ namespace Ktisis.Interface.Components {
 	public class TransformTable {
 		public bool IsEditing = false;
 
+		const float BaseSpeedPos = 0.0005f;
+		const float BaseSpeedRot = 0.1f;
+		const float BaseSpeedSca = 0.001f;
+		const float ModifierMultCtrl = 0.1f;
+		const float ModifierMultShift = 10f;
+		const string DigitPrecision = "%.3f";
+
 		public Vector3 Position;
 		public Vector3 Rotation;
 		public Vector3 Scale;
@@ -39,6 +46,10 @@ namespace Ktisis.Interface.Components {
 			var iconRot = FontAwesomeIcon.Sync;
 			var iconSca = FontAwesomeIcon.ExpandAlt;
 
+			var multiplier = 1f;
+			if (ImGui.GetIO().KeyCtrl) multiplier *= ModifierMultCtrl;
+			if (ImGui.GetIO().KeyShift) multiplier *= ModifierMultShift;
+
 			// Attempt to find the exact size for any font and font size.
 			float[] sizes = new float[3];
 			sizes[0] = GuiHelpers.CalcIconSize(iconPos).X;
@@ -46,14 +57,15 @@ namespace Ktisis.Interface.Components {
 			sizes[2] = GuiHelpers.CalcIconSize(iconSca).X;
 			var rightOffset = GuiHelpers.GetRightOffset(sizes.Max());
 
-			ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - rightOffset);
-			result |= ImGui.DragFloat3("##Position", ref Position, 0.0005f);
+			var inputsWidth = ImGui.GetContentRegionAvail().X - rightOffset;
+			ImGui.PushItemWidth(inputsWidth);
+			result |= ImGui.DragFloat3("##Position", ref Position, BaseSpeedPos * multiplier,0,0, DigitPrecision);
 			ImGui.SameLine();
 			GuiHelpers.IconTooltip(iconPos, "Position", true);
-			result |= ImGui.DragFloat3("##Rotation", ref Rotation, 0.1f);
+			result |= ImGui.DragFloat3("##Rotation", ref Rotation, BaseSpeedRot * multiplier, 0, 0, DigitPrecision);
 			ImGui.SameLine();
 			GuiHelpers.IconTooltip(iconRot, "Rotation", true);
-			result |= ImGui.DragFloat3("##Scale", ref Scale, 0.01f);
+			result |= ImGui.DragFloat3("##Scale", ref Scale, BaseSpeedSca * multiplier, 0, 0, DigitPrecision);
 			ImGui.SameLine();
 			GuiHelpers.IconTooltip(iconSca, "Scale", true);
 			ImGui.PopItemWidth();

--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -18,16 +18,26 @@ namespace Ktisis.Interface.Components {
 	public class TransformTable {
 		public bool IsEditing = false;
 
-		private float BaseSpeedPos = 0.0005f;
-		private float BaseSpeedRot = 0.1f;
-		private float BaseSpeedSca = 0.001f;
-		private float ModifierMultCtrl = 0.1f;
-		private float ModifierMultShift = 10f;
+		private float BaseSpeedPos;
+		private float BaseSpeedRot;
+		private float BaseSpeedSca;
+		private float ModifierMultCtrl;
+		private float ModifierMultShift;
 		private string DigitPrecision = "%.3f";
 
 		public Vector3 Position;
 		public Vector3 Rotation;
 		public Vector3 Scale;
+
+		public void FetchConfigurations() {
+			BaseSpeedPos = Ktisis.Configuration.TransformTableBaseSpeedPos;
+			BaseSpeedRot = Ktisis.Configuration.TransformTableBaseSpeedRot;
+			BaseSpeedSca = Ktisis.Configuration.TransformTableBaseSpeedSca;
+			ModifierMultCtrl = Ktisis.Configuration.TransformTableModifierMultCtrl;
+			ModifierMultShift = Ktisis.Configuration.TransformTableModifierMultShift;
+			DigitPrecision = $"%.{Ktisis.Configuration.TransformTableDigitPrecision}f";
+		}
+
 
 		// Set stored values.
 
@@ -41,6 +51,8 @@ namespace Ktisis.Interface.Components {
 
 		public bool DrawTable() {
 			var result = false;
+
+			FetchConfigurations();
 
 			var iconPos = FontAwesomeIcon.LocationArrow;
 			var iconRot = FontAwesomeIcon.Sync;
@@ -71,14 +83,17 @@ namespace Ktisis.Interface.Components {
 			ImGui.PopItemWidth();
 			IsEditing = result;
 
-			var cellWidth = inputsWidth / 3 - (ImGui.GetStyle().ItemSpacing.X / 2);
-			ImGui.PushItemWidth(cellWidth);
-			ImGui.DragFloat("##SpeedMult##shift", ref ModifierMultShift, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
-			ImGui.SameLine();
-			ImGui.DragFloat("##SpeedMult##ctrl", ref ModifierMultCtrl, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
-			ImGui.PopItemWidth();
-			ImGui.SameLine();
-			GuiHelpers.IconTooltip(FontAwesomeIcon.Running, "Ctrl and Shift speed multipliers");
+
+			if (Ktisis.Configuration.TransformTableDisplayMultiplierInputs) {
+				var cellWidth = inputsWidth / 3 - (ImGui.GetStyle().ItemSpacing.X / 2);
+				ImGui.PushItemWidth(cellWidth);
+				ImGui.DragFloat("##SpeedMult##shift", ref ModifierMultShift, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+				ImGui.SameLine();
+				ImGui.DragFloat("##SpeedMult##ctrl", ref ModifierMultCtrl, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic);
+				ImGui.PopItemWidth();
+				ImGui.SameLine();
+				GuiHelpers.IconTooltip(FontAwesomeIcon.Running, "Ctrl and Shift speed multipliers");
+			}
 
 			return result;
 		}

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -58,34 +58,40 @@ namespace Ktisis.Interface.Windows {
 		// Interface
 
 		public static void DrawInterfaceTab(Configuration cfg) {
+
+			ImGui.Text("General");
+
 			var displayCharName = !cfg.DisplayCharName;
 			if (ImGui.Checkbox("Hide character name", ref displayCharName))
 				cfg.DisplayCharName = !displayCharName;
 
+			ImGui.Spacing();
 			ImGui.Separator();
+			ImGui.Text("Transform Table");
+
 			ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
 			var transformTablePointDigits = cfg.TransformTableDigitPrecision;
 			if (ImGui.DragInt("Digit Precision", ref transformTablePointDigits, 1f, 1, 8))
 				cfg.TransformTableDigitPrecision = transformTablePointDigits;
 
 			var transformTableBaseSpeedPos = cfg.TransformTableBaseSpeedPos;
-			if (ImGui.DragFloat("Base position speed", ref transformTableBaseSpeedPos, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic))
+			if (ImGui.DragFloat("Base position speed", ref transformTableBaseSpeedPos, 1f, 0.00001f, 10000f, "%.4f", ImGuiSliderFlags.Logarithmic))
 				cfg.TransformTableBaseSpeedPos = transformTableBaseSpeedPos;
 
 			var transformTableBaseSpeedRot = cfg.TransformTableBaseSpeedRot;
-			if (ImGui.DragFloat("Base rotation speed", ref transformTableBaseSpeedRot, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+			if (ImGui.DragFloat("Base rotation speed", ref transformTableBaseSpeedRot, 1f, 0.00001f, 10000f, "%.4f", ImGuiSliderFlags.Logarithmic))
 				cfg.TransformTableBaseSpeedRot = transformTableBaseSpeedRot;
 
 			var transformTableBaseSpeedSca = cfg.TransformTableBaseSpeedSca;
-			if (ImGui.DragFloat("Base scale speed", ref transformTableBaseSpeedSca, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+			if (ImGui.DragFloat("Base scale speed", ref transformTableBaseSpeedSca, 1f, 0.00001f, 10000f, "%.4f", ImGuiSliderFlags.Logarithmic))
 				cfg.TransformTableBaseSpeedSca = transformTableBaseSpeedSca;
 
 			var transformTableModifierMultCtrl = cfg.TransformTableModifierMultCtrl;
-			if (ImGui.DragFloat("Ctrl speed multiplier", ref transformTableModifierMultCtrl, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+			if (ImGui.DragFloat("Ctrl speed multiplier", ref transformTableModifierMultCtrl, 1f, 0.00001f, 10000f, "%.4f",ImGuiSliderFlags.Logarithmic))
 				cfg.TransformTableModifierMultCtrl = transformTableModifierMultCtrl;
 
 			var transformTableModifierMultShift = cfg.TransformTableModifierMultShift;
-			if (ImGui.DragFloat("Shift speed multiplier", ref transformTableModifierMultShift, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+			if (ImGui.DragFloat("Shift speed multiplier", ref transformTableModifierMultShift, 1f, 0.00001f, 10000f, "%.4f", ImGuiSliderFlags.Logarithmic))
 				cfg.TransformTableModifierMultShift = transformTableModifierMultShift;
 
 			var displayMultiplierInputs = cfg.TransformTableDisplayMultiplierInputs;

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -62,6 +62,37 @@ namespace Ktisis.Interface.Windows {
 			if (ImGui.Checkbox("Hide character name", ref displayCharName))
 				cfg.DisplayCharName = !displayCharName;
 
+			ImGui.Separator();
+			ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
+			var transformTablePointDigits = cfg.TransformTableDigitPrecision;
+			if (ImGui.DragInt("Digit Precision", ref transformTablePointDigits, 1f, 1, 8))
+				cfg.TransformTableDigitPrecision = transformTablePointDigits;
+
+			var transformTableBaseSpeedPos = cfg.TransformTableBaseSpeedPos;
+			if (ImGui.DragFloat("Base position speed", ref transformTableBaseSpeedPos, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic))
+				cfg.TransformTableBaseSpeedPos = transformTableBaseSpeedPos;
+
+			var transformTableBaseSpeedRot = cfg.TransformTableBaseSpeedRot;
+			if (ImGui.DragFloat("Base rotation speed", ref transformTableBaseSpeedRot, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+				cfg.TransformTableBaseSpeedRot = transformTableBaseSpeedRot;
+
+			var transformTableBaseSpeedSca = cfg.TransformTableBaseSpeedSca;
+			if (ImGui.DragFloat("Base scale speed", ref transformTableBaseSpeedSca, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+				cfg.TransformTableBaseSpeedSca = transformTableBaseSpeedSca;
+
+			var transformTableModifierMultCtrl = cfg.TransformTableModifierMultCtrl;
+			if (ImGui.DragFloat("Ctrl speed multiplier", ref transformTableModifierMultCtrl, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+				cfg.TransformTableModifierMultCtrl = transformTableModifierMultCtrl;
+
+			var transformTableModifierMultShift = cfg.TransformTableModifierMultShift;
+			if (ImGui.DragFloat("Shift speed multiplier", ref transformTableModifierMultShift, 1f, 0.00001f, 10000f, null,ImGuiSliderFlags.Logarithmic))
+				cfg.TransformTableModifierMultShift = transformTableModifierMultShift;
+
+			var displayMultiplierInputs = cfg.TransformTableDisplayMultiplierInputs;
+			if (ImGui.Checkbox("Show speed multipler inputs", ref displayMultiplierInputs))
+				cfg.TransformTableDisplayMultiplierInputs = displayMultiplierInputs;
+			ImGui.PopItemWidth();
+
 			ImGui.EndTabItem();
 		}
 


### PR DESCRIPTION
This adds a way transform table drag speed multiplier to increase accuracy and efficiency.
New configurations added to allow the user to customize base speeds, modified speeds, precision digit, and to show modifier speed inputs below the transform table.