### PR TITLE
Stretch window potential fix

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -43,6 +43,7 @@ namespace Ktisis
 		public float TransformTableModifierMultCtrl { get; set; } = 0.1f;
 		public float TransformTableModifierMultShift { get; set; } = 10f;
 		public int TransformTableDigitPrecision { get; set; } = 3;
+		public float CustomWidthMarginDebug { get; set; } = 0.5f;
 
 		// Input
 		public bool EnableKeybinds { get; set; } = false;

--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -43,7 +43,7 @@ namespace Ktisis
 		public float TransformTableModifierMultCtrl { get; set; } = 0.1f;
 		public float TransformTableModifierMultShift { get; set; } = 10f;
 		public int TransformTableDigitPrecision { get; set; } = 3;
-		public float CustomWidthMarginDebug { get; set; } = 0.5f;
+		public float CustomWidthMarginDebug { get; set; } = 0.1f;
 
 		// Input
 		public bool EnableKeybinds { get; set; } = false;

--- a/Ktisis/Interface/Components/ActorsList.cs
+++ b/Ktisis/Interface/Components/ActorsList.cs
@@ -43,7 +43,7 @@ namespace Ktisis.Interface.Components {
 			// It can be actors turning invalid
 			SavedObjects.RemoveAll(o => !IsValidActor(o));
 
-			var buttonSize = new Vector2(ImGui.GetContentRegionAvail().X, ControlButtons.ButtonSize.Y);
+			var buttonSize = new Vector2(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin(), ControlButtons.ButtonSize.Y);
 			if (ImGui.CollapsingHeader("Actor List")) {
 				long? toRemove = null;
 				foreach (var pointer in SavedObjects) {
@@ -58,7 +58,7 @@ namespace Ktisis.Interface.Components {
 				if (GuiHelpers.IconButtonTooltip(FontAwesomeIcon.Plus, "Add Actor", ControlButtons.ButtonSize))
 					OpenSelector();
 
-				ImGui.SameLine(ImGui.GetContentRegionAvail().X - (ImGui.GetStyle().ItemSpacing.X) - GuiHelpers.CalcIconSize(FontAwesomeIcon.InfoCircle).X);
+				ImGui.SameLine(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - (ImGui.GetStyle().ItemSpacing.X) - GuiHelpers.CalcIconSize(FontAwesomeIcon.InfoCircle).X);
 				ControlButtons.VerticalAlignTextOnButtonSize();
 
 				// help hover

--- a/Ktisis/Interface/Components/AnimationControls.cs
+++ b/Ktisis/Interface/Components/AnimationControls.cs
@@ -30,7 +30,7 @@ namespace Ktisis.Interface.Components {
 			if (control->hkaAnimationControl.LocalTime >= durationLimit)
 				control->hkaAnimationControl.LocalTime = 0f;
 
-			ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - GuiHelpers.GetRightOffset(ImGui.CalcTextSize("Speed").X));
+			ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - GuiHelpers.GetRightOffset(ImGui.CalcTextSize("Speed").X));
 			ImGui.SliderFloat("Seek", ref control->hkaAnimationControl.LocalTime, 0, durationLimit);
 			ImGui.SliderFloat("Speed", ref control->PlaybackSpeed, 0f, 0.999f);
 			ImGui.PopItemWidth();

--- a/Ktisis/Interface/Components/Categories.cs
+++ b/Ktisis/Interface/Components/Categories.cs
@@ -94,7 +94,7 @@ namespace Ktisis.Interface.Components {
 					foreach (var key in Category.Categories.Keys)
 						cfg.ShowBoneByCategory[key] = false;
 			}
-			ImGui.SameLine(ImGui.GetContentRegionAvail().X - (ImGui.GetStyle().ItemSpacing.X) - GuiHelpers.CalcIconSize(FontAwesomeIcon.InfoCircle).X);
+			ImGui.SameLine(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - (ImGui.GetStyle().ItemSpacing.X) - GuiHelpers.CalcIconSize(FontAwesomeIcon.InfoCircle).X);
 			ControlButtons.VerticalAlignTextOnButtonSize();
 
 			// help hover

--- a/Ktisis/Interface/Components/TransformTable.cs
+++ b/Ktisis/Interface/Components/TransformTable.cs
@@ -78,7 +78,7 @@ namespace Ktisis.Interface.Components {
 			if (ImGui.GetIO().KeyCtrl) multiplier *= ModifierMultCtrl;
 			if (ImGui.GetIO().KeyShift) multiplier *= ModifierMultShift / 10; //divide by 10 cause of the native *10 when holding shift on DragFloat
 
-			var inputsWidth = (ImGui.GetContentRegionAvail().X - ControlButtons.ButtonSize.X - ImGui.GetStyle().ItemSpacing.X * 3.0f) / 3.0f;
+			var inputsWidth = (ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - ControlButtons.ButtonSize.X - ImGui.GetStyle().ItemSpacing.X * 3.0f) / 3.0f;
 			ImGui.PushItemWidth(inputsWidth);
 
 			// Position
@@ -110,7 +110,7 @@ namespace Ktisis.Interface.Components {
 			if (!Ktisis.Configuration.TransformTableDisplayMultiplierInputs)
 				return result;
 			
-			inputsWidth = ImGui.GetContentRegionAvail().X - GuiHelpers.CalcIconSize(FontAwesomeIcon.Running).X - ImGui.GetStyle().ItemSpacing.X;
+			inputsWidth = ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - GuiHelpers.CalcIconSize(FontAwesomeIcon.Running).X - ImGui.GetStyle().ItemSpacing.X;
 			Vector2 mults = new(ModifierMultShift, ModifierMultCtrl);
 			ImGui.PushItemWidth(inputsWidth);
 			if (ImGui.DragFloat2("##SpeedMult##shiftCtrl", ref mults, 1f, 0.00001f, 10000f, null, ImGuiSliderFlags.Logarithmic)) {

--- a/Ktisis/Interface/Windows/ActorEdit/EditCustomize.cs
+++ b/Ktisis/Interface/Windows/ActorEdit/EditCustomize.cs
@@ -398,7 +398,7 @@ namespace Ktisis.Interface.Windows {
 					//focus |= ImGui.IsItemFocused() || ImGui.IsItemActive() || ImGui.IsItemActivated() || ImGui.IsItemHovered();
 
 					var id = (int)value;
-					ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+					ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin());
 					if (ImGui.InputInt("##colId", ref id)) {
 						value = (byte)id;
 						result |= true;

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -157,8 +157,10 @@ namespace Ktisis.Interface.Windows {
 			ImGui.Text(Locale.GetString("UI Customization (Experimental)"));
 
 			var customWidthMarginDebug = cfg.CustomWidthMarginDebug;
-			if (ImGui.DragFloat(Locale.GetString("Custom width margin (debug)"), ref customWidthMarginDebug, 0.05f, -10, 50, "%.2f"))
+			if (ImGui.DragFloat("Right margin (debug)", ref customWidthMarginDebug, 0.05f, -10, 50, "%.2f"))
 				cfg.CustomWidthMarginDebug = customWidthMarginDebug;
+			ImGui.SameLine();
+			ImGuiComponents.HelpMarker(Locale.GetString("Right margin for determining window content size (used for right-aligning and width-filling).\nIncrease this value if the UI stretches to the entire screen.\n\nNote: If this value is changed, reporting these info to Ktisis team would greatly help!\n - The edited Right margin value\n - The Dalamud theme preset in use"));
 
 			ImGui.PopItemWidth();
 

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -151,6 +151,15 @@ namespace Ktisis.Interface.Windows {
 			var showToolbar = cfg.ShowToolbar;
 			if (ImGui.Checkbox("Show Experimental Toolbar", ref showToolbar))
 				cfg.ShowToolbar = showToolbar;
+
+			ImGui.Spacing();
+			ImGui.Separator();
+			ImGui.Text(Locale.GetString("UI Customization (Experimental)"));
+
+			var customWidthMarginDebug = cfg.CustomWidthMarginDebug;
+			if (ImGui.DragFloat(Locale.GetString("Custom width margin (debug)"), ref customWidthMarginDebug))
+				cfg.CustomWidthMarginDebug = customWidthMarginDebug;
+
 			ImGui.PopItemWidth();
 
 			ImGui.EndTabItem();

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -370,7 +370,7 @@ namespace Ktisis.Interface.Windows {
 					// display the current key (config or default)
 					ImGui.TableNextColumn();
 					var configuredKeysPretty = PrettyKeys(configuredKeys);
-					ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetContentRegionAvail().X - ImGui.CalcTextSize(configuredKeysPretty).X) / 2));
+					ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - ImGui.CalcTextSize(configuredKeysPretty).X) / 2));
 					ImGui.Selectable($"{configuredKeysPretty}##{purpose}", false, ImGuiSelectableFlags.SpanAllColumns);
 					clickRow |= ImGui.IsItemClicked(ImGuiMouseButton.Left) || ImGui.IsItemClicked(ImGuiMouseButton.Right);
 

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -157,7 +157,7 @@ namespace Ktisis.Interface.Windows {
 			ImGui.Text(Locale.GetString("UI Customization (Experimental)"));
 
 			var customWidthMarginDebug = cfg.CustomWidthMarginDebug;
-			if (ImGui.DragFloat(Locale.GetString("Custom width margin (debug)"), ref customWidthMarginDebug))
+			if (ImGui.DragFloat(Locale.GetString("Custom width margin (debug)"), ref customWidthMarginDebug, 0.05f, -10, 50, "%.2f"))
 				cfg.CustomWidthMarginDebug = customWidthMarginDebug;
 
 			ImGui.PopItemWidth();

--- a/Ktisis/Interface/Windows/Workspace/EditGaze.cs
+++ b/Ktisis/Interface/Windows/Workspace/EditGaze.cs
@@ -88,7 +88,7 @@ namespace Ktisis.Interface.Windows.Workspace {
 			var hasGizmo = gizmo != null;
 
 			float buttonsWidth = GuiHelpers.CalcIconSize(FontAwesomeIcon.LocationArrow).X + GuiHelpers.CalcIconSize(FontAwesomeIcon.Eye).X + (ImGui.GetStyle().FramePadding.X * 4) + (ImGui.GetStyle().ItemSpacing.X * 2);
-			ImGui.SameLine(ImGui.GetContentRegionAvail().X - buttonsWidth);
+			ImGui.SameLine(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - buttonsWidth);
 
 			if (isTracking) ImGui.BeginDisabled();
 			else if (hasGizmo) ImGui.PushStyleColor(ImGuiCol.Button, UsingColor);
@@ -143,7 +143,7 @@ namespace Ktisis.Interface.Windows.Workspace {
 					gaze.Pos = baseGaze.Pos;
 			}
 
-			ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X);
+			ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin() - ImGui.GetStyle().ItemSpacing.X);
 			result |= ImGui.DragFloat3($"##{type}", ref gaze.Pos, 0.005f);
 			ImGui.PopItemWidth();
 

--- a/Ktisis/Interface/Windows/Workspace/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace/Workspace.cs
@@ -246,7 +246,7 @@ namespace Ktisis.Interface.Windows.Workspace
 			var select = Skeleton.BoneSelect;
 			var bone = Skeleton.GetSelectedBone();
 
-			var frameSize = new Vector2(ImGui.GetContentRegionAvail().X, PanelHeight);
+			var frameSize = new Vector2(ImGui.GetContentRegionAvail().X - GuiHelpers.WidthMargin(), PanelHeight);
 			ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(ImGui.GetStyle().FramePadding.X, ImGui.GetStyle().FramePadding.Y / 2));
 			if (ImGui.BeginChildFrame(8, frameSize, ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar)) {
 				GameAnimationIndicator();

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -165,7 +165,7 @@ namespace Ktisis.Util
 			return calculatedTextSize
 				+ ImGui.GetStyle().ItemSpacing.X
 				//+ ImGui.GetStyle().WindowPadding.X
-				+ 0.1f; // extra safety
+				+ WidthMargin(); // extra safety
 		}
 		public static float WidthMargin() =>
 			Ktisis.Configuration.CustomWidthMarginDebug;
@@ -187,11 +187,13 @@ namespace Ktisis.Util
 			foreach (var icon in iconsAfter)
 				iconsWidth += CalcIconSize(icon).X;
 			return ImGui.GetContentRegionAvail().X
+				- WidthMargin()
 				- iconsWidth
 				- (ImGui.GetStyle().ItemSpacing.X * iconsAfter.Length);
 		}
 		public static float AvailableWidthText(string textAfter) =>
 			 ImGui.GetContentRegionAvail().X
+				- WidthMargin()
 				- ImGui.CalcTextSize(textAfter).X
 				- ImGui.GetStyle().ItemSpacing.X;
 		public static float AvailableWidth(float sizeOfAllItemsAfter) =>
@@ -203,6 +205,7 @@ namespace Ktisis.Util
 			Icon(icon, enabled, color);
 		}
 		public static void TextRight(string text, float offset = 0) {
+			// Careful: use of ImGui.GetContentRegionAvail().X without - WidthMargin()
 			offset = ImGui.GetContentRegionAvail().X - offset - ImGui.CalcTextSize(text).X;
 			ImGui.SetCursorPosX(ImGui.GetCursorPosX() + offset);
 			ImGui.TextUnformatted(text);

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -167,6 +167,8 @@ namespace Ktisis.Util
 				//+ ImGui.GetStyle().WindowPadding.X
 				+ 0.1f; // extra safety
 		}
+		public static float WidthMargin() =>
+			Ktisis.Configuration.CustomWidthMarginDebug;
 
 
 		public static float AvailableWidthIconButton(FontAwesomeIcon[] iconsAfter) =>


### PR DESCRIPTION
This adds a margin offset to every occurrences of right align or width filling items.

The margin is configurable in experimental config.
Default value is `0.1`, it may be enough to fix the issue for some users.

The config tooltip info text:
> Right margin for determining window content size (used for right-aligning and width-filling).
> Increase this value if the UI stretches to the entire screen.
> Note: If this value is changed, reporting these info to Ktisis team would greatly help!
>  - The edited Right margin value
>  - The Dalamud theme preset in use
