### PR TITLE
Actor List tweaks

### DIFF
--- a/Ktisis/Interface/Components/ActorsList.cs
+++ b/Ktisis/Interface/Components/ActorsList.cs
@@ -107,6 +107,7 @@ namespace Ktisis.Interface.Components {
 
 			var actor = (Actor*)gameObject;
 			if (actor == null) return false;
+			if (actor->Model == null) return false;
 
 			var objectKind = (ObjectKind)gameObject->ObjectKind;
 			if (!WhitelistObjectKinds.Contains(objectKind))

--- a/Ktisis/Interface/Components/ActorsList.cs
+++ b/Ktisis/Interface/Components/ActorsList.cs
@@ -6,6 +6,8 @@ using System.Numerics;
 using ImGuiNET;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using Dalamud.Interface;
+using DalamudGameObject = Dalamud.Game.ClientState.Objects.Types.GameObject;
+using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
 
 using Ktisis.Structs.Actor;
 using Ktisis.Util;
@@ -14,23 +16,27 @@ namespace Ktisis.Interface.Components {
 	internal static class ActorsList {
 
 		private static List<long> SavedObjects = new(); // TODO: clean the list on gpose leave
-		private static bool IsSelectorListOpened = false;
+		private static List<DalamudGameObject>? SelectorList = null;
 		private static string Search = "";
 		private static readonly HashSet<ObjectKind> WhitelistObjectKinds = new(){
-				ObjectKind.Pc,
+				ObjectKind.Player,
 				ObjectKind.BattleNpc,
 				ObjectKind.EventNpc,
-				ObjectKind.Mount,
+				ObjectKind.MountType,
 				ObjectKind.Companion,
 			};
 
+		// TODO to clear the list on gpose leave
+		public static void Clear() => SavedObjects.Clear();
 		public unsafe static void Draw() {
-			// This cleans up the list a little, while waiting for the TODO to clean it on gpose leave
+			// Prevent displaying the same target multiple time
 			SavedObjects = SavedObjects.Distinct().ToList();
 
 			var currentTarget = Ktisis.Target;
 			if (!SavedObjects.Contains((long)currentTarget)) SavedObjects.Add((long)currentTarget);
 
+			// Remove invalid actors, as SelectorList is only created on the list opening
+			// It can be actors turning invalid
 			SavedObjects.RemoveAll(o => !IsValidActor(o));
 
 			var buttonSize = new Vector2(ImGui.GetContentRegionAvail().X, ControlButtons.ButtonSize.Y);
@@ -38,8 +44,8 @@ namespace Ktisis.Interface.Components {
 				long? toRemove = null;
 				foreach (var pointer in SavedObjects) {
 					if (!IsValidActor(pointer)) continue;
-					if (ImGui.Button($"{((Actor*)pointer)->GetNameOrId()}##ActorList##{pointer}", buttonSize))
-						Services.Targets->GPoseTarget = (GameObject*)pointer; // TODO: check if this is safe for expected actors, and unexpected actors
+					if (ImGui.Button($"{((Actor*)pointer)->GetNameOrId()}{ExtraInfo(pointer)}##ActorList##{pointer}", buttonSize))
+						Services.Targets->GPoseTarget = (GameObject*)pointer;
 					if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
 						toRemove = pointer;
 				}
@@ -58,42 +64,45 @@ namespace Ktisis.Interface.Components {
 					ImGui.Text("Right click to remove an Actor from the list");
 					ImGui.EndTooltip();
 				}
-				if (IsSelectorListOpened)
+				if (SelectorList != null)
 					DrawListAddActor();
 			}
 		}
 
-		public static void OpenSelector() => IsSelectorListOpened = true;
-		public static void CloseSelector() => IsSelectorListOpened = false;
+		public unsafe static void OpenSelector() =>
+			SelectorList = Services.ObjectTable
+
+			// filter unwanted objects
+			.Where(o =>
+				o.IsValid()
+				&& IsValidActor(o)
+				// && !IsPlayerNotGpose(o) // uncomment to prevent selectability of non-gpose players
+				&& !IsGposeSpecialObject(o))
+
+			// group gpose and non-gpose instances of the same player to only get the gpose player object
+			// (TODO: add world id or name, for accuracy)
+			// non-gpose companions don't have a model in gpose, they're filtered by IsValidActor()
+			.GroupBy(o => IsPlayer(o) ? o.Name.TextValue : o.Name.TextValue + "_" + GetGposeId(o))
+			.Select(o => o.OrderBy(t => !IsGposeActor(t)).First())
+
+			// order by closest to the player
+			.OrderBy(a => Distance(a))
+			.ToList();
+
+		public static void CloseSelector() => SelectorList = null;
 
 
 		private unsafe static void DrawListAddActor() {
-			//var sight = Services.Targets->ObjectFilterArray0;
-			var playerMinionFriends = Services.Targets->ObjectFilterArray1;
-			var otherPlayersAndNpc = Services.Targets->ObjectFilterArray2;
-			var playerMinionFriendsAgain = Services.Targets->ObjectFilterArray3;
-
-			List<long> allObjectsAround = new();
-			for (int i = 0; i < playerMinionFriends.Length; i++)
-				allObjectsAround.Add((long)playerMinionFriends[i]);
-			for (int i = 0; i < otherPlayersAndNpc.Length; i++)
-				allObjectsAround.Add((long)otherPlayersAndNpc[i]);
-			for (int i = 0; i < playerMinionFriendsAgain.Length; i++)
-				allObjectsAround.Add((long)playerMinionFriendsAgain[i]);
-
-			var sanitizedObjects = allObjectsAround.Where(IsValidActor).Distinct();
-
 			PopupSelect.HoverPopupWindow(
 				PopupSelect.HoverPopupWindowFlags.SelectorList | PopupSelect.HoverPopupWindowFlags.SearchBar,
-				sanitizedObjects,
-				(e, input) => e.Where(t => ((Actor*)t)->GetNameOrId().Contains(input, StringComparison.OrdinalIgnoreCase)),
-				(i) => { },
+				SelectorList!,
+				(e, input) => e.Where(t => ((Actor*)t.Address)->GetNameOrId().Contains(input, StringComparison.OrdinalIgnoreCase)),
 				(t, a) => { // draw Line
-					bool selected = ImGui.Selectable($"{((Actor*)t)->GetNameOrId()}##{t}", a);
+					bool selected = ImGui.Selectable($"{((Actor*)t.Address)->GetNameOrId()}{ExtraInfo(t)}##{t}", a);
 					bool focus = ImGui.IsItemFocused();
 					return (selected, focus);
 				},
-				(t) => SavedObjects.Add(t), // on Select
+				(t) => SavedObjects.Add((long)t.Address), // on Select
 				CloseSelector, // on close
 				ref Search,
 				"Actor Select",
@@ -101,7 +110,7 @@ namespace Ktisis.Interface.Components {
 				"##actor_search");
 		}
 
-		public static unsafe bool IsValidActor(long target) {
+		public unsafe static bool IsValidActor(long target) {
 			var gameObject = (GameObject*)target;
 			if (gameObject == null) return false;
 
@@ -113,10 +122,38 @@ namespace Ktisis.Interface.Components {
 			if (!WhitelistObjectKinds.Contains(objectKind))
 				return false;
 
-			//PluginLog.Debug($"{((Actor*)target)->GetNameOrId()} Kind:{gameObject->ObjectKind} SubKind:{gameObject->SubKind}");
-			//both ennemies and Striking dummies are 2 5
-
 			return true;
 		}
+		public unsafe static bool IsValidActor(DalamudGameObject gameObject) =>
+			IsValidActor((long)gameObject.Address);
+		private static bool IsNonNetworkObject(DalamudGameObject gameObject) =>
+			gameObject.ObjectId == DalamudGameObject.InvalidGameObjectId;
+		private static string ExtraInfo(DalamudGameObject gameObject) {
+			List<string> info = new();
+			if (IsGposeActor(gameObject)) info.Add("GPose");
+			if (IsPlayer(gameObject)) info.Add("Player");
+			return info.Any() ? $" ({String.Join(", ", info)})" : "";
+		}
+		private static string ExtraInfo(long gameObjectPointer) =>
+			ExtraInfo(Services.ObjectTable.CreateObjectReference((IntPtr)gameObjectPointer)!);
+		private static float Distance(DalamudGameObject gameObject) =>
+			(float)Math.Sqrt(gameObject.YalmDistanceX * gameObject.YalmDistanceX + gameObject.YalmDistanceZ * gameObject.YalmDistanceZ);
+		private static bool IsGposeActor(DalamudGameObject gameObject) {
+			return GetGposeId(gameObject) >= 200;
+		}
+		private static bool IsGposeSpecialObject(DalamudGameObject gameObject) {
+			// this matches the weird object on ObjectID 200
+			return GetGposeId(gameObject) == 200;
+		}
+		private static bool IsPlayer(DalamudGameObject gameObject) {
+			return gameObject.ObjectKind == ObjectKind.Player;
+		}
+		private static bool IsPlayerNotGpose(DalamudGameObject gameObject) {
+			return gameObject.ObjectKind == ObjectKind.Player && GetGposeId(gameObject) < 200;
+		}
+		private unsafe static byte GetGposeId(DalamudGameObject gameObject) {
+			return ((Actor*)gameObject.Address)->ObjectID;
+		}
+
 	}
 }

--- a/Ktisis/Interface/Components/ActorsList.cs
+++ b/Ktisis/Interface/Components/ActorsList.cs
@@ -131,7 +131,8 @@ namespace Ktisis.Interface.Components {
 		private static string ExtraInfo(DalamudGameObject gameObject) {
 			List<string> info = new();
 			if (IsGposeActor(gameObject)) info.Add("GPose");
-			if (IsPlayer(gameObject)) info.Add("Player");
+			if (IsYou(gameObject)) info.Add("You");
+			else if (IsPlayer(gameObject)) info.Add("Player");
 			return info.Any() ? $" ({String.Join(", ", info)})" : "";
 		}
 		private static string ExtraInfo(long gameObjectPointer) =>
@@ -140,6 +141,9 @@ namespace Ktisis.Interface.Components {
 			(float)Math.Sqrt(gameObject.YalmDistanceX * gameObject.YalmDistanceX + gameObject.YalmDistanceZ * gameObject.YalmDistanceZ);
 		private static bool IsGposeActor(DalamudGameObject gameObject) {
 			return GetGposeId(gameObject) >= 200;
+		}
+		private static bool IsYou(DalamudGameObject gameObject) {
+			return GetGposeId(gameObject) == 201;
 		}
 		private static bool IsGposeSpecialObject(DalamudGameObject gameObject) {
 			// this matches the weird object on ObjectID 200

--- a/Ktisis/Interface/Components/ActorsList.cs
+++ b/Ktisis/Interface/Components/ActorsList.cs
@@ -15,7 +15,7 @@ using Ktisis.Util;
 namespace Ktisis.Interface.Components {
 	internal static class ActorsList {
 
-		private static List<long> SavedObjects = new(); // TODO: clean the list on gpose leave
+		private static List<long> SavedObjects = new();
 		private static List<DalamudGameObject>? SelectorList = null;
 		private static string Search = "";
 		private static readonly HashSet<ObjectKind> WhitelistObjectKinds = new(){
@@ -28,6 +28,10 @@ namespace Ktisis.Interface.Components {
 
 		// TODO to clear the list on gpose leave
 		public static void Clear() => SavedObjects.Clear();
+
+
+		// Draw
+
 		public unsafe static void Draw() {
 			// Prevent displaying the same target multiple time
 			SavedObjects = SavedObjects.Distinct().ToList();
@@ -69,9 +73,8 @@ namespace Ktisis.Interface.Components {
 			}
 		}
 
-		public unsafe static void OpenSelector() =>
+		private static void OpenSelector() =>
 			SelectorList = Services.ObjectTable
-
 			// filter unwanted objects
 			.Where(o =>
 				o.IsValid()
@@ -89,8 +92,7 @@ namespace Ktisis.Interface.Components {
 			.OrderBy(a => Distance(a))
 			.ToList();
 
-		public static void CloseSelector() => SelectorList = null;
-
+		private static void CloseSelector() => SelectorList = null;
 
 		private unsafe static void DrawListAddActor() {
 			PopupSelect.HoverPopupWindow(
@@ -110,7 +112,10 @@ namespace Ktisis.Interface.Components {
 				"##actor_search");
 		}
 
-		public unsafe static bool IsValidActor(long target) {
+
+		// Filters
+
+		private unsafe static bool IsValidActor(long target) {
 			var gameObject = (GameObject*)target;
 			if (gameObject == null) return false;
 
@@ -124,40 +129,37 @@ namespace Ktisis.Interface.Components {
 
 			return true;
 		}
-		public unsafe static bool IsValidActor(DalamudGameObject gameObject) =>
+		private static bool IsValidActor(DalamudGameObject gameObject) =>
 			IsValidActor((long)gameObject.Address);
 		private static bool IsNonNetworkObject(DalamudGameObject gameObject) =>
 			gameObject.ObjectId == DalamudGameObject.InvalidGameObjectId;
 		private static string ExtraInfo(DalamudGameObject gameObject) {
 			List<string> info = new();
-			if (IsGposeActor(gameObject)) info.Add("GPose");
-			if (IsYou(gameObject)) info.Add("You");
-			else if (IsPlayer(gameObject)) info.Add("Player");
+			if (IsGposeActor(gameObject))
+				info.Add("GPose");
+			if (IsYou(gameObject))
+				info.Add("You");
+			else if (IsPlayer(gameObject))
+				info.Add("Player");
 			return info.Any() ? $" ({String.Join(", ", info)})" : "";
 		}
 		private static string ExtraInfo(long gameObjectPointer) =>
 			ExtraInfo(Services.ObjectTable.CreateObjectReference((IntPtr)gameObjectPointer)!);
 		private static float Distance(DalamudGameObject gameObject) =>
 			(float)Math.Sqrt(gameObject.YalmDistanceX * gameObject.YalmDistanceX + gameObject.YalmDistanceZ * gameObject.YalmDistanceZ);
-		private static bool IsGposeActor(DalamudGameObject gameObject) {
-			return GetGposeId(gameObject) >= 200;
-		}
-		private static bool IsYou(DalamudGameObject gameObject) {
-			return GetGposeId(gameObject) == 201;
-		}
-		private static bool IsGposeSpecialObject(DalamudGameObject gameObject) {
+		private static bool IsYou(DalamudGameObject gameObject) =>
+			GetGposeId(gameObject) == 201;
+		private static bool IsGposeActor(DalamudGameObject gameObject) =>
+			GetGposeId(gameObject) >= 200;
+		private static bool IsGposeSpecialObject(DalamudGameObject gameObject) =>
 			// this matches the weird object on ObjectID 200
-			return GetGposeId(gameObject) == 200;
-		}
-		private static bool IsPlayer(DalamudGameObject gameObject) {
-			return gameObject.ObjectKind == ObjectKind.Player;
-		}
-		private static bool IsPlayerNotGpose(DalamudGameObject gameObject) {
-			return gameObject.ObjectKind == ObjectKind.Player && GetGposeId(gameObject) < 200;
-		}
-		private unsafe static byte GetGposeId(DalamudGameObject gameObject) {
-			return ((Actor*)gameObject.Address)->ObjectID;
-		}
+			GetGposeId(gameObject) == 200;
+		private static bool IsPlayer(DalamudGameObject gameObject) =>
+			gameObject.ObjectKind == ObjectKind.Player;
+		private static bool IsPlayerNotGpose(DalamudGameObject gameObject) =>
+			gameObject.ObjectKind == ObjectKind.Player && GetGposeId(gameObject) < 200;
+		private unsafe static byte GetGposeId(DalamudGameObject gameObject) =>
+			((Actor*)gameObject.Address)->ObjectID;
 
 	}
 }

--- a/Ktisis/Interface/Components/PopupSelect.cs
+++ b/Ktisis/Interface/Components/PopupSelect.cs
@@ -103,7 +103,7 @@ namespace Ktisis.Interface.Components {
 				ImGui.PushItemWidth(minWidth);
 				if (flags.HasFlag(HoverPopupWindowFlags.SearchBar))
 					HoverPopupWindowSearchBarValidated = ImGui.InputTextWithHint(searchBarLabel, searchBarHint, ref inputSearch, 32, ImGuiInputTextFlags.EnterReturnsTrue);
-
+				ImGui.PopItemWidth();
 				if (ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows) && !ImGui.IsAnyItemActive() && !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
 					ImGui.SetKeyboardFocusHere(flags.HasFlag(HoverPopupWindowFlags.SearchBar) ? -1 : 0); // TODO: verify the keyboarf focus behaviour when searchbar is disabled
 
@@ -175,7 +175,6 @@ namespace Ktisis.Interface.Components {
 				if (flags.HasFlag(HoverPopupWindowFlags.SelectorList))
 					ImGui.EndListBox();
 				HoverPopupWindowFocus |= ImGui.IsItemActive();
-				ImGui.PopItemWidth();
 
 				if ((!flags.HasFlag(HoverPopupWindowFlags.StayWhenLoseFocus) && !HoverPopupWindowFocus) || ImGui.IsKeyPressed(ImGuiKey.Escape)) {
 					onClose();

--- a/Ktisis/Interface/Components/PopupSelect.cs
+++ b/Ktisis/Interface/Components/PopupSelect.cs
@@ -20,7 +20,6 @@ namespace Ktisis.Interface.Components {
 
 		// Properties
 		private static Vector2 HoverPopupWindowSelectPos = Vector2.Zero;
-		private static bool HoverPopupWindowIsBegan = false;
 		private static bool HoverPopupWindowFocus = false;
 		private static bool HoverPopupWindowSearchBarValidated = false;
 		public static int HoverPopupWindowLastSelectedItemKey = 0;
@@ -99,8 +98,7 @@ namespace Ktisis.Interface.Components {
 			if (!flags.HasFlag(HoverPopupWindowFlags.Grabbable))
 				windowFlags |= ImGuiWindowFlags.NoDecoration;
 
-			HoverPopupWindowIsBegan = ImGui.Begin(windowLabel, windowFlags);
-			if (HoverPopupWindowIsBegan) {
+			if (ImGui.Begin(windowLabel, windowFlags)) {
 				HoverPopupWindowFocus = ImGui.IsWindowFocused() || ImGui.IsWindowHovered();
 				ImGui.PushItemWidth(minWidth);
 				if (flags.HasFlag(HoverPopupWindowFlags.SearchBar))

--- a/Ktisis/Structs/Actor/Actor.cs
+++ b/Ktisis/Structs/Actor/Actor.cs
@@ -31,7 +31,7 @@ namespace Ktisis.Structs.Actor {
 
 		public unsafe string? Name => Marshal.PtrToStringAnsi((IntPtr)GameObject.GetName());
 
-		public string GetNameOr(string fallback) => !Ktisis.Configuration.DisplayCharName || Name == null ? fallback : Name;
+		public string GetNameOr(string fallback) => ((ObjectKind)GameObject.ObjectKind == ObjectKind.Pc && !Ktisis.Configuration.DisplayCharName) || string.IsNullOrEmpty(Name)? fallback : Name;
 		public string GetNameOrId() => GetNameOr("Actor #" + ObjectID);
 
 		public unsafe IntPtr GetAddress() {


### PR DESCRIPTION
- Better method to find and filter objects to put in the search list
- Change (Player) for (You) when it's Actor 201
- Put non-player names instead of actors ids when "Hide character name" option is enabled.
- Allow selecting non-networked NPCs (non-targetable even outside of gpose)
- NPC or objects without a name will be displayed as Actor #xxx
- Optimize performances, clean up, comments.