### PR TITLE
Add a VisibleCheckboxColor method to help make button toggle more visible

### DIFF
--- a/Ktisis/Interface/Components/ControlButtons.cs
+++ b/Ktisis/Interface/Components/ControlButtons.cs
@@ -31,7 +31,7 @@ namespace Ktisis.Interface.Components {
 
 			ImGui.SameLine();
 			var showSkeleton = Ktisis.Configuration.ShowSkeleton;
-			if (showSkeleton) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (showSkeleton) ImGui.PushStyleColor(ImGuiCol.Text,GuiHelpers.VisibleCheckmarkColor());
 			if (GuiHelpers.IconButton(showSkeleton ? FontAwesomeIcon.Eye : FontAwesomeIcon.EyeSlash, ButtonSize))
 				Skeleton.Toggle();
 			if (showSkeleton) ImGui.PopStyleColor();
@@ -106,7 +106,7 @@ namespace Ktisis.Interface.Components {
 
 		public static void ButtonChangeOperation(OPERATION operation, FontAwesomeIcon icon) {
 			var isCurrentOperation = Ktisis.Configuration.GizmoOp.HasFlag(OPERATION.ROTATE_X) ? (Ktisis.Configuration.GizmoOp | OPERATION.ROTATE).HasFlag(operation) : Ktisis.Configuration.GizmoOp.HasFlag(operation);
-			if (isCurrentOperation) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (isCurrentOperation) ImGui.PushStyleColor(ImGuiCol.Text, GuiHelpers.VisibleCheckmarkColor());
 
 			if (GuiHelpers.IconButton(icon, ButtonSize))
 				if (!isCurrentOperation)
@@ -168,7 +168,7 @@ namespace Ktisis.Interface.Components {
 		private static void DrawSiblingLink() {
 			var siblingLink = Ktisis.Configuration.SiblingLink;
 
-			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, GuiHelpers.VisibleCheckmarkColor());
 			if (GuiHelpers.IconButton(SiblingLinkToIcon(siblingLink), ButtonSize))
 				CircleTroughSiblingLinkModes();
 			if (siblingLink != SiblingLink.None) ImGui.PopStyleColor();

--- a/Ktisis/Interface/Components/Toolbar/ToolbarControlButtons.cs
+++ b/Ktisis/Interface/Components/Toolbar/ToolbarControlButtons.cs
@@ -43,7 +43,7 @@ namespace Ktisis.Interface.Components.Toolbar {
 			ImGui.SameLine();
 
 			var showSkeleton = Ktisis.Configuration.ShowSkeleton;
-			if (showSkeleton) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (showSkeleton) ImGui.PushStyleColor(ImGuiCol.Text, GuiHelpers.VisibleCheckmarkColor());
 			if (GuiHelpers.IconButton(showSkeleton ? FontAwesomeIcon.Eye : FontAwesomeIcon.EyeSlash, ButtonSize))
 				Skeleton.Toggle();
 			if (showSkeleton) ImGui.PopStyleColor();
@@ -56,7 +56,7 @@ namespace Ktisis.Interface.Components.Toolbar {
 
 		public static void ButtonChangeOperation(OPERATION operation, FontAwesomeIcon icon) {
 			var isCurrentOperation = Ktisis.Configuration.GizmoOp.HasFlag(OPERATION.ROTATE_X) ? (Ktisis.Configuration.GizmoOp | OPERATION.ROTATE).HasFlag(operation) : Ktisis.Configuration.GizmoOp.HasFlag(operation);
-			if (isCurrentOperation) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (isCurrentOperation) ImGui.PushStyleColor(ImGuiCol.Text, GuiHelpers.VisibleCheckmarkColor());
 
 			if (GuiHelpers.IconButton(icon, ButtonSize))
 				if (!isCurrentOperation)
@@ -98,7 +98,7 @@ namespace Ktisis.Interface.Components.Toolbar {
 		private static void DrawSiblingLink() {
 			var siblingLink = Ktisis.Configuration.SiblingLink;
 
-			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark]);
+			if (siblingLink != SiblingLink.None) ImGui.PushStyleColor(ImGuiCol.Text, GuiHelpers.VisibleCheckmarkColor());
 			if (GuiHelpers.IconButton(SiblingLinkToIcon(siblingLink), ButtonSize))
 				CircleTroughSiblingLinkModes();
 			if (siblingLink != SiblingLink.None) ImGui.PopStyleColor();

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -132,6 +132,15 @@ namespace Ktisis.Util
 			}
 		}
 
+		public static Vector4 VisibleCheckmarkColor() {
+			var currentCol = ImGui.GetStyle().Colors[(int)ImGuiCol.CheckMark];
+			ImGui.ColorConvertRGBtoHSV(currentCol.X, currentCol.Y, currentCol.Z, out var h, out var s, out var v);
+			s = 0.55f;
+			v = Math.Clamp(v * 1.25f, 0.0f, 1.0f);
+			ImGui.ColorConvertHSVtoRGB(h, s, v, out currentCol.X, out currentCol.Y, out currentCol.Z);
+			return currentCol;
+		}
+		
 		// Copy from Dalamud's ToggleButton but with colorizable circle
 		public static bool ToggleButton(string id, ref bool v, Vector4 circleColor) {
 			RangeAccessor<Vector4> colors = ImGui.GetStyle().Colors;


### PR DESCRIPTION
Add a method to get a color that should be visible to show that the button is toggle in almost all themes (And at least the default Dalamud theme)

https://user-images.githubusercontent.com/103204902/205417836-f9180e68-88af-418f-9bf9-e62a3d2bcb88.mp4

