### PR TITLE
CI: Setup build tests + auto release CI

### DIFF
--- a/.github/release-notices.md
+++ b/.github/release-notices.md
@@ -1,0 +1,2 @@
+**Don't install Ktisis by downloading this manually!**
+See the README for instructions on plugin installation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Add a concurrency group incase a tag is created, deleted, and then recreated while a release is in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Only run this workflow when a tag is pushed when the tag starts with "v".
+on:
+  push:
+    tags:
+      - 'v*'
+
+# So we can use the GitHub API to create releases with the run token.
+permissions:
+  contents: write
+
+jobs:
+  Release:
+    if: github.event.pull_request.draft == false # Ignore draft PRs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Ktisis/
+        shell: bash
+    env:
+      DALAMUD_HOME: /tmp/dalamud
+      IsCI: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true # Grab any submodules that may be required
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Download Dalamud Library
+        run: |
+          wget https://goatcorp.github.io/dalamud-distrib/latest.zip -O /tmp/dalamud.zip
+          unzip /tmp/dalamud.zip -d /tmp/dalamud
+
+      - name: Restore Dependencies
+        run: dotnet restore
+
+      - name: Build plugin in release mode
+        run: dotnet build -c Release --no-restore --nologo -o ./bin/Release
+
+      - name: Generate Checksums
+        working-directory: Ktisis/bin/Release/Ktisis
+        run: |
+          sha512sum latest.zip >> checksums.sha512
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Ktisis/bin/Release/Ktisis/latest.zip
+            Ktisis/bin/Release/Ktisis/checksums.sha512
+          prerelease: false # Releases cant be marked as prereleases as Dalamud wont be able to find them
+          append_body: true # Append the release notes to the release body
+          body_path: .github/release-notices.md # These notes are automatically added to the release body every time.
+          generate_release_notes: true # Automatically makes a release body from PRs since the last release.
+          fail_on_unmatched_files: true # If the files arent found, fail the workflow and abort the release.
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Release Artifacts
+          path: |
+            Ktisis/bin/Release/Ktisis/latest.zip
+            Ktisis/bin/Release/Ktisis/checksums.sha512
+
+      - name: Update repo.json
+        run: |
+          cd ../
+
+          export TAG_NAME=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          export REPO_LOCATION=$(echo ${{ github.server_url }}/${{ github.repository }} | sed  's/\//\\\//g')
+
+          sed -i "s/\"AssemblyVersion\": \"[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\"/\"AssemblyVersion\": \"${TAG_NAME}\"/g" repo.json
+          sed -i "s/\"TestingAssemblyVersion\": \"[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\"/\"TestingAssemblyVersion\": \"${TAG_NAME}\"/g" repo.json
+          sed -i "s/\"DownloadLinkInstall\": \"[^\"]*\"/\"DownloadLinkInstall\": \"$REPO_LOCATION\/releases\/download\/${{ github.ref_name }}\/latest.zip\"/g" repo.json
+          sed -i "s/\"DownloadLinkTesting\": \"[^\"]*\"/\"DownloadLinkTesting\": \"$REPO_LOCATION\/releases\/download\/${{ github.ref_name }}\/latest.zip\"/g" repo.json
+          sed -i "s/\"DownloadLinkUpdate\": \"[^\"]*\"/\"DownloadLinkUpdate\": \"$REPO_LOCATION\/releases\/download\/${{ github.ref_name }}\/latest.zip\"/g" repo.json
+
+          git add repo.json
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update repo.json for ${{ github.ref_name }}"
+          
+          git push origin HEAD:main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+# If another commit is made to the same pull request, the previous workflow run is cancelled to save resources.
+concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
+
+# Only run CI against the main branch or on PRs to the main branch.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [ready_for_review, opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  Build:
+    if: github.event.pull_request.draft == false # Ignore draft PRs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Ktisis/
+        shell: bash
+    strategy:
+      matrix:
+        dotnet-version: [7.0.x] # Can add multiple .NET versions here to test against (For example, testing a new version of .NET before it's released)
+        dalamud-version: ["latest"] # Can add multiple Dalamud branches here to test against (For example, testing against Dalamud staging)
+    env:
+      DALAMUD_HOME: /tmp/dalamud
+      IsCI: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # We don't need the history for testing builds, so we can save some time by not fetching it
+          submodules: true # Grab any submodules that may be required
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Download Dalamud Library
+        run: |
+          wget https://goatcorp.github.io/dalamud-distrib/${{ matrix.dalamud-version }}.zip -O /tmp/dalamud.zip
+          unzip /tmp/dalamud.zip -d /tmp/dalamud
+
+      - name: Restore Dependencies
+        run: dotnet restore
+
+      - name: Build plugin in debug mode
+        run: dotnet build -c Debug --no-restore --nologo
+
+      - name: Build plugin in release mode
+        run: dotnet build -c Release --no-restore --nologo
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Build Artifacts
+          path: Ktisis/bin/

--- a/Ktisis/Ktisis.csproj
+++ b/Ktisis/Ktisis.csproj
@@ -24,6 +24,10 @@
   <PropertyGroup>
     <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT' OR '$(CI)' == 'true'">
+    <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration) == 'External'">
     <TargetFramework>net7.0</TargetFramework>


### PR DESCRIPTION
Discussed this PR with @chirpxiv before moving forward. This PR aims to streamline the PR testing & release process for Ktisis with the help of GitHub Actions.

An example release using this CI can be found here:
https://github.com/BitsOfAByte/container-testing-ci/releases/tag/v0.7.2.3

An example build run can be found here:
https://github.com/BitsOfAByte/container-testing-ci/actions/runs/3920817168/jobs/6702655988

An example repo.json update can be found here (it uses the current repo, ignore the url change)
https://github.com/BitsOfAByte/container-testing-ci/commit/9c868eb7bb6f7c21a54f9aed9dbf387742e18451