### PR TITLE
Add `GuiHelpers.FormattedString` (no visual changes) + example

### DIFF
--- a/Ktisis/Interface/Windows/Workspace/Workspace.cs
+++ b/Ktisis/Interface/Windows/Workspace/Workspace.cs
@@ -190,11 +190,12 @@ namespace Ktisis.Interface.Windows.Workspace
 
 				if (!Categories.DrawToggleList(cfg)) {
 					ImGui.Text("No bone found.");
-					ImGui.Text("Show Skeleton (");
-					ImGui.SameLine();
-					GuiHelpers.Icon(FontAwesomeIcon.EyeSlash);
-					ImGui.SameLine();
-					ImGui.Text(") to fill this.");
+					//ImGui.Text("Show Skeleton (");
+					//ImGui.SameLine();
+					//GuiHelpers.Icon(FontAwesomeIcon.EyeSlash);
+					//ImGui.SameLine();
+					//ImGui.Text(") to fill this.");
+					GuiHelpers.FormattedString($"Show Skeleton ({FontAwesomeIcon.EyeSlash}) to fill this.");
 				}
 			}
 

--- a/Ktisis/Util/GuiHelpers.cs
+++ b/Ktisis/Util/GuiHelpers.cs
@@ -6,6 +6,7 @@ using ImGuiNET;
 using Dalamud.Interface;
 
 using Ktisis.Interface.Components;
+using System.Text.RegularExpressions;
 
 namespace Ktisis.Util
 {
@@ -236,6 +237,25 @@ namespace Ktisis.Util
 			if (contrastRatio < 1.0f)
 				return 1.0f / contrastRatio;
 			return contrastRatio;
+		}
+
+		public static void FormattedString(FormattableString @string)
+        {
+			var args = @string.GetArguments();
+			var format = Regex.Split(@string.Format, "{\\d}");
+
+            for (int i = 0; i < args.Length; i++)
+			{
+				ImGui.Text(format[i]);
+				ImGui.SameLine();
+				var arg = args[0];
+				if (arg is FontAwesomeIcon) Icon((FontAwesomeIcon)arg);
+				if (arg is string) ImGui.Text((string)arg);
+				ImGui.SameLine();
+			}
+
+			if (format.Length > 1)
+                ImGui.Text(format[^1]);
 		}
 	}
 }


### PR DESCRIPTION
* Currently only supports `string` and `FontAwesomeIcon`.
* Further support towards Input handling is unlikely.

> **Note**
> I do not expect this to be merged, given the overhead needed to ensure it runs correctly on each type it would handle. However, if it does get to that stage, considerations to support other native types would be on the table.

[C# Reference](https://learn.microsoft.com/en-us/dotnet/api/system.formattablestring?view=net-6.0)