### PR TITLE
Autosave folder customization

### DIFF
--- a/Ktisis/Configuration.cs
+++ b/Ktisis/Configuration.cs
@@ -71,6 +71,7 @@ namespace Ktisis
 		public int AutoSaveInterval { get; set; } = 60;
 		public int AutoSaveCount { get; set; } = 5;
 		public string AutoSavePath { get; set; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Ktisis", "PoseAutoBackup");
+		public string AutoSaveFormat { get; set; } = "AutoSave - %Date% %Time%";
 		public bool ClearAutoSavesOnExit { get; set; } = false;
 
 		// References

--- a/Ktisis/Helpers/PathHelper.cs
+++ b/Ktisis/Helpers/PathHelper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Lumina.Excel.GeneratedSheets;
+
+
+namespace Ktisis.Helpers
+{
+	public static class PathHelper {
+		
+		internal static readonly Dictionary<string, Func<string>> Replacers = new() {
+			{"%Date%", () => DateTime.Now.ToString("yyyy-MM-dd")},
+			{"%Year%", () => DateTime.Now.ToString("yyyy")},
+			{"%Month%", () => DateTime.Now.ToString("MM")},
+			{"%Day%", () => DateTime.Now.ToString("dd")},
+			{"%Time%", () => DateTime.Now.ToString("hh-mm-ss")},
+			{"%PlayerName%", () => {
+				if (Ktisis.Configuration.DisplayCharName)
+					return Services.ClientState.LocalPlayer?.Name.ToString() ?? "Unknown";
+
+				return "Player";
+			}},
+			{"%CurrentWorld%", () => Services.ClientState.LocalPlayer?.CurrentWorld.GameData?.Name.ToString() ?? "Unknown"},
+			{"%HomeWorld%", () => Services.ClientState.LocalPlayer?.HomeWorld.GameData?.Name.ToString() ?? "Unknown" },
+			{"%Zone%", () => Services.DataManager.GetExcelSheet<TerritoryType>()?.GetRow(Services.ClientState.TerritoryType)?.PlaceName.Value?.Name.ToString() ?? "Unknown"},
+		};
+		
+		internal static string Replace(string path) {
+			if (string.IsNullOrEmpty(path)) return path;
+			if (!path.Contains('%')) return path;
+			
+			foreach ((var key, var value) in Replacers) {
+				path = path.Replace(key, value());
+			}
+
+			return path;
+		}
+	}
+}

--- a/Ktisis/Interface/Windows/ConfigGui.cs
+++ b/Ktisis/Interface/Windows/ConfigGui.cs
@@ -13,6 +13,7 @@ using Dalamud.Interface;
 using Dalamud.Interface.Components;
 using Dalamud.Game.ClientState.Keys;
 
+using Ktisis.Helpers;
 using Ktisis.Util;
 using Ktisis.Overlay;
 using Ktisis.Localization;
@@ -300,6 +301,31 @@ namespace Ktisis.Interface.Windows {
 			var autoSavePath = cfg.AutoSavePath;
 			if (ImGui.InputText(Locale.GetString("Auto_save_path"), ref autoSavePath, 256))
 				cfg.AutoSavePath = autoSavePath;
+
+			var autoSaveFormat = cfg.AutoSaveFormat;
+			if (ImGui.InputText(Locale.GetString("Auto_save_Folder_Name"), ref autoSaveFormat, 256))
+				cfg.AutoSaveFormat = autoSaveFormat;
+
+			ImGui.Text(Locale.GetString("Example_Folder_Name"));
+			ImGui.TextUnformatted(PathHelper.Replace(autoSaveFormat));
+			
+			ImGui.Spacing();
+			ImGui.BeginTable("AutoSaveFormatters", 2, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders| ImGuiTableFlags.PadOuterX);
+			
+			ImGui.TableSetupScrollFreeze(0, 1);
+			ImGui.TableSetupColumn(Locale.GetString("Formatter"));
+			ImGui.TableSetupColumn(Locale.GetString("Example_Value"));
+			ImGui.TableHeadersRow();
+
+			foreach ((var replaceKey, var replaceFunc) in PathHelper.Replacers) {
+				ImGui.TableNextRow();
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(replaceKey);
+				ImGui.TableNextColumn();
+				ImGui.TextUnformatted(replaceFunc());
+			}
+			
+			ImGui.EndTable();
 
 			ImGui.EndTabItem();
 		}

--- a/Ktisis/Locale/i18n/English.json
+++ b/Ktisis/Locale/i18n/English.json
@@ -67,6 +67,10 @@
     "Auto_save_count": "Auto Save Count",
     "Auto_save_path": "Auto Save Path",
     "Clear_auto_saves_on_exit":  "Clear auto saves on exit",
+    "Formatter": "Formatter",
+    "Example_Value": "Example Value",
+    "Example_Folder_Name": "Example Folder Name:",
+    "Auto_save_Folder_Name": "Auto Save Folder Name",
     // Display keyboard configs from enum defined in Input.cs
     "Input_Generic_Toggle": "Toggle",
     "Input_Generic_Hold": "Hold",


### PR DESCRIPTION
This is a basic tool to allow customizing of the autosave folder name.

This came up from a little bit of usage by myself and found that having the ability of the files organised a little more would be nicer.

defaults are set to match the current, so the change is as transparent to users as possible.
I have updated the code for cleanups to auto prune empty directories.