### PR TITLE
Configurable keybinds

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -7,8 +7,10 @@ using ImGuizmoNET;
 using Dalamud;
 using Dalamud.Logging;
 using Dalamud.Configuration;
+using Dalamud.Game.ClientState.Keys;
 
 using Ktisis.Localization;
+using Ktisis.Interface;
 using Ktisis.Structs.Bones;
 
 namespace Ktisis {
@@ -30,6 +32,9 @@ namespace Ktisis {
 		public float TransformTableModifierMultCtrl { get; set; } = 0.1f;
 		public float TransformTableModifierMultShift { get; set; } = 10f;
 		public int TransformTableDigitPrecision { get; set; } = 3;
+
+		// Input
+		public Dictionary<Input.Purpose, VirtualKey> KeyBinds { get; set; } = new();
 
 		// Overlay
 

--- a/Ktisis/Dalamud.cs
+++ b/Ktisis/Dalamud.cs
@@ -5,6 +5,7 @@ using Dalamud.Plugin;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Command;
 using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Keys;
 using Dalamud.Game.ClientState.Objects;
 
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
@@ -17,6 +18,8 @@ namespace Ktisis {
 		[PluginService] internal static ClientState ClientState { get; private set; } = null!;
 		[PluginService] internal static ObjectTable ObjectTable { get; private set; } = null!;
 		[PluginService] internal static SigScanner SigScanner { get; private set; } = null!;
+		[PluginService] internal static Framework Framework { get; private set; } = null!;
+		[PluginService] internal static KeyState KeyState { get; private set; } = null!;
 		[PluginService] internal static GameGui GameGui { get; private set; } = null!;
 
 		internal unsafe static TargetSystem* Targets = TargetSystem.Instance();

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+
 using Dalamud.Game;
 using Dalamud.Game.ClientState.Keys;
 using Dalamud.Logging;
 using ImGuizmoNET;
+
 using Ktisis.Overlay;
-using Ktisis.Structs.Actor;
 
 namespace Ktisis.Interface {
 	public sealed class Input : IDisposable {
@@ -19,6 +20,8 @@ namespace Ktisis.Interface {
 
 		public void Monitor(Framework framework) {
 			if (!Ktisis.IsInGPose) return; // TODO: when implemented move init/dispose to Gpose enter and leave instead of in Ktisis
+
+			if (!Ktisis.Configuration.KeyBinds.Any()) Ktisis.Configuration.KeyBinds = DefaultKeys;
 			GetPurposesStates();
 
 			if (IsPurposeReleased(Purpose.SwitchToTranslate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.TRANSLATE;

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -21,7 +21,6 @@ namespace Ktisis.Interface {
 		public void Monitor(Framework framework) {
 			if (!Ktisis.IsInGPose) return; // TODO: when implemented move init/dispose to Gpose enter and leave instead of in Ktisis
 
-			if (!Ktisis.Configuration.KeyBinds.Any()) Ktisis.Configuration.KeyBinds = DefaultKeys;
 			GetPurposesStates();
 
 			if (IsPurposeReleased(Purpose.SwitchToTranslate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.TRANSLATE;
@@ -84,8 +83,11 @@ namespace Ktisis.Interface {
 			get => Enum.GetValues<Purpose>().ToImmutableList();
 		}
 		private static VirtualKey PurposeToVirtualKey(Purpose purpose) {
-			if (!Ktisis.Configuration.KeyBinds.TryGetValue(purpose, out VirtualKey key))
-				key = VirtualKey.NO_KEY;
+			if (!Ktisis.Configuration.KeyBinds.TryGetValue(purpose, out VirtualKey key)) {
+				if (!DefaultKeys.TryGetValue(purpose, out VirtualKey defaultKey))
+					defaultKey = FallbackKey;
+				key = defaultKey;
+			}
 			return Dalamud.KeyState.IsVirtualKeyValid(key) ? key : FallbackKey;
 		}
 		private void GetPurposesStates() {

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -26,6 +26,7 @@ namespace Ktisis.Interface {
 			if (IsPurposeReleased(Purpose.SwitchToTranslate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.TRANSLATE;
 			if (IsPurposeReleased(Purpose.SwitchToRotate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.ROTATE;
 			if (IsPurposeReleased(Purpose.SwitchToScale) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.SCALE;
+			if (IsPurposeReleased(Purpose.SwitchToUniversal) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.UNIVERSAL;
 			if (IsPurposeReleased(Purpose.ToggleLocalWorld) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoMode = Ktisis.Configuration.GizmoMode == MODE.WORLD ? MODE.LOCAL : MODE.WORLD;
 			if (IsPurposeChanged(Purpose.HoldToHideSkeleton)) Skeleton.Toggle();
 
@@ -40,6 +41,7 @@ namespace Ktisis.Interface {
 			SwitchToScale,
 			ToggleLocalWorld,
 			HoldToHideSkeleton,
+			SwitchToUniversal,
 		}
 
 		public static readonly Dictionary<Purpose, VirtualKey> DefaultKeys = new(){
@@ -48,6 +50,7 @@ namespace Ktisis.Interface {
 			{Purpose.SwitchToScale, VirtualKey.T},
 			{Purpose.ToggleLocalWorld, VirtualKey.X},
 			{Purpose.HoldToHideSkeleton, VirtualKey.V},
+			{Purpose.SwitchToUniversal, VirtualKey.U},
 		};
 
 

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -21,7 +21,7 @@ namespace Ktisis.Interface {
 		public void Monitor(Framework framework) {
 			if (!Ktisis.IsInGPose) return; // TODO: when implemented move init/dispose to Gpose enter and leave instead of in Ktisis
 
-			GetPurposesStates();
+			ReadPurposesStates();
 
 			if (IsPurposeReleased(Purpose.SwitchToTranslate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.TRANSLATE;
 			if (IsPurposeReleased(Purpose.SwitchToRotate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.ROTATE;
@@ -93,7 +93,7 @@ namespace Ktisis.Interface {
 			}
 			return Dalamud.KeyState.IsVirtualKeyValid(key) ? key : FallbackKey;
 		}
-		private void GetPurposesStates() {
+		private void ReadPurposesStates() {
 			CurrentKeyStates = Purposes.Select(p =>
 				(purpose: p, state: Dalamud.KeyState[PurposeToVirtualKey(p)])
 			).ToDictionary(kp => kp.purpose, kp => kp.state);

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Dalamud.Game;
+using Dalamud.Game.ClientState.Keys;
+using Dalamud.Logging;
+using ImGuizmoNET;
+using Ktisis.Overlay;
+using Ktisis.Structs.Actor;
+
+namespace Ktisis.Interface {
+	public sealed class Input : IDisposable {
+		// When adding a new keybind:
+		//  - add the logic in Monitor
+		//      (held/release/changed [+ extra conditions] and what it executes )
+		//  - add the key action in Purpose enum
+		//  - add the default key in DefaultKeys
+
+		public void Monitor(Framework framework) {
+			if (!Ktisis.IsInGPose) return; // TODO: when implemented move init/dispose to Gpose enter and leave instead of in Ktisis
+			GetPurposesStates();
+
+			if (IsPurposeReleased(Purpose.SwitchToTranslate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.TRANSLATE;
+			if (IsPurposeReleased(Purpose.SwitchToRotate) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.ROTATE;
+			if (IsPurposeReleased(Purpose.SwitchToScale) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoOp = OPERATION.SCALE;
+			if (IsPurposeReleased(Purpose.ToggleLocalWorld) && !ImGuizmo.IsUsing()) Ktisis.Configuration.GizmoMode = Ktisis.Configuration.GizmoMode == MODE.WORLD ? MODE.LOCAL : MODE.WORLD;
+			if (IsPurposeChanged(Purpose.HoldToHideSkeleton)) Skeleton.Toggle();
+
+			PrevriousKeyStates = CurrentKeyStates!;
+			CurrentKeyStates = null;
+		}
+
+		[Serializable]
+		public enum Purpose {
+			SwitchToTranslate,
+			SwitchToRotate,
+			SwitchToScale,
+			ToggleLocalWorld,
+			HoldToHideSkeleton,
+		}
+
+		public static readonly Dictionary<Purpose, VirtualKey> DefaultKeys = new(){
+			{Purpose.SwitchToTranslate, VirtualKey.G},
+			{Purpose.SwitchToRotate, VirtualKey.R},
+			{Purpose.SwitchToScale, VirtualKey.T},
+			{Purpose.ToggleLocalWorld, VirtualKey.X},
+			{Purpose.HoldToHideSkeleton, VirtualKey.V},
+		};
+
+
+
+		// Thanks to (Edited) for the intgration with the Framework Update <3
+		private static Input? _instance = null;
+		private Input() {
+			Dalamud.Framework.Update += Monitor;
+		}
+		public static Input Instance {
+			get {
+				_instance ??= new Input();
+				return _instance!;
+			}
+		}
+		public static void Init() {
+			var _ = Instance;
+		}
+		public void Dispose() {
+			Dalamud.Framework.Update -= Monitor;
+		}
+
+
+
+
+		// Below are the methods and variables needed for Monitor to handle inputs
+		public const VirtualKey FallbackKey = VirtualKey.OEM_102;
+
+		private Dictionary<Purpose, bool> PrevriousKeyStates = new();
+		private Dictionary<Purpose, bool>? CurrentKeyStates = new();
+
+		public static IEnumerable<Purpose> Purposes {
+			get => Enum.GetValues<Purpose>().ToImmutableList();
+		}
+		private static VirtualKey PurposeToVirtualKey(Purpose purpose) {
+			if (!Ktisis.Configuration.KeyBinds.TryGetValue(purpose, out VirtualKey key))
+				key = VirtualKey.NO_KEY;
+			return Dalamud.KeyState.IsVirtualKeyValid(key) ? key : FallbackKey;
+		}
+		private void GetPurposesStates() {
+			CurrentKeyStates = Purposes.Select(p =>
+				(purpose: p, state: Dalamud.KeyState[PurposeToVirtualKey(p)])
+			).ToDictionary(kp => kp.purpose, kp => kp.state);
+		}
+
+		// Below are methods to check different kind of key state
+		private bool IsPurposeChanged(Purpose purpose) {
+			if (!PrevriousKeyStates.TryGetValue(purpose, out bool previous)) return false;
+			if (CurrentKeyStates == null) return false;
+			if (!CurrentKeyStates.TryGetValue(purpose, out bool current)) return false;
+			return previous != current;
+		}
+		private bool IsPurposeHeld(Purpose purpose) {
+			if (CurrentKeyStates == null) return false;
+			if (!CurrentKeyStates.TryGetValue(purpose, out bool current)) return false;
+			return IsPurposeChanged(purpose) && current;
+		}
+		private bool IsPurposeReleased(Purpose purpose) {
+			if (CurrentKeyStates == null) return false;
+			if (!CurrentKeyStates.TryGetValue(purpose, out bool current)) return false;
+			return IsPurposeChanged(purpose) && !current;
+		}
+	}
+}

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -232,18 +232,18 @@ namespace Ktisis.Interface.Windows {
 
 			string[] strings = new string[Input.Purposes.Count()];
 			foreach (var purpose in Input.Purposes) {
-				if (!cfg.KeyBinds.TryGetValue(purpose, out VirtualKey configuredKey)) {
-					if (!Input.DefaultKeys.TryGetValue(purpose, out VirtualKey defaultKey))
-						defaultKey = Input.FallbackKey;
+				if (!Input.DefaultKeys.TryGetValue(purpose, out VirtualKey defaultKey))
+					defaultKey = Input.FallbackKey;
+				if (!cfg.KeyBinds.TryGetValue(purpose, out VirtualKey configuredKey))
 					configuredKey = defaultKey;
-				}
 
 				// TODO: find a way to record a key when pressing it, instead of a select list
 				if (ImGui.BeginCombo($"{purpose}",$"{configuredKey}")) {
 					foreach (var key in Enum.GetValues<VirtualKey>()) {
 						if (!Dalamud.KeyState.IsVirtualKeyValid(key)) continue;
 						if (ImGui.Selectable($"{key}", key == configuredKey))
-							cfg.KeyBinds[purpose] = key;
+							if (key == defaultKey) cfg.KeyBinds.Remove(purpose);
+							else cfg.KeyBinds[purpose] = key;
 					}
 
 					ImGui.SetItemDefaultFocus();

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Numerics;
-using System.Collections.Generic;
-using System.Linq;
+using System.Text.RegularExpressions;
 
 using ImGuiNET;
 
@@ -235,8 +234,9 @@ namespace Ktisis.Interface.Windows {
 				if (!cfg.KeyBinds.TryGetValue(purpose, out VirtualKey configuredKey))
 					configuredKey = defaultKey;
 
+				ImGui.PushItemWidth(ImGui.GetFontSize() * 6);
 				// TODO: find a way to record a key when pressing it, instead of a select list
-				if (ImGui.BeginCombo($"{purpose}",$"{configuredKey}")) {
+				if (ImGui.BeginCombo($"{Regex.Replace(purpose.ToString(), @"((?<=\p{Ll})\p{Lu})|((?!\A)\p{Lu}(?>\p{Ll}))", " $0")}",$"{configuredKey}")) {
 					foreach (var key in Enum.GetValues<VirtualKey>()) {
 						if (!Dalamud.KeyState.IsVirtualKeyValid(key)) continue;
 						if (ImGui.Selectable($"{key}", key == configuredKey))
@@ -247,6 +247,7 @@ namespace Ktisis.Interface.Windows {
 					ImGui.SetItemDefaultFocus();
 					ImGui.EndCombo();
 				}
+				ImGui.PopItemWidth();
 			}
 		}
 	}

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -238,6 +238,7 @@ namespace Ktisis.Interface.Windows {
 					configuredKey = defaultKey;
 				}
 
+				// TODO: find a way to record a key when pressing it, instead of a select list
 				if (ImGui.BeginCombo($"{purpose}",$"{configuredKey}")) {
 					foreach (var key in Enum.GetValues<VirtualKey>()) {
 						if (!Dalamud.KeyState.IsVirtualKeyValid(key)) continue;

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -1,8 +1,11 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Linq;
 
 using ImGuiNET;
 
-using Dalamud.Interface.Components;
+using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface;
 
 using Ktisis.Util;
@@ -98,6 +101,11 @@ namespace Ktisis.Interface.Windows {
 			if (ImGui.Checkbox("Show speed multipler inputs", ref displayMultiplierInputs))
 				cfg.TransformTableDisplayMultiplierInputs = displayMultiplierInputs;
 			ImGui.PopItemWidth();
+
+			ImGui.Spacing();
+			ImGui.Separator();
+			ImGui.Text("Keybind");
+			DrawInput(cfg);
 
 			ImGui.EndTabItem();
 		}
@@ -215,6 +223,32 @@ namespace Ktisis.Interface.Windows {
 				cfg.TranslateBones = translateBones;
 
 			ImGui.EndTabItem();
+		}
+
+
+		// input selector
+		public static void DrawInput(Configuration cfg) {
+			Dictionary<Input.Purpose,string> inputs = Input.Purposes.ToDictionary(p => p, p=>"");
+
+			string[] strings = new string[Input.Purposes.Count()];
+			foreach (var purpose in Input.Purposes) {
+				if (!cfg.KeyBinds.TryGetValue(purpose, out VirtualKey configuredKey)) {
+					if (!Input.DefaultKeys.TryGetValue(purpose, out VirtualKey defaultKey))
+						defaultKey = Input.FallbackKey;
+					configuredKey = defaultKey;
+				}
+
+				if (ImGui.BeginCombo($"{purpose}",$"{configuredKey}")) {
+					foreach (var key in Enum.GetValues<VirtualKey>()) {
+						if (!Dalamud.KeyState.IsVirtualKeyValid(key)) continue;
+						if (ImGui.Selectable($"{key}", key == configuredKey))
+							cfg.KeyBinds[purpose] = key;
+					}
+
+					ImGui.SetItemDefaultFocus();
+					ImGui.EndCombo();
+				}
+			}
 		}
 	}
 }

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -228,9 +228,7 @@ namespace Ktisis.Interface.Windows {
 
 		// input selector
 		public static void DrawInput(Configuration cfg) {
-			Dictionary<Input.Purpose,string> inputs = Input.Purposes.ToDictionary(p => p, p=>"");
 
-			string[] strings = new string[Input.Purposes.Count()];
 			foreach (var purpose in Input.Purposes) {
 				if (!Input.DefaultKeys.TryGetValue(purpose, out VirtualKey defaultKey))
 					defaultKey = Input.FallbackKey;

--- a/Ktisis/Ktisis.cs
+++ b/Ktisis/Ktisis.cs
@@ -34,6 +34,7 @@ namespace Ktisis {
 			Interop.Hooks.ActorHooks.Init();
 			Interop.Hooks.PoseHooks.Init();
 			Interop.Hooks.GuiHooks.Init();
+			Input.Init();
 
 			// Register command
 
@@ -57,6 +58,7 @@ namespace Ktisis {
 			Interop.Hooks.ActorHooks.Dispose();
 			Interop.Hooks.PoseHooks.Dispose();
 			Interop.Hooks.GuiHooks.Dispose();
+			Input.Instance.Dispose();
 
 			GameData.Sheets.Cache.Clear();
 			if (EditEquip.Items != null)


### PR DESCRIPTION
A system to easily add new keys and key events.

For now, it features the following events:
- switch gizmo operation to translate (on key release)
- switch gizmo operation to rotate (on key release)
- switch gizmo operation to scale (on key release)
- switch gizmo operation to universal (on key release)
- toggle gizmo mode (on key release)
- toggle hide skeleton (on key state change => hide on hold, show on release)


