### PR TITLE
Allow Zero Speed for WindEditor.cs

### DIFF
--- a/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
+++ b/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
@@ -20,7 +20,7 @@ public class WindEditor : EditorBase {
 		
 		this.DrawAngle("Direction", ref state.Wind.Direction, 0.0f, 360.0f);
 		this.DrawAngle("Angle", ref state.Wind.Angle, 0.0f, 180.0f);
-		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.01f, 1.5f);
+		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.0f, 1.5f);
 	}
 
 	private void DrawAngle(string label, ref float angle, float min, float max) {


### PR DESCRIPTION
changes the min value on the WindEditor speed input to allow for 0.0, allowing total freezing of wind physics without needing to enable pose mode. can technically support a negative value, but the UX is not friendly with it

#ktisis-suggestions thread: https://discord.com/channels/975894364020686878/1212626932433293403/1212626932433293403