### PR TITLE
Set DelimitCamera to match Anamesis logic

### DIFF
--- a/Ktisis/Camera/CameraService.cs
+++ b/Ktisis/Camera/CameraService.cs
@@ -182,6 +182,9 @@ namespace Ktisis.Camera {
 				var active = (GPoseCamera*)Services.Camera->GetActiveCamera();
 				if (active != null) {
 					active->DistanceMax = 20;
+					active->DistanceMin = 1.5f;
+					active->YMax = -1.5f;
+					active->YMin = 1.5f;
 					active->Distance = Math.Clamp(active->Distance, 0, 20);
 				}
 			}

--- a/Ktisis/Interface/Windows/Workspace/Tabs/CameraTab.cs
+++ b/Ktisis/Interface/Windows/Workspace/Tabs/CameraTab.cs
@@ -318,7 +318,10 @@ namespace Ktisis.Interface.Windows.Workspace.Tabs {
 			if (ImGui.Checkbox("Delimit camera", ref delimit)) {
 				var max = delimit ? 350 : 20;
 				gposeCam->DistanceMax = max;
+				gposeCam->DistanceMin = delimit ? 0 : 1.5f;
 				gposeCam->Distance = Math.Clamp(gposeCam->Distance, 0, max);
+				gposeCam->YMin = delimit ? 1.5f : 1.25f;
+				gposeCam->YMax = delimit ? -1.5f : -1.4f;
 			}
 
 			ImGui.SameLine();

--- a/Ktisis/Structs/FFXIV/GPoseCamera.cs
+++ b/Ktisis/Structs/FFXIV/GPoseCamera.cs
@@ -9,12 +9,15 @@ namespace Ktisis.Structs.FFXIV {
 		[FieldOffset(0x60)] public Vector3 Position;
 
 		[FieldOffset(0x114)] public float Distance;
+		[FieldOffset(0x118)] public float DistanceMin;
 		[FieldOffset(0x11C)] public float DistanceMax;
 		[FieldOffset(0x12C)] public float FoV;
 		[FieldOffset(0x130)] public Vector2 Angle;
 		[FieldOffset(0x150)] public Vector2 Pan;
 		[FieldOffset(0x160)] public float Rotation;
 		[FieldOffset(0x208)] public Vector2 DistanceCollide;
+		[FieldOffset(0x14C)] public float YMin;
+		[FieldOffset(0x148)] public float YMax;
 
 		public Vector3 CalcRotation() => new(Angle.X - Pan.X, -Angle.Y - Pan.Y, Rotation);
 	}


### PR DESCRIPTION
This changes delimit camera to do the following when enabled:
 - set CameraMin to 0 like anamesis
 - Set YMin accordingly 
 - Set YMax accordingly