### PR TITLE
Added an event manager.

### DIFF
--- a/Ktisis/Events/EventManager.cs
+++ b/Ktisis/Events/EventManager.cs
@@ -1,0 +1,18 @@
+﻿using Ktisis.Structs.Actor.State;
+
+namespace Ktisis.Events
+{
+	public static class EventManager
+	{
+		public unsafe delegate void GPoseChange(ActorGposeState state);
+		public static GPoseChange? OnGPoseChange = null;
+
+		public static void FireOnGposeChangeEvent (ActorGposeState state)
+		{
+			OnGPoseChange?.Invoke(state);
+		}
+
+
+
+	}
+}

--- a/Ktisis/Events/EventManager.cs
+++ b/Ktisis/Events/EventManager.cs
@@ -2,7 +2,7 @@
 
 namespace Ktisis.Events {
 	public static class EventManager {
-		public unsafe delegate void GPoseChange(ActorGposeState state);
+		public delegate void GPoseChange(ActorGposeState state);
 		public static GPoseChange? OnGPoseChange = null;
 
 		public static void FireOnGposeChangeEvent(ActorGposeState state) {

--- a/Ktisis/Events/EventManager.cs
+++ b/Ktisis/Events/EventManager.cs
@@ -1,18 +1,12 @@
 ﻿using Ktisis.Structs.Actor.State;
 
-namespace Ktisis.Events
-{
-	public static class EventManager
-	{
+namespace Ktisis.Events {
+	public static class EventManager {
 		public unsafe delegate void GPoseChange(ActorGposeState state);
 		public static GPoseChange? OnGPoseChange = null;
 
-		public static void FireOnGposeChangeEvent (ActorGposeState state)
-		{
+		public static void FireOnGposeChangeEvent(ActorGposeState state) {
 			OnGPoseChange?.Invoke(state);
 		}
-
-
-
 	}
 }

--- a/Ktisis/Ktisis.cs
+++ b/Ktisis/Ktisis.cs
@@ -7,6 +7,7 @@ using Dalamud.Game.ClientState.Objects.Types;
 using Ktisis.Interface;
 using Ktisis.Interface.Windows.ActorEdit;
 using Ktisis.Interface.Windows.Workspace;
+using Ktisis.Structs.Actor.State;
 using Ktisis.Structs.Actor;
 
 namespace Ktisis {
@@ -37,6 +38,7 @@ namespace Ktisis {
 			Interop.Hooks.GuiHooks.Init();
 			Interop.Hooks.EventsHooks.Init();
 			Input.Init();
+			ActorStateWatcher.Init();
 
 			// Register command
 
@@ -63,6 +65,7 @@ namespace Ktisis {
 			Interop.Hooks.GuiHooks.Dispose();
 			Interop.Hooks.EventsHooks.Dispose();
 			Input.Instance.Dispose();
+			ActorStateWatcher.Instance.Dispose();
 
 			GameData.Sheets.Cache.Clear();
 			if (EditEquip.Items != null)

--- a/Ktisis/Structs/Actor/State/ActorGposeState.cs
+++ b/Ktisis/Structs/Actor/State/ActorGposeState.cs
@@ -1,8 +1,6 @@
-﻿namespace Ktisis.Structs.Actor.State
-{
-    public enum ActorGposeState
-    {
-        ON,
-        OFF
-    }
+﻿namespace Ktisis.Structs.Actor.State {
+	public enum ActorGposeState {
+		ON,
+		OFF
+	}
 }

--- a/Ktisis/Structs/Actor/State/ActorGposeState.cs
+++ b/Ktisis/Structs/Actor/State/ActorGposeState.cs
@@ -1,0 +1,8 @@
+﻿namespace Ktisis.Structs.Actor.State
+{
+    public enum ActorGposeState
+    {
+        ON,
+        OFF
+    }
+}

--- a/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
+++ b/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
@@ -1,0 +1,65 @@
+﻿using Dalamud.Game;
+using Dalamud.Logging;
+using Ktisis.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Ktisis.Structs.Actor.State
+{
+    public sealed class ActorStateWatcher : IDisposable
+    {
+
+        private static ActorStateWatcher? _instance;
+
+        private ActorGposeState _gposeState = ActorGposeState.OFF;
+
+
+        public static ActorStateWatcher Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new ActorStateWatcher();
+                }
+                return _instance;
+            }
+        }
+
+        private ActorStateWatcher()
+        {
+            Services.Framework.Update += Monitor;
+        }
+
+		public void Dispose()
+        {
+			Services.Framework.Update -= Monitor;
+		}
+
+		public static void Init()
+        {
+            _ = Instance;
+        }
+
+
+
+        public void Monitor(Framework framework)
+        {
+            if (_gposeState == ActorGposeState.OFF && Ktisis.IsInGPose)
+            {
+                _gposeState = ActorGposeState.ON;
+                EventManager.FireOnGposeChangeEvent(_gposeState);
+            }
+
+            if (_gposeState == ActorGposeState.ON && !Ktisis.IsInGPose)
+            {
+                _gposeState = ActorGposeState.OFF;
+                EventManager.FireOnGposeChangeEvent(_gposeState);
+            }
+        }
+    }
+}

--- a/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
+++ b/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
@@ -8,58 +8,44 @@ using System.Text;
 using System.Threading.Tasks;
 using static System.Net.Mime.MediaTypeNames;
 
-namespace Ktisis.Structs.Actor.State
-{
-    public sealed class ActorStateWatcher : IDisposable
-    {
+namespace Ktisis.Structs.Actor.State {
+	public sealed class ActorStateWatcher : IDisposable {
 
-        private static ActorStateWatcher? _instance;
+		private static ActorStateWatcher? _instance;
 
-        private ActorGposeState _gposeState = ActorGposeState.OFF;
+		private ActorGposeState _gposeState = ActorGposeState.OFF;
 
+		public static ActorStateWatcher Instance {
+			get {
+				if (_instance == null) {
+					_instance = new ActorStateWatcher();
+				}
+				return _instance;
+			}
+		}
 
-        public static ActorStateWatcher Instance
-        {
-            get
-            {
-                if (_instance == null)
-                {
-                    _instance = new ActorStateWatcher();
-                }
-                return _instance;
-            }
-        }
+		private ActorStateWatcher() {
+			Services.Framework.Update += Monitor;
+		}
 
-        private ActorStateWatcher()
-        {
-            Services.Framework.Update += Monitor;
-        }
-
-		public void Dispose()
-        {
+		public void Dispose() {
 			Services.Framework.Update -= Monitor;
 		}
 
-		public static void Init()
-        {
-            _ = Instance;
-        }
+		public static void Init() {
+			_ = Instance;
+		}
 
+		public void Monitor(Framework framework) {
+			if (_gposeState == ActorGposeState.OFF && Ktisis.IsInGPose) {
+				_gposeState = ActorGposeState.ON;
+				EventManager.FireOnGposeChangeEvent(_gposeState);
+			}
 
-
-        public void Monitor(Framework framework)
-        {
-            if (_gposeState == ActorGposeState.OFF && Ktisis.IsInGPose)
-            {
-                _gposeState = ActorGposeState.ON;
-                EventManager.FireOnGposeChangeEvent(_gposeState);
-            }
-
-            if (_gposeState == ActorGposeState.ON && !Ktisis.IsInGPose)
-            {
-                _gposeState = ActorGposeState.OFF;
-                EventManager.FireOnGposeChangeEvent(_gposeState);
-            }
-        }
-    }
+			if (_gposeState == ActorGposeState.ON && !Ktisis.IsInGPose) {
+				_gposeState = ActorGposeState.OFF;
+				EventManager.FireOnGposeChangeEvent(_gposeState);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Alongside the event manager, the event `GPoseChange` was added.

This event is fired in two cases:
- The actor entered GPose.
- The actor left GPose.

Any method that subscribes to it will receive an enum `ActorGposeState` as input that indicates the current gpose state of the actor.