### PR TITLE
Input release key fix

### DIFF
--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -112,7 +112,12 @@ namespace Ktisis.Interface {
 			return false;
 		}
 
-		internal static void OnKeyReleased(VirtualKey key) => HandleHeldPurposes(key);
+		internal static void OnKeyReleased(VirtualKey key) {
+			if (!Ktisis.Configuration.EnableKeybinds || IsChatInputActive())
+				return;
+
+			HandleHeldPurposes(key);
+		}
 
 		internal static Purpose? GetPurposeFromInput(VirtualKey input) {
 			foreach (Purpose purpose in Purposes) {


### PR DESCRIPTION
Prevents release key event to have effect when it shouldn't:

- when chat is active
- when EnableKeybinds is false