### PR TITLE
Sibling link modes

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -68,6 +68,8 @@ namespace Ktisis {
 		public MODE GizmoMode { get; set; } = MODE.LOCAL;
 		public OPERATION GizmoOp { get; set; } = OPERATION.TRANSLATE;
 
+		public Overlay.Skeleton.SiblingLink SiblingLink { get; set; } = Overlay.Skeleton.SiblingLink.None;
+
 		public bool AllowAxisFlip { get; set; } = true;
 
 		// Language

--- a/Ktisis/Interface/Components/ControlButtons.cs
+++ b/Ktisis/Interface/Components/ControlButtons.cs
@@ -1,4 +1,6 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Linq;
+using System.Numerics;
 
 using ImGuiNET;
 using ImGuizmoNET;
@@ -9,6 +11,7 @@ using Dalamud.Game.ClientState.Objects.Types;
 
 using Ktisis.Util;
 using Ktisis.Overlay;
+using static Ktisis.Overlay.Skeleton;
 using Ktisis.Interop.Hooks;
 using Ktisis.Interface.Windows;
 using Ktisis.Interface.Windows.Workspace;
@@ -59,6 +62,9 @@ namespace Ktisis.Interface.Components {
 			if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.MinusCircle, "Deselect gizmo", ButtonSize))
 				OverlayWindow.SetGizmoOwner(null);
 			if (!gizmoActive) ImGui.EndDisabled();
+
+			ImGui.SameLine();
+			DrawSiblingLink();
 		}
 
 		// As the settings button is a bit special and should not be as present as others
@@ -151,5 +157,27 @@ namespace Ktisis.Interface.Components {
 			GuiHelpers.Icon(isGamePlaybackRunning ? FontAwesomeIcon.Play : FontAwesomeIcon.Pause);
 			GuiHelpers.Tooltip(isGamePlaybackRunning ? "Game Animation is playing for this target."+(PoseHooks.PosingEnabled?"\nPosing may reset periodically.":"") : "Game Animation is paused for this target."+(!PoseHooks.PosingEnabled ? "\nAnimation Control Can be used." : ""));
 		}
+
+		private static void DrawSiblingLink() {
+			var siblingLink = Ktisis.Configuration.SiblingLink;
+
+			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (GuiHelpers.IconButton(SiblingLinkToIcon(siblingLink), ButtonSize))
+				Ktisis.Configuration.SiblingLink = siblingLink == Enum.GetValues(typeof(SiblingLink)).Cast<SiblingLink>().Last() ? SiblingLink.None : siblingLink + 1;
+			if (siblingLink != SiblingLink.None) ImGui.PopStyleColor();
+			GuiHelpers.Tooltip(SiblingLinkToTooltip(siblingLink));
+		}
+		private static FontAwesomeIcon SiblingLinkToIcon(SiblingLink siblingLink)
+			=> siblingLink switch {
+				SiblingLink.Rotation => FontAwesomeIcon.Link,
+				SiblingLink.RotationMirrorX => FontAwesomeIcon.Adjust,
+				_ => FontAwesomeIcon.ArrowUp
+			};
+		private static string SiblingLinkToTooltip(SiblingLink siblingLink)
+			=> siblingLink switch {
+				SiblingLink.Rotation => "Link rotation",
+				SiblingLink.RotationMirrorX => "Mirror rotation",
+				_ => "No sibling link"
+			};
 	}
 }

--- a/Ktisis/Interface/Components/ControlButtons.cs
+++ b/Ktisis/Interface/Components/ControlButtons.cs
@@ -163,10 +163,12 @@ namespace Ktisis.Interface.Components {
 
 			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
 			if (GuiHelpers.IconButton(SiblingLinkToIcon(siblingLink), ButtonSize))
-				Ktisis.Configuration.SiblingLink = siblingLink == Enum.GetValues(typeof(SiblingLink)).Cast<SiblingLink>().Last() ? SiblingLink.None : siblingLink + 1;
+				CircleTroughSiblingLinkModes();
 			if (siblingLink != SiblingLink.None) ImGui.PopStyleColor();
 			GuiHelpers.Tooltip(SiblingLinkToTooltip(siblingLink));
 		}
+		public static void CircleTroughSiblingLinkModes() =>
+			Ktisis.Configuration.SiblingLink = Ktisis.Configuration.SiblingLink == Enum.GetValues(typeof(SiblingLink)).Cast<SiblingLink>().Last() ? SiblingLink.None : Ktisis.Configuration.SiblingLink + 1;
 		private static FontAwesomeIcon SiblingLinkToIcon(SiblingLink siblingLink)
 			=> siblingLink switch {
 				SiblingLink.Rotation => FontAwesomeIcon.Link,

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -8,6 +8,7 @@ using Dalamud.Game.ClientState.Keys;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuizmoNET;
 
+using Ktisis.Interface.Components;
 using Ktisis.Overlay;
 
 namespace Ktisis.Interface {
@@ -37,6 +38,8 @@ namespace Ktisis.Interface {
 			}
 			if (IsPurposeChanged(Purpose.HoldToHideSkeleton))
 				Skeleton.Toggle();
+			if (IsPurposeHeld(Purpose.CircleThroughSiblingLinkModes))
+				ControlButtons.CircleTroughSiblingLinkModes();
 
 			PrevriousKeyStates = CurrentKeyStates!;
 			CurrentKeyStates = null;
@@ -51,6 +54,7 @@ namespace Ktisis.Interface {
 			ToggleLocalWorld,
 			HoldToHideSkeleton,
 			SwitchToUniversal,
+			CircleThroughSiblingLinkModes,
 		}
 
 		public static readonly Dictionary<Purpose, List<VirtualKey>> DefaultKeys = new(){
@@ -61,6 +65,7 @@ namespace Ktisis.Interface {
 			{Purpose.ToggleLocalWorld, new(){VirtualKey.X}},
 			{Purpose.HoldToHideSkeleton, new(){VirtualKey.V}},
 			{Purpose.SwitchToUniversal, new(){VirtualKey.U}},
+			{Purpose.CircleThroughSiblingLinkModes, new(){VirtualKey.C}},
 		};
 
 		// Helpers

--- a/Ktisis/Overlay/Skeleton.cs
+++ b/Ktisis/Overlay/Skeleton.cs
@@ -202,12 +202,11 @@ namespace Ktisis.Overlay {
 			matrix *= Matrix4x4.CreateFromQuaternion(deltaRot);
 			matrix.Translation = offset;
 
-			// TODO: parenting
-			//var initialRot = access->Rotation.ToQuat();
-			//var initialPos = access->Translation.ToVector3();
+			var initialRot = access->Rotation.ToQuat();
+			var initialPos = access->Translation.ToVector3();
 			Interop.Alloc.SetMatrix(access, matrix);
 
-			//PropagateChildren(child, access, initialPos, initialRot);
+			PropagateChildren(child, access, initialPos, initialRot);
 		}
 		public unsafe static Bone? GetSelectedBone() {
 			if (!BoneSelect.Active) return null;

--- a/Ktisis/Overlay/Skeleton.cs
+++ b/Ktisis/Overlay/Skeleton.cs
@@ -190,13 +190,13 @@ namespace Ktisis.Overlay {
 			}
 		}
 		private unsafe static void LinkRota (Bone child, Quaternion deltaRot) {
+			if (Ktisis.Configuration.SiblingLink == SiblingLink.None) return;
+
 			var access = child.AccessModelSpace(PropagateOrNot.DontPropagate);
 			var offset = access->Translation.ToVector3();
 
-			// TODO: mirror toggle
-			//var isMirror = false;
-			//if (isMirror)
-			//	deltaRot = new(-deltaRot.X, deltaRot.Y, deltaRot.Z, -deltaRot.W);
+			if(Ktisis.Configuration.SiblingLink == SiblingLink.RotationMirrorX)
+				deltaRot = new(-deltaRot.X, deltaRot.Y, deltaRot.Z, -deltaRot.W);
 
 			var matrix = Interop.Alloc.GetMatrix(access);
 			matrix *= Matrix4x4.CreateFromQuaternion(deltaRot);
@@ -219,6 +219,11 @@ namespace Ktisis.Overlay {
 			if (model == null) return null;
 
 			return model->Skeleton->GetBone(BoneSelect.Partial, BoneSelect.Index);
+		}
+		public enum SiblingLink {
+			None,
+			Rotation,
+			RotationMirrorX,
 		}
 	}
 }

--- a/Ktisis/Structs/Bones/Bone.cs
+++ b/Ktisis/Structs/Bones/Bone.cs
@@ -65,6 +65,27 @@ namespace Ktisis.Structs.Bones {
 			return result;
 		}
 
+		public unsafe Bone? GetMirrorSibling() {
+			var name = HkaBone.Name.String;
+			var prefix = name[..^2];
+
+			for (var p = 0; p < Skeleton->PartialSkeletonCount; p++) {
+				var partial = Skeleton->PartialSkeletons[p];
+				var pose = partial.GetHavokPose(0);
+				if (pose == null) continue;
+
+				var skeleton = pose->Skeleton;
+				for (var i = 1; i < skeleton->Bones.Length; i++) {
+					var potentialBone = Skeleton->GetBone(p, i);
+					if (potentialBone == null) continue;
+					var pBName = potentialBone.HkaBone.Name.String;
+					if (pBName[..^2] == prefix && pBName != name)
+						return potentialBone;
+				}
+			}
+			return null;
+		}
+
 		public List<Bone> GetDescendants() {
 			var list = GetChildren();
 			for (var i = 0; i < list.Count; i++)

--- a/Ktisis/Structs/Bones/Bone.cs
+++ b/Ktisis/Structs/Bones/Bone.cs
@@ -74,9 +74,9 @@ namespace Ktisis.Structs.Bones {
 				var pose = partial.GetHavokPose(0);
 				if (pose == null) continue;
 
-				var skeleton = pose->Skeleton;
-				for (var i = 1; i < skeleton->Bones.Length; i++) {
-					var potentialBone = Skeleton->GetBone(p, i);
+				var poseSkeleton = pose->Skeleton;
+				for (var i = 1; i < poseSkeleton->Bones.Length; i++) {
+					var potentialBone = new Bone(Skeleton, p, i);
 					if (potentialBone == null) continue;
 					var pBName = potentialBone.HkaBone.Name.String;
 					if (pBName[..^2] == prefix && pBName != name)


### PR DESCRIPTION
Implementation of optional parenting mode based on siblings.

E.g. link eye movements, or open both arms mirrored.
A key shortcut allows circling through these modes.

Thanks to L- and Serena for the suggestions.