### PR TITLE
Add ability to load .cmp files

### DIFF
--- a/Ktisis/Data/Serialization/Converters/LegacyPoseConverter.cs
+++ b/Ktisis/Data/Serialization/Converters/LegacyPoseConverter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+
+using Ktisis.Data.Files;
+
+namespace Ktisis.Data.Serialization.Converters {
+	public static class LegacyPoseConverter {
+		public static string ConvertLegacyPose(string file)
+		{
+			var  result = "{\n";
+			result += "\t\"FileExtension\": \".pose\",\n";
+			result += "\t\"TypeName\": \"Anamnesis Pose\",\n";
+			result += "\t\"Position\": \"0, 0, 0\",\n";
+			result += "\t\"Rotation\": \"0, 0, 0, 1\",\n";
+			result += "\t\"Scale\": \"1, 1, 1\",\n";
+			result += "\t\"Bones\": {\n";
+			
+			var lines = file.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.TrimEntries);
+			
+			for (var i = 7; i < lines.Length - 1; i++)
+			{
+				result += ConvertLegacyBone(lines[i]);
+			}
+			
+			// Length - 2 removes the trailing comma and, incorrectly, an extra curly bracket. Length - 1 doesn't remove the comma at all. Beats me.
+			result = result.Substring(0, result.Length - 2);
+			result += "}\n\t}";
+			return result;
+		}
+
+		private static string? ConvertLegacyBone(string bone)
+		{
+			var boneString = "";
+			var boneName = bone.Split(new char[] {':'}, 2)[0].Replace("\"", "");
+			var boneRotation = bone.Split(new char[] {':'}, 2)[1].Replace("\"", "").Replace(",", "").Replace(" ", "");
+			
+			if (!PoseFile.LegacyConversions.ContainsKey(boneName) || boneRotation.Contains("null")) return null;
+			
+			var boneRotationValues = new float[4];
+			for (var i = 0; i < 4; i++)
+			{
+				var axisValue = Convert.ToInt32(boneRotation.Substring(i * 8, 8), 16);
+				boneRotationValues[i] = BitConverter.ToSingle(BitConverter.GetBytes(axisValue).Reverse().ToArray(), 0);
+			}
+			
+			boneString += "\t\t\"" + boneName + "\": {\n";
+			boneString += "\t\t\t\"Position\": \"0, 0, 0\",\n";
+			boneString += "\t\t\t\"Rotation\": \"" + boneRotationValues[0] + ", " + boneRotationValues[1] + ", " + boneRotationValues[2] + ", " + boneRotationValues[3] + "\",\n";
+			boneString += "\t\t\t\"Scale\": \"1, 1, 1\"\n";
+			boneString += "\t\t},\n";
+			return boneString;
+		}
+	}
+}

--- a/Ktisis/Helpers/LegacyPoseHelpers.cs
+++ b/Ktisis/Helpers/LegacyPoseHelpers.cs
@@ -3,8 +3,8 @@ using System.Linq;
 
 using Ktisis.Data.Files;
 
-namespace Ktisis.Data.Serialization.Converters {
-	public static class LegacyPoseConverter {
+namespace Ktisis.Helpers {
+	public static class LegacyPoseHelpers {
 		public static string ConvertLegacyPose(string file)
 		{
 			var  result = "{\n";

--- a/Ktisis/Helpers/LegacyPoseHelpers.cs
+++ b/Ktisis/Helpers/LegacyPoseHelpers.cs
@@ -5,8 +5,7 @@ using Ktisis.Data.Files;
 
 namespace Ktisis.Helpers {
 	public static class LegacyPoseHelpers {
-		public static string ConvertLegacyPose(string file)
-		{
+		public static string ConvertLegacyPose(string file) {
 			var  result = "{\n";
 			result += "\t\"FileExtension\": \".pose\",\n";
 			result += "\t\"TypeName\": \"Anamnesis Pose\",\n";
@@ -17,8 +16,7 @@ namespace Ktisis.Helpers {
 			
 			var lines = file.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.TrimEntries);
 			
-			for (var i = 7; i < lines.Length - 1; i++)
-			{
+			for (var i = 7; i < lines.Length - 1; i++) {
 				result += ConvertLegacyBone(lines[i]);
 			}
 			
@@ -28,8 +26,7 @@ namespace Ktisis.Helpers {
 			return result;
 		}
 
-		private static string? ConvertLegacyBone(string bone)
-		{
+		private static string? ConvertLegacyBone(string bone) {
 			var boneString = "";
 			var boneName = bone.Split(new char[] {':'}, 2)[0].Replace("\"", "");
 			var boneRotation = bone.Split(new char[] {':'}, 2)[1].Replace("\"", "").Replace(",", "").Replace(" ", "");
@@ -37,8 +34,7 @@ namespace Ktisis.Helpers {
 			if (!PoseFile.LegacyConversions.ContainsKey(boneName) || boneRotation.Contains("null")) return null;
 			
 			var boneRotationValues = new float[4];
-			for (var i = 0; i < 4; i++)
-			{
+			for (var i = 0; i < 4; i++) {
 				var axisValue = Convert.ToInt32(boneRotation.Substring(i * 8, 8), 16);
 				boneRotationValues[i] = BitConverter.ToSingle(BitConverter.GetBytes(axisValue).Reverse().ToArray(), 0);
 			}

--- a/Ktisis/Helpers/PoseHelpers.cs
+++ b/Ktisis/Helpers/PoseHelpers.cs
@@ -54,7 +54,7 @@ namespace Ktisis.Helpers {
 
 		public unsafe static void ImportPose(Actor* actor, List<string> path, PoseMode modes) {
 			var content = File.ReadAllText(path[0]);
-			if (path[0].Contains(".cmp")) content = LegacyPoseHelpers.ConvertLegacyPose(content);
+			if (Path.GetExtension(path[0]).Equals(".cmp")) content = LegacyPoseHelpers.ConvertLegacyPose(content);
 			var pose = JsonParser.Deserialize<PoseFile>(content);
 			if (pose == null) return;
 

--- a/Ktisis/Helpers/PoseHelpers.cs
+++ b/Ktisis/Helpers/PoseHelpers.cs
@@ -54,7 +54,7 @@ namespace Ktisis.Helpers {
 
 		public unsafe static void ImportPose(Actor* actor, List<string> path, PoseMode modes) {
 			var content = File.ReadAllText(path[0]);
-			if (path[0].Contains(".cmp")) content = LegacyPoseConverter.ConvertLegacyPose(content);
+			if (path[0].Contains(".cmp")) content = LegacyPoseHelpers.ConvertLegacyPose(content);
 			var pose = JsonParser.Deserialize<PoseFile>(content);
 			if (pose == null) return;
 

--- a/Ktisis/Helpers/PoseHelpers.cs
+++ b/Ktisis/Helpers/PoseHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Ktisis.Data.Files;
 using Ktisis.Data.Serialization;
+using Ktisis.Data.Serialization.Converters;
 using Ktisis.Structs.Actor;
 using Ktisis.Structs.Poses;
 using Ktisis.Interop.Hooks;
@@ -53,6 +54,7 @@ namespace Ktisis.Helpers {
 
 		public unsafe static void ImportPose(Actor* actor, List<string> path, PoseMode modes) {
 			var content = File.ReadAllText(path[0]);
+			if (path[0].Contains(".cmp")) content = LegacyPoseConverter.ConvertLegacyPose(content);
 			var pose = JsonParser.Deserialize<PoseFile>(content);
 			if (pose == null) return;
 

--- a/Ktisis/Interface/Windows/Workspace/Tabs/PoseTab.cs
+++ b/Ktisis/Interface/Windows/Workspace/Tabs/PoseTab.cs
@@ -172,7 +172,7 @@ namespace Ktisis.Interface.Windows.Workspace.Tabs {
 			if (ImGui.Button("Import##ImportExportPose")) {
 				KtisisGui.FileDialogManager.OpenFileDialog(
 					"Importing Pose",
-					"Pose Files (.pose){.pose}",
+					"Pose Files{.pose,.cmp}",
 					(success, path) => {
 						if (!success) return;
 


### PR DESCRIPTION
This adds the ability to load older poses in .cmp format by converting them to .pose format after the pose file string is loaded on import but before JSON deserialization. Bone names are not converted during this step as the existing legacy bone name conversion will handle it.