### PR TITLE
Make debug solution config actually target debug

### DIFF
--- a/Ktisis.sln
+++ b/Ktisis.sln
@@ -16,8 +16,8 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.ActiveCfg = Release|x64
-		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.Build.0 = Release|x64
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.ActiveCfg = Debug|x64
+		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Debug|x64.Build.0 = Debug|x64
 		{13C812E9-0D42-4B95-8646-40EEBF30636F}.External|x64.ActiveCfg = External|x64
 		{13C812E9-0D42-4B95-8646-40EEBF30636F}.External|x64.Build.0 = External|x64
 		{13C812E9-0D42-4B95-8646-40EEBF30636F}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
I'm assuming this isn't intentional?
Building the debug configuration of the solution actually builds the release config.