### PR TITLE
New camera controls & Updates to freecam controls

### DIFF
--- a/Ktisis/Camera/CameraService.cs
+++ b/Ktisis/Camera/CameraService.cs
@@ -164,6 +164,21 @@ namespace Ktisis.Camera {
 			CameraHooks.Init();
 			EventManager.OnGPoseChange += OnGPoseChange;
 		}
+		
+		internal static void ChangeCameraIndex(int offset) {
+			var camera = GetActiveCamera();
+			if (camera == null) 
+				return;
+				
+			if (GetFreecam() == camera)
+				return;
+
+			var newIndex = (Cameras.FindIndex(tofind => tofind == camera) + offset) % Cameras.Count;
+			if (newIndex < 0) // loop back to start.
+				newIndex = Cameras.Count - 1; 
+				
+			SetOverride(Cameras[newIndex]);
+		}
 
 		internal static void Dispose() {
 			EventManager.OnGPoseChange -= OnGPoseChange;

--- a/Ktisis/Camera/WorkCamera.cs
+++ b/Ktisis/Camera/WorkCamera.cs
@@ -5,6 +5,7 @@ using GameCamera = FFXIVClientStructs.FFXIV.Client.Game.Camera;
 using SceneCamera = FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Camera;
 
 using Ktisis.Helpers;
+using Ktisis.Interface;
 using Ktisis.Structs.Input;
 
 namespace Ktisis.Camera {
@@ -60,7 +61,7 @@ namespace Ktisis.Camera {
 			}
 
 			MoveSpeed = DefaultSpeed;
-			if (keyState != null) {
+			if (keyState != null && !Input.IsChatInputActive()) {
 				if (Ktisis.Configuration.FreecamFast.IsActive(keyState))
 					MoveSpeed *= Ktisis.Configuration.FreecamShiftMuli;
 				else if (Ktisis.Configuration.FreecamSlow.IsActive(keyState))

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -9,6 +9,7 @@ using Dalamud.Game.ClientState.Keys;
 
 using FFXIVClientStructs.FFXIV.Client.UI;
 
+using Ktisis.Camera;
 using Ktisis.Events;
 using Ktisis.Overlay;
 using Ktisis.Interop.Hooks;
@@ -41,6 +42,19 @@ namespace Ktisis.Interface {
 				case Purpose.HoldToHideSkeleton:
 					Skeleton.Toggle();
 					return true;
+				case Purpose.NextCamera:
+					CameraService.ChangeCameraIndex(1);
+					break;
+				case Purpose.PreviousCamera:
+					CameraService.ChangeCameraIndex(-1);
+					break;
+				case Purpose.ToggleFreeCam:
+					CameraService.ToggleFreecam();
+					break;
+				case Purpose.NewCamera:
+					var camera = CameraService.SpawnCamera();
+					CameraService.SetOverride(camera);
+					break;
 			}
 
 			return false;
@@ -156,6 +170,10 @@ namespace Ktisis.Interface {
 			DeselectGizmo,
 			BoneSelectionUp,
 			BoneSelectionDown,
+			NextCamera,
+			PreviousCamera,
+			ToggleFreeCam,
+			NewCamera,
 		}
 
 		public static readonly Dictionary<Purpose, List<VirtualKey>> DefaultKeys = new(){
@@ -172,6 +190,8 @@ namespace Ktisis.Interface {
 			{Purpose.DeselectGizmo, new(){VirtualKey.ESCAPE}},
 			{Purpose.BoneSelectionUp, new(){VirtualKey.UP}},
 			{Purpose.BoneSelectionDown, new(){VirtualKey.DOWN}},
+			{Purpose.NextCamera, new(){VirtualKey.OEM_6}},
+			{Purpose.PreviousCamera, new(){VirtualKey.OEM_4}},
 		};
 
 		// Init & dispose

--- a/Ktisis/Interface/Input.cs
+++ b/Ktisis/Interface/Input.cs
@@ -277,6 +277,6 @@ namespace Ktisis.Interface {
 				return (purpose: p, state);
 			}).ToDictionary(kp => kp.purpose, kp => kp.state);
 		}
-		private unsafe static bool IsChatInputActive() => ((UIModule*)Services.GameGui.GetUIModule())->GetRaptureAtkModule()->AtkModule.IsTextInputActive();
+		internal unsafe static bool IsChatInputActive() => ((UIModule*)Services.GameGui.GetUIModule())->GetRaptureAtkModule()->AtkModule.IsTextInputActive();
 	}
 }

--- a/Ktisis/Locale/i18n/English.json
+++ b/Ktisis/Locale/i18n/English.json
@@ -82,6 +82,10 @@
     "Keyboard_Action_ClearCategoryVisibilityOverload": "Clear category visibility overload",
     "Keyboard_Action_HoldAllCategoryVisibilityOverload": "Hold all category visibility overload",
     "Keyboard_Action_CircleThroughSiblingLinkModes": "Circle through sibling link modes",
+    "Keyboard_Action_NextCamera": "Next camera",
+    "Keyboard_Action_PreviousCamera": "Previous camera",
+    "Keyboard_Action_ToggleFreeCam": "Toggle free cam",
+    "Keyboard_Action_NewCamera": "New camera",
 
     //// Game Jargon ////
 


### PR DESCRIPTION
This adds a few new controls to the system allowing for key binding for the following actions:
1. New Camera
2. Next Camera
3. Previous Camera
4. Toggle Free camera

This also adds a small addition to when chat input is focused, do not move the free camera