### PR TITLE
Resizable Settings window

### DIFF
--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -24,6 +24,8 @@ namespace Ktisis.Interface.Windows {
 	internal static class ConfigGui {
 		public static bool Visible = false;
 		public static Vector2 ButtonSize = new Vector2(ImGui.GetFontSize() * 1.50f);
+		private static Vector2 WindowSizeMin = new(ImGui.GetFontSize() * 15, ImGui.GetFontSize() * 20);
+		private static Vector2 WindowSizeMax = ImGui.GetIO().DisplaySize * 0.85f;
 
 		// Toggle visibility
 
@@ -44,10 +46,11 @@ namespace Ktisis.Interface.Windows {
 
 			var size = new Vector2(-1, -1);
 			ImGui.SetNextWindowSize(size, ImGuiCond.FirstUseEver);
+			ImGui.SetNextWindowSizeConstraints(WindowSizeMin, WindowSizeMax);
 
 			ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(10, 10));
 
-			if (ImGui.Begin(Locale.GetString("Ktisis_settings"), ref Visible, ImGuiWindowFlags.AlwaysAutoResize)) {
+			if (ImGui.Begin(Locale.GetString("Ktisis_settings"), ref Visible)) {
 				if (ImGui.BeginTabBar(Locale.GetString("Settings"))) {
 					var cfg = Ktisis.Configuration;
 					if (ImGui.BeginTabItem(Locale.GetString("Interface")))


### PR DESCRIPTION
In an attempt to prevent 1) crazy window syndrome, 2) size change in tab browsing

Changes:

- Remove auto-resize flag, the windows is now resizable by the user
- Add size constraints, min size is defined by the font size, max size is based on display size.