### PR TITLE
Category tweaks

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Numerics;
 using System.Collections.Generic;
 
@@ -54,6 +55,13 @@ namespace Ktisis {
 			return LinkedBoneCategoryColor;
 		}
 		public bool IsBoneVisible(Bone bone) {
+			// Check if input is forcing a category to show solo
+			if (Input.CategoryOverload.Count > 0)
+				if (Input.CategoryOverload.Intersect(bone.Categories.Select(c => c.Name)).Any())
+					return true;
+				else
+					return false;
+
 			// bone will be visible if any category is visible
 			foreach (var category in bone.Categories)
 				if (ShowBoneByCategory.TryGetValue(category.Name, out bool boneVisible))

--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -56,8 +56,8 @@ namespace Ktisis {
 		}
 		public bool IsBoneVisible(Bone bone) {
 			// Check if input is forcing a category to show solo
-			if (Input.CategoryOverload.Count > 0)
-				if (Input.CategoryOverload.Intersect(bone.Categories.Select(c => c.Name)).Any())
+			if (Category.VisibilityOverload.Count > 0)
+				if (Category.VisibilityOverload.Intersect(bone.Categories.Select(c => c.Name)).Any())
 					return true;
 				else
 					return false;

--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -26,6 +26,7 @@ namespace Ktisis {
 		public bool AutoOpenCtor { get; set; } = false;
 
 		public bool DisplayCharName { get; set; } = true;
+		public bool CensorNsfw { get; set; } = true;
 
 		public bool TransformTableDisplayMultiplierInputs { get; set; } = false;
 		public float TransformTableBaseSpeedPos { get; set; } = 0.0005f;

--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -47,15 +47,18 @@ namespace Ktisis {
 
 		public Vector4 GetCategoryColor(Bone bone) {
 			if (LinkBoneCategoryColors) return LinkedBoneCategoryColor;
-			if (!BoneCategoryColors.TryGetValue(bone.Category.Name, out Vector4 color))
-				return LinkedBoneCategoryColor;
-
-			return color;
+			// pick the first category found
+			foreach (var category in bone.Categories)
+				if (IsBoneCategoryVisible(category) && BoneCategoryColors.TryGetValue(category.Name, out Vector4 color))
+					return color;
+			return LinkedBoneCategoryColor;
 		}
 		public bool IsBoneVisible(Bone bone) {
-			if (!ShowBoneByCategory.TryGetValue(bone.Category.Name, out bool boneVisible))
-				return DrawLinesOnSkeleton;
-			return DrawLinesOnSkeleton && boneVisible;
+			// bone will be visible if any category is visible
+			foreach (var category in bone.Categories)
+				if (ShowBoneByCategory.TryGetValue(category.Name, out bool boneVisible))
+					if (boneVisible) return true;
+			return false;
 		}
 
 		public bool IsBoneCategoryVisible(Category category) {

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -46,7 +46,7 @@ namespace Ktisis.Interface.Components {
 
 		public static bool DrawToggleList(Configuration cfg) {
 			return DrawList(category => {
-				bool isOverloaded = Input.CategoryOverload.Any(c => c == category.Name);
+				bool isOverloaded = Category.VisibilityOverload.Any(c => c == category.Name);
 				bool categoryState = isOverloaded || cfg.IsBoneCategoryVisible(category);
 				if (isOverloaded) ImGui.PushStyleColor(ImGuiCol.CheckMark, Workspace.ColGreen);
 				var changed = ImGui.Checkbox(Locale.GetString(category.Name), ref categoryState);
@@ -54,9 +54,9 @@ namespace Ktisis.Interface.Components {
 
 				if (ImGui.GetIO().KeyShift) {
 					if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
-						Input.HoldCategory(category);
+						Category.ToggleVisibilityOverload(category);
 				} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-					Input.HoldCategory(category);
+					Category.ToggleVisibilityOverload(category);
 				else if (changed)
 					cfg.ShowBoneByCategory[category.Name] = categoryState;
 

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -1,12 +1,12 @@
-﻿using ImGuiNET;
-using Ktisis.Localization;
-using Ktisis.Structs.Bones;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
+
+using ImGuiNET;
+
+using Ktisis.Interface.Windows.Workspace;
+using Ktisis.Localization;
+using Ktisis.Structs.Bones;
 
 namespace Ktisis.Interface.Components {
 	internal static class Categories {
@@ -46,8 +46,18 @@ namespace Ktisis.Interface.Components {
 
 		public static bool DrawToggleList(Configuration cfg) {
 			return DrawList(category => {
-				bool categoryState = cfg.IsBoneCategoryVisible(category);
-				if (ImGui.Checkbox(Locale.GetString(category.Name), ref categoryState))
+				bool isOverloaded = Input.CategoryOverload.Any(c => c == category.Name);
+				bool categoryState = isOverloaded || cfg.IsBoneCategoryVisible(category);
+				if (isOverloaded) ImGui.PushStyleColor(ImGuiCol.CheckMark, Workspace.ColGreen);
+				var changed = ImGui.Checkbox(Locale.GetString(category.Name), ref categoryState);
+				if (isOverloaded) ImGui.PopStyleColor();
+
+				if (ImGui.GetIO().KeyShift) {
+					if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
+						Input.HoldCategory(category);
+				} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+					Input.HoldCategory(category);
+				else if (changed)
 					cfg.ShowBoneByCategory[category.Name] = categoryState;
 
 				return true;

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -11,12 +11,14 @@ using System.Threading.Tasks;
 namespace Ktisis.Interface.Components {
 	internal static class Categories {
 
-		public static bool DrawList(Func<Category,bool> drawForEach) {
+		private static bool DrawList(Func<Category,bool> drawForEach) {
 			ImGui.Columns(2);
 			int i = 0;
 			bool hasShownAnyCategory = false;
 			foreach (Category category in Category.Categories.Values) {
 				if (!category.ShouldDisplay)
+					continue;
+				if (Ktisis.Configuration.CensorNsfw && category.IsNsfw)
 					continue;
 
 				if (!drawForEach(category)) continue;

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -1,12 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
+using Dalamud.Interface;
 using ImGuiNET;
 
 using Ktisis.Interface.Windows.Workspace;
 using Ktisis.Localization;
 using Ktisis.Structs.Bones;
+using Ktisis.Util;
 
 namespace Ktisis.Interface.Components {
 	internal static class Categories {
@@ -45,23 +48,74 @@ namespace Ktisis.Interface.Components {
 		}
 
 		public static bool DrawToggleList(Configuration cfg) {
-			return DrawList(category => {
+			if (!DrawList(category => {
+
+				// display checkboxes
 				bool isOverloaded = Category.VisibilityOverload.Any(c => c == category.Name);
 				bool categoryState = isOverloaded || cfg.IsBoneCategoryVisible(category);
 				if (isOverloaded) ImGui.PushStyleColor(ImGuiCol.CheckMark, Workspace.ColGreen);
 				var changed = ImGui.Checkbox(Locale.GetString(category.Name), ref categoryState);
 				if (isOverloaded) ImGui.PopStyleColor();
 
+				// clicks and modifiers handles
 				if (ImGui.GetIO().KeyShift) {
 					if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
 						Category.ToggleVisibilityOverload(category);
+					else if (ImGui.IsItemClicked(ImGuiMouseButton.Right)) {
+						Category.VisibilityOverload.Clear();
+						Category.ToggleVisibilityOverload(category);
+					}
+
 				} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
 					SelectOnlyCategory(category);
 				else if (changed)
 					cfg.ShowBoneByCategory[category.Name] = categoryState;
 
 				return true;
-			});
+			})) return false;
+
+			// buttons to deselect or select all categories
+			if (Category.VisibilityOverload.Any()) {
+				ImGui.PushStyleColor(ImGuiCol.Text, Workspace.ColGreen);
+				if (GuiHelpers.IconButton(FontAwesomeIcon.Times, new(ControlButtons.ButtonSize.X * 2 + ImGui.GetStyle().ItemSpacing.X, ControlButtons.ButtonSize.Y)))
+					Category.VisibilityOverload.Clear();
+				ImGui.PopStyleColor();
+				if (ImGui.IsItemHovered()) {
+					ImGui.BeginTooltip();
+					ImGui.Text("Clear category");
+					ImGui.SameLine();
+					ImGui.TextColored(Workspace.ColGreen, "overload visibility");
+					ImGui.EndTooltip();
+				}
+			} else {
+				if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.CheckDouble, "Select all categories", ControlButtons.ButtonSize))
+					cfg.ShowBoneByCategory = cfg.ShowBoneByCategory.ToDictionary(p => p.Key, p => true);
+				ImGui.SameLine();
+				if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Times, "Deselect all categories", ControlButtons.ButtonSize))
+					cfg.ShowBoneByCategory = cfg.ShowBoneByCategory.ToDictionary(p => p.Key, p => false);
+			}
+			ImGui.SameLine(ImGui.GetContentRegionAvail().X - (ImGui.GetStyle().ItemSpacing.X) - GuiHelpers.CalcIconSize(FontAwesomeIcon.InfoCircle).X);
+			ControlButtons.VerticalAlignTextOnButtonSize();
+
+			// help hover
+			GuiHelpers.Icon(FontAwesomeIcon.InfoCircle, false);
+			if (ImGui.IsItemHovered()) {
+				ImGui.BeginTooltip();
+				ImGui.Text("Tips:");
+				ImGui.BulletText("Left click to toggle a category");
+				ImGui.BulletText("Right click to select the desired category only");
+				ImGui.BulletText("Shift + Left click to toggle the category into");
+				ImGui.SameLine(); ImGui.TextColored(Workspace.ColGreen, "overload visibility");
+				ImGui.BulletText("Shift + Right click to select the desired");
+				ImGui.SameLine(); ImGui.TextColored(Workspace.ColGreen, "overload visibility"); ImGui.SameLine();
+				ImGui.Text("only");
+				ImGui.BulletText("Keyboard shortcuts can be bound to individual category");
+				ImGui.SameLine(); ImGui.TextColored(Workspace.ColGreen, "overload visibility"); ImGui.SameLine();
+				ImGui.Text("hold or toggle");
+				ImGui.EndTooltip();
+			}
+
+			return true;
 		}
 		public static void SelectOnlyCategory(Category category) {
 			Ktisis.Configuration.ShowBoneByCategory = Ktisis.Configuration.ShowBoneByCategory.ToDictionary(p => p.Key, p => false);

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -1,0 +1,59 @@
+﻿using ImGuiNET;
+using Ktisis.Localization;
+using Ktisis.Structs.Bones;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ktisis.Interface.Components {
+	internal static class Categories {
+
+		public static bool DrawList(Func<Category,bool> drawForEach) {
+			ImGui.Columns(2);
+			int i = 0;
+			bool hasShownAnyCategory = false;
+			foreach (Category category in Category.Categories.Values) {
+				if (!category.ShouldDisplay)
+					continue;
+
+				if (!drawForEach(category)) continue;
+
+				if (i % 2 != 0) ImGui.NextColumn();
+				i++;
+				hasShownAnyCategory = true;
+			}
+			ImGui.Columns();
+			return hasShownAnyCategory;
+		}
+
+
+		public static bool DrawConfigList(Configuration cfg) {
+			return DrawList(category => {
+				if (!cfg.BoneCategoryColors.ContainsKey(category.Name))
+					return false;
+
+				if (!cfg.BoneCategoryColors.TryGetValue(category.Name, out Vector4 categoryColor))
+					categoryColor = cfg.LinkedBoneCategoryColor;
+
+				if (ImGui.ColorEdit4(category.Name, ref categoryColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaBar))
+					cfg.BoneCategoryColors[category.Name] = categoryColor;
+
+				return true;
+			});
+		}
+
+		public static bool DrawToggleList(Configuration cfg) {
+			return DrawList(category => {
+				bool categoryState = cfg.IsBoneCategoryVisible(category);
+				if (ImGui.Checkbox(category.Name, ref categoryState))
+					cfg.ShowBoneByCategory[category.Name] = categoryState;
+
+				return true;
+			});
+		}
+
+	}
+}

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -34,9 +34,6 @@ namespace Ktisis.Interface.Components {
 
 		public static bool DrawConfigList(Configuration cfg) {
 			return DrawList(category => {
-				if (!cfg.BoneCategoryColors.ContainsKey(category.Name))
-					return false;
-
 				if (!cfg.BoneCategoryColors.TryGetValue(category.Name, out Vector4 categoryColor))
 					categoryColor = cfg.LinkedBoneCategoryColor;
 

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -37,7 +37,7 @@ namespace Ktisis.Interface.Components {
 				if (!cfg.BoneCategoryColors.TryGetValue(category.Name, out Vector4 categoryColor))
 					categoryColor = cfg.LinkedBoneCategoryColor;
 
-				if (ImGui.ColorEdit4(category.Name, ref categoryColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaBar))
+				if (ImGui.ColorEdit4(Locale.GetString(category.Name), ref categoryColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaBar))
 					cfg.BoneCategoryColors[category.Name] = categoryColor;
 
 				return true;
@@ -47,7 +47,7 @@ namespace Ktisis.Interface.Components {
 		public static bool DrawToggleList(Configuration cfg) {
 			return DrawList(category => {
 				bool categoryState = cfg.IsBoneCategoryVisible(category);
-				if (ImGui.Checkbox(category.Name, ref categoryState))
+				if (ImGui.Checkbox(Locale.GetString(category.Name), ref categoryState))
 					cfg.ShowBoneByCategory[category.Name] = categoryState;
 
 				return true;

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -56,13 +56,16 @@ namespace Ktisis.Interface.Components {
 					if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
 						Category.ToggleVisibilityOverload(category);
 				} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-					Category.ToggleVisibilityOverload(category);
+					SelectOnlyCategory(category);
 				else if (changed)
 					cfg.ShowBoneByCategory[category.Name] = categoryState;
 
 				return true;
 			});
 		}
-
+		public static void SelectOnlyCategory(Category category) {
+			Ktisis.Configuration.ShowBoneByCategory = Ktisis.Configuration.ShowBoneByCategory.ToDictionary(p => p.Key, p => false);
+			Ktisis.Configuration.ShowBoneByCategory[category.Name] = true;
+		}
 	}
 }

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -60,10 +60,10 @@ namespace Ktisis.Interface.Components {
 				// clicks and modifiers handles
 				if (ImGui.GetIO().KeyShift) {
 					if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
-						Category.ToggleVisibilityOverload(category);
+						category.ToggleVisibilityOverload();
 					else if (ImGui.IsItemClicked(ImGuiMouseButton.Right)) {
 						Category.VisibilityOverload.Clear();
-						Category.ToggleVisibilityOverload(category);
+						category.ToggleVisibilityOverload();
 					}
 
 				} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right))

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -42,10 +42,10 @@ namespace Ktisis.Interface {
 
 				foreach ((var p, var c) in PurposesCategoriesHold)
 					if (IsPurposeChanged(p))
-						Category.ToggleVisibilityOverload(c);
+						c.ToggleVisibilityOverload();
 				foreach ((var p, var c) in PurposesCategoriesToggle)
 					if (IsPurposeReleased(p))
-						Category.ToggleVisibilityOverload(c);
+						c.ToggleVisibilityOverload();
 			}
 			if (IsPurposeChanged(Purpose.HoldToHideSkeleton))
 				Skeleton.Toggle();

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -35,6 +35,10 @@ namespace Ktisis.Interface {
 					Ktisis.Configuration.GizmoOp = OPERATION.UNIVERSAL;
 				if (IsPurposeReleased(Purpose.ToggleLocalWorld))
 					Ktisis.Configuration.GizmoMode = Ktisis.Configuration.GizmoMode == MODE.WORLD ? MODE.LOCAL : MODE.WORLD;
+				if (IsPurposeReleased(Purpose.ClearCategoryVisibilityOverload))
+					Category.VisibilityOverload.Clear();
+				if (IsPurposeChanged(Purpose.HoldAllCategoryVisibilityOverload))
+					Category.ToggleAllVisibilityOverload();
 
 				foreach ((var p, var c) in PurposesCategoriesHold)
 					if (IsPurposeChanged(p))
@@ -59,6 +63,8 @@ namespace Ktisis.Interface {
 			ToggleLocalWorld,
 			HoldToHideSkeleton,
 			SwitchToUniversal,
+			ClearCategoryVisibilityOverload,
+			HoldAllCategoryVisibilityOverload,
 		}
 
 		public static readonly Dictionary<Purpose, List<VirtualKey>> DefaultKeys = new(){
@@ -69,6 +75,8 @@ namespace Ktisis.Interface {
 			{Purpose.ToggleLocalWorld, new(){VirtualKey.X}},
 			{Purpose.HoldToHideSkeleton, new(){VirtualKey.V}},
 			{Purpose.SwitchToUniversal, new(){VirtualKey.U}},
+			{Purpose.ClearCategoryVisibilityOverload, new(){VirtualKey.J}},
+			{Purpose.HoldAllCategoryVisibilityOverload, new(){VirtualKey.J, VirtualKey.SHIFT}},
 		};
 
 		// Helpers

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -134,7 +134,7 @@ namespace Ktisis.Interface {
 				return purposesWithCategories;
 			}
 		}
-		private static void HoldCategory(Category category) {
+		public static void HoldCategory(Category category) {
 			if (CategoryOverload.Any(s => s == category.Name))
 				CategoryOverload.Remove(category.Name);
 			else

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -41,10 +41,10 @@ namespace Ktisis.Interface {
 
 			foreach ((var p, var c) in PurposesCategoriesHold)
 				if(IsPurposeChanged(p))
-					HoldCategory(c);
+					Category.ToggleVisibilityOverload(c);
 			foreach ((var p, var c) in PurposesCategoriesToggle)
 				if(IsPurposeReleased(p))
-					HoldCategory(c);
+					Category.ToggleVisibilityOverload(c);
 
 			PrevriousKeyStates = CurrentKeyStates!;
 			CurrentKeyStates = null;
@@ -103,7 +103,6 @@ namespace Ktisis.Interface {
 		public static readonly Dictionary<Purpose, Category> PurposesCategoriesToggle = new();
 		public const int FirstCategoryPurposeHold = 1000;
 		public const int FirstCategoryPurposeToggle = 2000;
-		public static List<string> CategoryOverload = new();
 
 		private Dictionary<Purpose, bool> PrevriousKeyStates = new();
 		private Dictionary<Purpose, bool>? CurrentKeyStates = new();
@@ -133,12 +132,6 @@ namespace Ktisis.Interface {
 
 				return purposesWithCategories;
 			}
-		}
-		public static void HoldCategory(Category category) {
-			if (CategoryOverload.Any(s => s == category.Name))
-				CategoryOverload.Remove(category.Name);
-			else
-				CategoryOverload.Add(category.Name);
 		}
 		private static List<VirtualKey> PurposeToVirtualKeys(Purpose purpose) {
 			if (!Ktisis.Configuration.KeyBinds.TryGetValue(purpose, out List<VirtualKey>? keys)) {

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -35,16 +35,16 @@ namespace Ktisis.Interface {
 					Ktisis.Configuration.GizmoOp = OPERATION.UNIVERSAL;
 				if (IsPurposeReleased(Purpose.ToggleLocalWorld))
 					Ktisis.Configuration.GizmoMode = Ktisis.Configuration.GizmoMode == MODE.WORLD ? MODE.LOCAL : MODE.WORLD;
+
+				foreach ((var p, var c) in PurposesCategoriesHold)
+					if (IsPurposeChanged(p))
+						Category.ToggleVisibilityOverload(c);
+				foreach ((var p, var c) in PurposesCategoriesToggle)
+					if (IsPurposeReleased(p))
+						Category.ToggleVisibilityOverload(c);
 			}
 			if (IsPurposeChanged(Purpose.HoldToHideSkeleton))
 				Skeleton.Toggle();
-
-			foreach ((var p, var c) in PurposesCategoriesHold)
-				if(IsPurposeChanged(p))
-					Category.ToggleVisibilityOverload(c);
-			foreach ((var p, var c) in PurposesCategoriesToggle)
-				if(IsPurposeReleased(p))
-					Category.ToggleVisibilityOverload(c);
 
 			PrevriousKeyStates = CurrentKeyStates!;
 			CurrentKeyStates = null;

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -169,26 +169,10 @@ namespace Ktisis.Interface.Windows {
 					}
 
 					ImGui.Text(Locale.GetString("Categories_colors"));
-					ImGui.Columns(2);
-					int i = 0;
-					bool hasShownAnyCategory = false;
-					foreach (Category category in Category.Categories.Values) {
-						if (!category.ShouldDisplay && !cfg.BoneCategoryColors.ContainsKey(category.Name))
-							continue;
 
-						if (!cfg.BoneCategoryColors.TryGetValue(category.Name, out Vector4 categoryColor))
-							categoryColor = cfg.LinkedBoneCategoryColor;
-
-						if (ImGui.ColorEdit4(category.Name, ref categoryColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaBar))
-							cfg.BoneCategoryColors[category.Name] = categoryColor;
-
-						if (i % 2 != 0) ImGui.NextColumn();
-						i++;
-						hasShownAnyCategory = true;
-					}
-					ImGui.Columns();
-					if (!hasShownAnyCategory)
+					if (!Components.Categories.DrawConfigList(cfg))
 						ImGui.TextWrapped(Locale.GetString("Categories_will_be_added_after_bones_are_displayed_once"));
+
 				}
 			}
 			if (ImGui.CollapsingHeader(Locale.GetString("Edit_bone_positions")))

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -257,6 +257,7 @@ namespace Ktisis.Interface.Windows {
 			ImGui.Spacing();
 			ImGui.Spacing();
 
+			ImGui.BeginChildFrame(74, new(-1, ImGui.GetFontSize() * 20));
 
 			// key/Action table
 			ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, ImGui.GetStyle().CellPadding * 3);
@@ -304,7 +305,7 @@ namespace Ktisis.Interface.Windows {
 			}
 			ImGui.PopStyleVar();
 			ImGui.EndTabItem();
-
+			ImGui.EndChildFrame();
 		}
 		private static string PrettyKeys(List<VirtualKey>  keys) => string.Join(" + ", keys.Select(k => VirtualKeyExtensions.GetFancyName(k)));
 

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -268,7 +268,10 @@ namespace Ktisis.Interface.Windows {
 				ImGui.TableSetupColumn("Action");
 				ImGui.TableHeadersRow();
 
-				foreach (var purpose in Input.Purposes) {
+				foreach (var purpose in Input.PurposesWithCategories) {
+					if ((int)purpose >= Input.FirstCategoryPurposeHold)
+						if (Input.PurposesCategories.TryGetValue(purpose, out var category))
+							if ((!cfg.KeyBinds.Any(t => t.Key == purpose) && !category.ShouldDisplay) || (cfg.CensorNsfw && category.IsNsfw)) continue;
 
 					// get currently configured or default keys
 					if (!Input.DefaultKeys.TryGetValue(purpose, out List<VirtualKey>? defaultKeys))

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -291,7 +291,7 @@ namespace Ktisis.Interface.Windows {
 
 					// display the purpose
 					ImGui.TableNextColumn();
-					ImGui.Selectable(Locale.GetString($"Keyboard_Action_{purpose}"), false, ImGuiSelectableFlags.SpanAllColumns);
+					ImGui.Selectable(Locale.GetInputPurposeName(purpose), false, ImGuiSelectableFlags.SpanAllColumns);
 					clickRow |= ImGui.IsItemClicked(ImGuiMouseButton.Left) || ImGui.IsItemClicked(ImGuiMouseButton.Right);
 
 					// execute the change if clicked

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -82,6 +82,10 @@ namespace Ktisis.Interface.Windows {
 			if (ImGui.Checkbox(Locale.GetString("Hide_char_name"), ref displayCharName))
 				cfg.DisplayCharName = !displayCharName;
 
+			var censorNsfw = !cfg.CensorNsfw;
+			if (ImGui.Checkbox(Locale.GetString("Censor_nsfw"), ref censorNsfw))
+				cfg.CensorNsfw = !censorNsfw;
+
 			ImGui.Spacing();
 			ImGui.Separator();
 			ImGui.Text(Locale.GetString("Transform_table"));

--- a/Ktisis/Interface/Windows/Workspace/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace/Workspace.cs
@@ -103,23 +103,7 @@ namespace Ktisis.Interface.Windows.Workspace {
 			if (ImGui.CollapsingHeader("Bone Category Visibility")) {
 
 				ImGui.Indent(16.0f);
-				ImGui.Columns(2);
-				int i = 0;
-				bool hasShownAnyCategory = false;
-				foreach (Category category in Category.Categories.Values) {
-					if (!category.ShouldDisplay) continue;
-
-					bool categoryState = cfg.IsBoneCategoryVisible(category);
-
-					if (ImGui.Checkbox(category.Name, ref categoryState))
-						cfg.ShowBoneByCategory[category.Name] = categoryState;
-
-					if (i % 2 != 0) ImGui.NextColumn();
-					i++;
-					hasShownAnyCategory = true;
-				}
-				ImGui.Columns();
-				if (!hasShownAnyCategory) {
+				if (!Categories.DrawToggleList(cfg)) {
 					ImGui.Text("No bone found.");
 					ImGui.Text("Show Skeleton (");
 					ImGui.SameLine();
@@ -127,7 +111,6 @@ namespace Ktisis.Interface.Windows.Workspace {
 					ImGui.SameLine();
 					ImGui.Text(") to fill this.");
 				}
-
 				ImGui.Unindent(16.0f);
 			}
 

--- a/Ktisis/Interface/Windows/Workspace/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace/Workspace.cs
@@ -102,7 +102,6 @@ namespace Ktisis.Interface.Windows.Workspace {
 			// Bone categories
 			if (ImGui.CollapsingHeader("Bone Category Visibility")) {
 
-				ImGui.Indent(16.0f);
 				if (!Categories.DrawToggleList(cfg)) {
 					ImGui.Text("No bone found.");
 					ImGui.Text("Show Skeleton (");
@@ -111,7 +110,6 @@ namespace Ktisis.Interface.Windows.Workspace {
 					ImGui.SameLine();
 					ImGui.Text(") to fill this.");
 				}
-				ImGui.Unindent(16.0f);
 			}
 
 			// Bone tree

--- a/Ktisis/Locale/Localization.cs
+++ b/Ktisis/Locale/Localization.cs
@@ -7,6 +7,8 @@ using Newtonsoft.Json.Linq;
 
 using Dalamud.Logging;
 
+using Ktisis.Interface;
+
 namespace Ktisis.Localization {
 	public static class Locale {
 		public static UserLocale Loaded = UserLocale.None;
@@ -40,6 +42,20 @@ namespace Ktisis.Localization {
 
 		public static string GetBoneName(string handle) {
 			return Ktisis.Configuration.TranslateBones ? GetString(handle) : handle;
+		}
+		public static string GetInputPurposeName(Input.Purpose purpose) {
+			string regularPurposeString = $"Keyboard_Action_{purpose}";
+			if(Strings.ContainsKey(regularPurposeString))
+				return GetString(regularPurposeString);
+
+			bool isHold = (int)purpose >= Input.FirstCategoryPurposeHold && (int)purpose < Input.FirstCategoryPurposeToggle;
+			bool isToggle = (int)purpose >= Input.FirstCategoryPurposeToggle;
+			string actionHandle = isHold ? "Input_Generic_Hold" : (isToggle ? "Input_Generic_Toggle" : "Input_Generic_Not_Applicable");
+
+			if (Input.PurposesCategories.TryGetValue(purpose, out var category))
+				return GetString(actionHandle) + " " + GetString(category.Name);
+
+			return regularPurposeString;
 		}
 
 		public static Stream GetLocaleFile(UserLocale lang) {

--- a/Ktisis/Locale/i18n/English.json
+++ b/Ktisis/Locale/i18n/English.json
@@ -41,6 +41,10 @@
     "Flip_axis_to_face_camera": "Flip axis to face camera",
     "Translate_bone_names": "Translate bone names",
     // Display keyboard configs from enum defined in Input.cs
+    "Input_Generic_Toggle": "Toggle",
+    "Input_Generic_Hold": "Hold",
+    "Input_Generic_Release": "Release",
+    "Input_Generic_Not_Applicable": "N/A",
     "Keyboard_Action_GlobalModifierKey": "Global modifier",
     "Keyboard_Action_SwitchToTranslate": "Switch to translate",
     "Keyboard_Action_SwitchToRotate": "Switch to rotate",
@@ -215,5 +219,27 @@
     "mh_n_hara": "Main Hand",
     "oh_n_hara": "Off Hand",
     "j_half_l": "Left Half",
-    "j_half_r": "Right Half"
+    "j_half_r": "Right Half",
+
+    // Bone Category names
+    "other": "Other",
+    "body": "Body",
+    "head": "Head",
+    "hair": "Hair",
+    "clothes": "Clothes",
+    "weapons": "Weapons",
+    "right hand": "Right hand",
+    "left hand": "Left hand",
+    "feet": "Feet",
+    "hands": "Hands",
+    "tail": "Tail",
+    "ears": "Ears",
+    "ivcs left hand": "IVCS left hand",
+    "ivcs right hand": "IVCS right hand",
+    "ivcs left foot": "IVCS left foot",
+    "ivcs right foot": "IVCS right foot",
+    "ivcs body": "IVCS body",
+    "ivcs penis": "IVCS penis",
+    "ivcs vagina": "IVCS vagina",
+    "ivcs buttocks": "IVCS buttocks"
 }

--- a/Ktisis/Structs/Bones/Bone.cs
+++ b/Ktisis/Structs/Bones/Bone.cs
@@ -37,7 +37,7 @@ namespace Ktisis.Structs.Bones {
 		public string UniqueId => $"{Partial}_{Index}";
 		public string UniqueName => $"{LocaleName}##{UniqueId}";
 
-		public Category Category => Category.GetForBone(HkaBone.Name.String);
+		public List<Category> Categories => Category.GetForBone(HkaBone.Name.String);
 
 		public unsafe hkQsTransformf* AccessModelSpace(PropagateOrNot propagate) => Pose->AccessBoneModelSpace(Index, propagate);
 

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -11,6 +11,7 @@ namespace Ktisis.Structs.Bones
 		public bool ShouldDisplay { get; private set; } = false;
 		public IReadOnlyList<string> PossibleBones => new ReadOnlyCollection<string>(_PossibleBones);
 		private readonly List<string> _PossibleBones;
+		public bool IsNsfw { get; private set; } = false;
 
 		public static IReadOnlyDictionary<string, Category> Categories
 			=> new ReadOnlyDictionary<string, Category>(_Categories);
@@ -19,16 +20,17 @@ namespace Ktisis.Structs.Bones
 
 		public static Category DefaultCategory => Categories["other"];
 
-		private Category(string name, Vector4 defaultColor, List<string> boneNames)
+		private Category(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw)
 		{
 			Name = name;
 			DefaultColor = defaultColor;
 			_PossibleBones = boneNames;
+			IsNsfw = isNsfw;
 		}
-		public static Category CreateCategory(string name, Vector4 defaultColor, List<string> boneNames)
+		public static Category CreateCategory(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw = false)
 		{
 			/* TODO: We currently throw for duplicated categories. This may turn out to be a problem in the future. */
-			Category cat = new(name, defaultColor, boneNames);
+			Category cat = new(name, defaultColor, boneNames, isNsfw);
 			_Categories.Add(name, cat);
 			foreach(string boneName in cat.PossibleBones) {
 				/* On collision, use the first registered category */
@@ -354,12 +356,12 @@ namespace Ktisis.Structs.Bones
 				"iv_ochinko_d",
 				"iv_ochinko_e",
 				"iv_ochinko_f",
-			});
+			},true);
 			CreateCategory("ivcs vagina", defaultColor, new List<string> {
 				"iv_kuritto", // Clitoris   rotation, position, scale
 				"iv_inshin_l", // Labia    rotation, position, scale
 				"iv_inshin_r", // Labia
-			});
+			},true);
 			CreateCategory("ivcs buttocks", defaultColor, new List<string> {
 				// Anus (rotation, scale, position)
 				"iv_koumon",
@@ -369,7 +371,7 @@ namespace Ktisis.Structs.Bones
 				// Buttocks (rotation, scale, position)
 				"iv_shiri_l",
 				"iv_shiri_r",
-			});
+			},true);
 		}
 	}
 }

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -63,13 +63,11 @@ namespace Ktisis.Structs.Bones
 			return categories;
 		}
 
-		private readonly static bool[] _lookup = new bool[65536];
-
 		public static string RemoveSpecialCharacters(string str) {
 			char[] buffer = new char[str.Length];
 			int index = 0;
 			foreach (char c in str) {
-				if (_lookup[c]) {
+				if (c < '0' || c > '9') {
 					buffer[index] = c;
 					index++;
 				}
@@ -79,13 +77,6 @@ namespace Ktisis.Structs.Bones
 
 		static Category()
 		{
-			// Create a lookup to strip numbers from bone names when checking them.
-			// it's relative fast, according to stackoverflow
-			//for (char c = '0'; c <= '9'; c++) _lookup[c] = true; // we strip numbers from the bone name
-			for (char c = 'A'; c <= 'Z'; c++) _lookup[c] = true;
-			for (char c = 'a'; c <= 'z'; c++) _lookup[c] = true;
-			_lookup['_'] = true;
-
 			Vector4 defaultColor = new Vector4(1.0F, 1.0F, 1.0F, 0.5647059F);
 
 			/* Default fallback category (do not assign bones here) */

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace Ktisis.Structs.Bones
-{
-	public class Category
-	{
+namespace Ktisis.Structs.Bones {
+	public class Category {
 		public string Name { get; set; }
 		public Vector4 DefaultColor { get; set; }
 		public bool ShouldDisplay { get; private set; } = false;
@@ -16,38 +14,34 @@ namespace Ktisis.Structs.Bones
 
 		public static IReadOnlyDictionary<string, Category> Categories
 			=> new ReadOnlyDictionary<string, Category>(_Categories);
-		private static readonly Dictionary<string,Category> _Categories = new();
+		private static readonly Dictionary<string, Category> _Categories = new();
 		private static readonly Dictionary<string, List<Category>> CategoriesByBone = new();
 
 		public static Category DefaultCategory => Categories["other"];
 		public static List<Category> DefaultCategories => new() { DefaultCategory };
 
-		private Category(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw)
-		{
+		private Category(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw) {
 			Name = name;
 			DefaultColor = defaultColor;
 			_PossibleBones = boneNames;
 			IsNsfw = isNsfw;
 		}
-		public static Category CreateCategory(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw = false)
-		{
+		public static Category CreateCategory(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw = false) {
 			/* TODO: We currently throw for duplicated categories. This may turn out to be a problem in the future. */
 			Category cat = new(name, defaultColor, boneNames, isNsfw);
 			_Categories.Add(name, cat);
-			foreach(string boneName in cat.PossibleBones) {
+			foreach (string boneName in cat.PossibleBones) {
 				if (!CategoriesByBone.TryAdd(boneName, new List<Category> { cat }))
 					CategoriesByBone[boneName].Add(cat);
 			}
 			return cat;
 		}
 
-		public void MarkForDisplay()
-		{
+		public void MarkForDisplay() {
 			ShouldDisplay = true;
 		}
 
-		public static List<Category> GetForBone(string? boneName)
-		{
+		public static List<Category> GetForBone(string? boneName) {
 			if (string.IsNullOrEmpty(boneName))
 				return DefaultCategories;
 
@@ -347,12 +341,12 @@ namespace Ktisis.Structs.Bones
 				"iv_ochinko_d",
 				"iv_ochinko_e",
 				"iv_ochinko_f",
-			},true);
+			}, true);
 			CreateCategory("ivcs vagina", defaultColor, new List<string> {
 				"iv_kuritto", // Clitoris   rotation, position, scale
 				"iv_inshin_l", // Labia    rotation, position, scale
 				"iv_inshin_r", // Labia
-			},true);
+			}, true);
 			CreateCategory("ivcs buttocks", defaultColor, new List<string> {
 				// Anus (rotation, scale, position)
 				"iv_koumon",
@@ -362,7 +356,7 @@ namespace Ktisis.Structs.Bones
 				// Buttocks (rotation, scale, position)
 				"iv_shiri_l",
 				"iv_shiri_r",
-			},true);
+			}, true);
 
 			// compount categories
 			// The categories below have bones in common with other categories above.

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -20,6 +20,8 @@ namespace Ktisis.Structs.Bones {
 		public static Category DefaultCategory => Categories["other"];
 		public static List<Category> DefaultCategories => new() { DefaultCategory };
 
+		public static List<string> VisibilityOverload = new();
+
 		private Category(string name, Vector4 defaultColor, List<string> boneNames, bool isNsfw) {
 			Name = name;
 			DefaultColor = defaultColor;
@@ -40,6 +42,7 @@ namespace Ktisis.Structs.Bones {
 		public void MarkForDisplay() {
 			ShouldDisplay = true;
 		}
+
 
 		public static List<Category> GetForBone(string? boneName) {
 			if (string.IsNullOrEmpty(boneName))
@@ -67,6 +70,13 @@ namespace Ktisis.Structs.Bones {
 				}
 			}
 			return new string(buffer, 0, index);
+		}
+
+		public static void ToggleVisibilityOverload(Category category) {
+			if (VisibilityOverload.Any(s => s == category.Name))
+				VisibilityOverload.Remove(category.Name);
+			else
+				VisibilityOverload.Add(category.Name);
 		}
 
 		static Category()

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -47,16 +47,41 @@ namespace Ktisis.Structs.Bones
 			if (string.IsNullOrEmpty(boneName))
 				return DefaultCategory;
 
-			if(!CategoriesByBone.TryGetValue(boneName, out Category? category))
-				category = DefaultCategory;
+			if (!CategoriesByBone.TryGetValue(boneName, out Category? category)) {
+				// This is needed for bone names with an ID, such as hair bones, e.g. j_ex_h0116_ke_b_a
+				var testedBoneName = RemoveSpecialCharacters(boneName);
+				if (!CategoriesByBone.TryGetValue(testedBoneName, out category))
+					category = DefaultCategory;
+			}
 
 			category.MarkForDisplay();
 
 			return category;
 		}
 
+		private readonly static bool[] _lookup = new bool[65536];
+
+		public static string RemoveSpecialCharacters(string str) {
+			char[] buffer = new char[str.Length];
+			int index = 0;
+			foreach (char c in str) {
+				if (_lookup[c]) {
+					buffer[index] = c;
+					index++;
+				}
+			}
+			return new string(buffer, 0, index);
+		}
+
 		static Category()
 		{
+			// Create a lookup to strip numbers from bone names when checking them.
+			// it's relative fast, according to stackoverflow
+			//for (char c = '0'; c <= '9'; c++) _lookup[c] = true; // we strip numbers from the bone name
+			for (char c = 'A'; c <= 'Z'; c++) _lookup[c] = true;
+			for (char c = 'a'; c <= 'z'; c++) _lookup[c] = true;
+			_lookup['_'] = true;
+
 			Vector4 defaultColor = new Vector4(1.0F, 1.0F, 1.0F, 0.5647059F);
 
 			/* Default fallback category (do not assign bones here) */
@@ -142,6 +167,28 @@ namespace Ktisis.Structs.Bones
 				"j_kami_f_r", // HairFrontRight
 				"j_kami_b", // HairB
 				"j_ex_met_va", // HairB
+
+				"j_ex_h_ke_a", // the bones below must be stipped from digits
+				"j_ex_h_ke_b", // some are real, some are guessed by pattern
+				"j_ex_h_ke_s",
+				"j_ex_h_ke_s_r",
+				"j_ex_h_ke_s_l",
+				"j_ex_h_ke_a_r",
+				"j_ex_h_ke_a_l",
+				"j_ex_h_ke_b_a",
+				"j_ex_h_ke_b_b",
+				"j_ex_h_ke_b_l",
+				"j_ex_h_ke_b_r",
+				"j_ex_h_ke_u",
+				"j_ex_h_ke_u_r",
+				"j_ex_h_ke_u_l",
+				"j_ex_h_ke_f",
+				"j_ex_h_ke_f_a",
+				"j_ex_h_ke_f_b",
+				"j_ex_h_ke_f_l",
+				"j_ex_h_ke_f_r",
+				"j_ex_h_ke_l",
+				"j_ex_h_ke_r",
 			});
 			CreateCategory("clothes", new Vector4(1.0F, 1.0F, 0.0F, 0.5647059F), new List<string> {
 				"j_sk_b_b_l",     // ClothBackBLeft

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -232,6 +232,10 @@ namespace Ktisis.Structs.Bones {
 				"j_ex_top_a_l",
 				"j_ex_top_b_r",
 				"j_ex_top_b_l",
+				"j_ex_met_a",
+				"j_ex_met_b",
+				"j_ex_met_c",
+				"j_ex_met_d",
 			});
 			CreateCategory("weapons", new Vector4(1.0F, 0.0F, 1.0F, 0.5647059F), new List<string> {
 				"j_buki_sebo_l",  // ScabbardLeft

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -78,6 +78,12 @@ namespace Ktisis.Structs.Bones {
 			else
 				VisibilityOverload.Add(category.Name);
 		}
+		public static void ToggleAllVisibilityOverload() {
+			if (VisibilityOverload.Any())
+				VisibilityOverload.Clear();
+			else
+				VisibilityOverload = Categories.Where(p => p.Value.ShouldDisplay).Select(p => p.Key).ToList();
+		}
 
 		static Category()
 		{

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -72,11 +72,11 @@ namespace Ktisis.Structs.Bones {
 			return new string(buffer, 0, index);
 		}
 
-		public static void ToggleVisibilityOverload(Category category) {
-			if (VisibilityOverload.Any(s => s == category.Name))
-				VisibilityOverload.Remove(category.Name);
+		public void ToggleVisibilityOverload() {
+			if (VisibilityOverload.Any(s => s == this.Name))
+				VisibilityOverload.Remove(this.Name);
 			else
-				VisibilityOverload.Add(category.Name);
+				VisibilityOverload.Add(this.Name);
 		}
 		public static void ToggleAllVisibilityOverload() {
 			if (VisibilityOverload.Any())

--- a/Ktisis/Structs/Bones/Category.cs
+++ b/Ktisis/Structs/Bones/Category.cs
@@ -157,27 +157,37 @@ namespace Ktisis.Structs.Bones {
 				"j_kami_b", // HairB
 				"j_ex_met_va", // HairB
 
-				"j_ex_h_ke_a", // the bones below must be stipped from digits
-				"j_ex_h_ke_b", // some are real, some are guessed by pattern
-				"j_ex_h_ke_s",
-				"j_ex_h_ke_s_r",
-				"j_ex_h_ke_s_l",
-				"j_ex_h_ke_a_r",
+				// some are real, some are guessed by pattern
+				// the bones below must be stipped from digits
 				"j_ex_h_ke_a_l",
+				"j_ex_h_ke_a_r",
+				"j_ex_h_ke_a",
 				"j_ex_h_ke_b_a",
 				"j_ex_h_ke_b_b",
 				"j_ex_h_ke_b_l",
 				"j_ex_h_ke_b_r",
-				"j_ex_h_ke_u",
-				"j_ex_h_ke_u_r",
-				"j_ex_h_ke_u_l",
-				"j_ex_h_ke_f",
+				"j_ex_h_ke_b",
+				"j_ex_h_ke_c_l",
+				"j_ex_h_ke_c_r",
+				"j_ex_h_ke_c",
+				"j_ex_h_ke_d",
+				"j_ex_h_ke_da",
+				"j_ex_h_ke_db",
+				"j_ex_h_ke_e",
 				"j_ex_h_ke_f_a",
 				"j_ex_h_ke_f_b",
 				"j_ex_h_ke_f_l",
 				"j_ex_h_ke_f_r",
+				"j_ex_h_ke_f",
 				"j_ex_h_ke_l",
 				"j_ex_h_ke_r",
+				"j_ex_h_ke_s_l",
+				"j_ex_h_ke_s_r",
+				"j_ex_h_ke_s",
+				"j_ex_h_ke_u_l",
+				"j_ex_h_ke_u_r",
+				"j_ex_h_ke_u",
+				"j_ex_h_ke_u",
 			});
 			CreateCategory("clothes", new Vector4(1.0F, 1.0F, 0.0F, 0.5647059F), new List<string> {
 				"j_sk_b_b_l",     // ClothBackBLeft
@@ -207,7 +217,11 @@ namespace Ktisis.Structs.Bones {
 				"n_ear_a_l",      // EarringALeft
 				"n_ear_a_r",      // EarringARight
 				"n_ear_b_l",      // EarringBLeft
-				"n_ear_b_r"       // EarringBRight
+				"n_ear_b_r",       // EarringBRight
+				"j_ex_top_a_r",
+				"j_ex_top_a_l",
+				"j_ex_top_b_r",
+				"j_ex_top_b_l",
 			});
 			CreateCategory("weapons", new Vector4(1.0F, 0.0F, 1.0F, 0.5647059F), new List<string> {
 				"j_buki_sebo_l",  // ScabbardLeft


### PR DESCRIPTION
Small tweaks became features, the main points are:
- multiple categories per bones
- NSFW option
- category visibility overload (a temporary "layer" of selected categories)
- hold and toggle visibility overload keybinds for each category
- various click combinations and buttons on category visibility checkboxes
- categorized many bones that were falling into "others"

Thanks to Rose, Fia, Allora and Serena for their suggestions! ❤️

