### PR TITLE
Alternate methods to auto open Ktisis

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -18,13 +18,15 @@ using Ktisis.Structs.Bones;
 namespace Ktisis {
 	[Serializable]
 	public class Configuration : IPluginConfiguration {
-		public const int CurVersion = 0;
+		public const int CurVersion = 1;
 		public int Version { get; set; } = CurVersion;
 
 		// Interface
-
+		[Obsolete("Replaced by AutoOpenCtor")]
 		public bool AutoOpen { get; set; } = true;
+		[Obsolete("Replaced by OpenKtisisMethod")]
 		public bool AutoOpenCtor { get; set; } = false;
+		public OpenKtisisMethod OpenKtisisMethod { get; set; } = OpenKtisisMethod.OnEnterGpose;
 
 		public bool DisplayCharName { get; set; } = true;
 		public bool CensorNsfw { get; set; } = true;
@@ -131,8 +133,13 @@ namespace Ktisis {
 
 			PluginLog.Warning($"Updating config to reflect changes between config versions {Version}-{CurVersion}.\nThis is nothing to worry about, but some settings may change or get reset!");
 
-			//switch (Version) {}
+#pragma warning disable CS0612, CS0618
+			// Apply changes from obsolete attributes
 
+			if (Version < 1)
+				if (AutoOpenCtor) OpenKtisisMethod = OpenKtisisMethod.OnPluginLoad;
+
+#pragma warning restore CS0612, CS0618
 			Version = CurVersion;
 		}
 	}
@@ -140,5 +147,11 @@ namespace Ktisis {
 	public class ReferenceInfo {
 		public bool Showing { get; set; }
 		public string? Path { get; set; }
+	}
+	[Serializable]
+	public enum OpenKtisisMethod {
+		Manually,
+		OnPluginLoad,
+		OnEnterGpose,
 	}
 }

--- a/Ktisis/Events/EventManager.cs
+++ b/Ktisis/Events/EventManager.cs
@@ -1,3 +1,5 @@
+using Dalamud.Logging;
+
 using Ktisis.Structs.Actor.State;
 
 namespace Ktisis.Events {
@@ -6,6 +8,7 @@ namespace Ktisis.Events {
 		public static GPoseChange? OnGPoseChange = null;
 
 		public static void FireOnGposeChangeEvent(ActorGposeState state) {
+			PluginLog.Debug($"FireOnGposeChangeEvent {state}");
 			OnGPoseChange?.Invoke(state);
 		}
 	}

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -35,6 +35,7 @@ namespace Ktisis.Interface.Windows {
 		public static void Hide() {
 			Visible = false;
 		}
+		public static void Toggle() => Visible = !Visible;
 
 		// Draw
 

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -81,9 +81,19 @@ namespace Ktisis.Interface.Windows {
 
 			ImGui.Text(Locale.GetString("General"));
 
-			var openCtor = cfg.AutoOpenCtor;
-			if (ImGui.Checkbox(Locale.GetString("Open_plugin_load"), ref openCtor))
-				cfg.AutoOpenCtor = openCtor;
+			ImGui.AlignTextToFramePadding();
+			ImGui.Text(Locale.GetString("Open_plugin_load") + " ");
+			ImGui.SameLine();
+			var selectedOpenKtisisMethod = cfg.OpenKtisisMethod;
+			ImGui.SetNextItemWidth(GuiHelpers.AvailableWidth(0));
+			if (ImGui.BeginCombo("##OpenKtisisMethod", $"{selectedOpenKtisisMethod}")) {
+				foreach (var openKtisisMethod in Enum.GetValues<OpenKtisisMethod>()) {
+					if (ImGui.Selectable($"{openKtisisMethod}", openKtisisMethod == selectedOpenKtisisMethod))
+						cfg.OpenKtisisMethod = openKtisisMethod;
+				}
+				ImGui.SetItemDefaultFocus();
+				ImGui.EndCombo();
+			}
 
 			var displayCharName = !cfg.DisplayCharName;
 			if (ImGui.Checkbox(Locale.GetString("Hide_char_name"), ref displayCharName))

--- a/Ktisis/Interface/Windows/Workspace/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace/Workspace.cs
@@ -28,6 +28,10 @@ namespace Ktisis.Interface.Windows.Workspace {
 		// Toggle visibility
 
 		public static void Show() => Visible = true;
+		public static void OnEnterGposeToggle(Structs.Actor.State.ActorGposeState gposeState) {
+			if (Ktisis.Configuration.OpenKtisisMethod == OpenKtisisMethod.OnEnterGpose)
+				Visible = gposeState == Structs.Actor.State.ActorGposeState.ON;
+		}
 
 		public static float PanelHeight => ImGui.GetTextLineHeight() * 2 + ImGui.GetStyle().ItemSpacing.Y + ImGui.GetStyle().FramePadding.Y;
 

--- a/Ktisis/Ktisis.cs
+++ b/Ktisis/Ktisis.cs
@@ -11,6 +11,7 @@ using Ktisis.Interface.Windows.ActorEdit;
 using Ktisis.Interface.Windows.Workspace;
 using Ktisis.Structs.Actor.State;
 using Ktisis.Structs.Actor;
+using Ktisis.Events;
 
 namespace Ktisis {
 	public sealed class Ktisis : IDalamudPlugin {
@@ -44,6 +45,8 @@ namespace Ktisis {
 			Interop.Hooks.GuiHooks.Init();
 			Interop.Hooks.PoseHooks.Init();
 
+			EventManager.OnGPoseChange += Workspace.OnEnterGposeToggle; // must be placed before ActorStateWatcher.Init()
+
 			Input.Init();
 			ActorStateWatcher.Init();
 
@@ -55,7 +58,7 @@ namespace Ktisis {
 
 			// Overlays & UI
 
-			if (Configuration.AutoOpenCtor)
+			if (Configuration.OpenKtisisMethod == OpenKtisisMethod.OnPluginLoad)
 				Workspace.Show();
 
 			pluginInterface.UiBuilder.DisableGposeUiHide = true;
@@ -77,6 +80,8 @@ namespace Ktisis {
 			Interop.Alloc.Dispose();
 			Input.Instance.Dispose();
 			ActorStateWatcher.Instance.Dispose();
+
+			EventManager.OnGPoseChange -= Workspace.OnEnterGposeToggle;
 
 			GameData.Sheets.Cache.Clear();
 			if (EditEquip.Items != null)

--- a/Ktisis/Ktisis.cs
+++ b/Ktisis/Ktisis.cs
@@ -61,6 +61,7 @@ namespace Ktisis {
 			if (Configuration.OpenKtisisMethod == OpenKtisisMethod.OnPluginLoad)
 				Workspace.Show();
 
+			pluginInterface.UiBuilder.OpenConfigUi += ConfigGui.Toggle;
 			pluginInterface.UiBuilder.DisableGposeUiHide = true;
 			pluginInterface.UiBuilder.Draw += KtisisGui.Draw;
 
@@ -70,6 +71,7 @@ namespace Ktisis {
 		public void Dispose() {
 			Services.CommandManager.RemoveHandler(CommandName);
 			Services.PluginInterface.SavePluginConfig(Configuration);
+			Services.PluginInterface.UiBuilder.OpenConfigUi -= ConfigGui.Toggle;
 
 			Interop.Hooks.ActorHooks.Dispose();
 			Interop.Hooks.ControlHooks.Dispose();

--- a/Ktisis/Locale/i18n/English.json
+++ b/Ktisis/Locale/i18n/English.json
@@ -21,7 +21,7 @@
     "Overlay": "Overlay",
     // ConfigGui.cs
     "Ktisis_settings": "Ktisis Settings",
-    "Open_plugin_load": "Auto open on plugin load",
+    "Open_plugin_load": "Open Ktisis",
     "config.references_tab.title": "References",
     "config.references_tab.explanation": "Overlay reference images onto your game, helping you to get just the right pose.",
     "config.references_tab.image_transparency": "Image transparency",

--- a/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
+++ b/Ktisis/Structs/Actor/State/ActorStateWatcher.cs
@@ -30,6 +30,8 @@ namespace Ktisis.Structs.Actor.State {
 
 		public void Dispose() {
 			Services.Framework.Update -= Monitor;
+			if(Ktisis.IsInGPose)
+				EventManager.FireOnGposeChangeEvent(ActorGposeState.OFF); ;
 		}
 
 		public static void Init() {

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -11,6 +11,8 @@ using Dalamud.Interface.Components;
 
 using FFXIVClientStructs.Havok;
 
+using Ktisis.Interface.Components;
+
 namespace Ktisis.Util
 {
 	internal class GuiHelpers {
@@ -163,6 +165,38 @@ namespace Ktisis.Util
 				+ 0.1f; // extra safety
 		}
 
+
+		public static float AvailableWidthIconButton(FontAwesomeIcon[] iconsAfter) =>
+			AvailableWidthIcon(iconsAfter)
+				- (ImGui.GetStyle().FramePadding.X * 2 * iconsAfter.Length);
+		public static float AvailableWidthIconButton(FontAwesomeIcon iconAfter) =>
+			AvailableWidthIcon(new FontAwesomeIcon[] { iconAfter });
+		public static float AvailableWidthControlButton(int numberOfButtonsAfter = 1) =>
+			ImGui.GetContentRegionAvail().X
+				- (ControlButtons.ButtonSize.X * numberOfButtonsAfter)
+				- (ImGui.GetStyle().ItemSpacing.X * numberOfButtonsAfter);
+		public static float AvailableWidthIcon(FontAwesomeIcon iconAfter) =>
+			AvailableWidthIcon(new FontAwesomeIcon[] { iconAfter });
+		public static float AvailableWidthIcon(FontAwesomeIcon[] iconsAfter) {
+			float iconsWidth = 0f;
+			foreach (var icon in iconsAfter)
+				iconsWidth += CalcIconSize(icon).X;
+			return ImGui.GetContentRegionAvail().X
+				- iconsWidth
+				- (ImGui.GetStyle().ItemSpacing.X * iconsAfter.Length);
+		}
+		public static float AvailableWidthText(string textAfter) =>
+			 ImGui.GetContentRegionAvail().X
+				- ImGui.CalcTextSize(textAfter).X
+				- ImGui.GetStyle().ItemSpacing.X;
+		public static float AvailableWidth(float sizeOfAllItemsAfter) =>
+			ImGui.GetContentRegionAvail().X - sizeOfAllItemsAfter;
+
+
+		public static void IconRight(FontAwesomeIcon icon, bool enabled = true, Vector4? color = null) {
+			ImGui.SetCursorPosX(ImGui.GetCursorPosX() + AvailableWidthIcon(icon));
+			Icon(icon, enabled, color);
+		}
 		public static void TextRight(string text, float offset = 0) {
 			offset = ImGui.GetContentRegionAvail().X - offset - ImGui.CalcTextSize(text).X;
 			ImGui.SetCursorPosX(ImGui.GetCursorPosX() + offset);


### PR DESCRIPTION
Replace the "On plugin load" checkbox by a dropdown select with the choices to open ktisis:

- Manually ( by typing `/ktisis`)
- On Plugin Load
- On Enter Gpose

Additional features:

- Ktisis config can be opened from Dalamud Plugin Manager
- A set of functions in `GuiHelper`  starting with `AvailableWidth` as an attempt to ease the issues when aligning something to the right.

