### PR TITLE
reinstate and expand locale strings for v0.3

### DIFF
--- a/Ktisis/Interface/Components/Config/BoneCategoryEditor.cs
+++ b/Ktisis/Interface/Components/Config/BoneCategoryEditor.cs
@@ -125,7 +125,7 @@ public class BoneCategoryEditor {
 		if (this.Selected == null) return;
 
 		ImGui.Spacing();
-		ImGui.Text("Colors:");
+		ImGui.Text(this._ctx.Locale.Translate("config.categories.editor.color_header"));
 		ImGui.Spacing();
 
 		this.DrawCategoryColors(this.Selected);
@@ -141,10 +141,10 @@ public class BoneCategoryEditor {
 
 		var changed = false;
 		if (category.LinkedColors) {
-			changed = DrawColorEdit("Group Color", ref category.GroupColor);
+			changed = DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
 		} else {
-			changed |= DrawColorEdit("Group Color", ref category.GroupColor);
-			changed |= DrawColorEdit("Bone Color", ref category.BoneColor);
+			changed |= DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
+			changed |= DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.bone_color"), ref category.BoneColor);
 		}
 
 		if (changed && this.ColorSub)
@@ -164,8 +164,8 @@ public class BoneCategoryEditor {
 	}
 
 	private void DrawSwitches(BoneCategory category) {
-		ImGui.Checkbox("Apply to subcategories", ref this.ColorSub);
-		ImGui.Checkbox("Link group & bone colors", ref category.LinkedColors);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.editor.subcategories"), ref this.ColorSub);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.editor.link_colors"), ref category.LinkedColors);
 	}
 
 	private static bool DrawColorEdit(string label, ref uint color) {

--- a/Ktisis/Interface/Components/Config/BoneCategoryEditor.cs
+++ b/Ktisis/Interface/Components/Config/BoneCategoryEditor.cs
@@ -125,7 +125,7 @@ public class BoneCategoryEditor {
 		if (this.Selected == null) return;
 
 		ImGui.Spacing();
-		ImGui.Text(this._ctx.Locale.Translate("config.categories.editor.color_header"));
+		ImGui.Text(this._locale.Translate("config.categories.editor.color_header"));
 		ImGui.Spacing();
 
 		this.DrawCategoryColors(this.Selected);
@@ -141,10 +141,10 @@ public class BoneCategoryEditor {
 
 		var changed = false;
 		if (category.LinkedColors) {
-			changed = DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
+			changed = DrawColorEdit(this._locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
 		} else {
-			changed |= DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
-			changed |= DrawColorEdit(this._ctx.Locale.Translate("config.categories.editor.bone_color"), ref category.BoneColor);
+			changed |= DrawColorEdit(this._locale.Translate("config.categories.editor.group_color"), ref category.GroupColor);
+			changed |= DrawColorEdit(this._locale.Translate("config.categories.editor.bone_color"), ref category.BoneColor);
 		}
 
 		if (changed && this.ColorSub)
@@ -164,8 +164,8 @@ public class BoneCategoryEditor {
 	}
 
 	private void DrawSwitches(BoneCategory category) {
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.editor.subcategories"), ref this.ColorSub);
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.editor.link_colors"), ref category.LinkedColors);
+		ImGui.Checkbox(this._locale.Translate("config.categories.editor.subcategories"), ref this.ColorSub);
+		ImGui.Checkbox(this._locale.Translate("config.categories.editor.link_colors"), ref category.LinkedColors);
 	}
 
 	private static bool DrawColorEdit(string label, ref uint color) {

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -22,9 +22,11 @@ public class GizmoStyleEditor {
 	private Configuration Config => this._cfg.File;
 	
 	public GizmoStyleEditor(
-		ConfigManager cfg
+		ConfigManager cfg,
+		LocaleManager locale
 	) {
 		this._cfg = cfg;
+		this._locale = locale;
 	}
 	
 	public void Draw() {

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -39,7 +39,7 @@ public class GizmoStyleEditor {
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_x"), ref style.ColorDirectionX, defaults.ColorDirectionX);
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_y"), ref style.ColorDirectionY, defaults.ColorDirectionY);
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_z"), ref style.ColorDirectionZ, defaults.ColorDirectionZ);
-			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.selected"), ref style.ColorSelection, defaults.ColorSelection);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.active"), ref style.ColorSelection, defaults.ColorSelection);
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.title"), ref style.ColorInactive, defaults.ColorInactive);
 		}
 

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -31,42 +31,106 @@ public class GizmoStyleEditor {
 		
 		using var frame = ImRaii.Child("##CfgStyleFrame", ImGui.GetContentRegionAvail(), true);
 
-		if (ImGui.CollapsingHeader("General")) {
-			DrawStyleColor("Direction X", ref style.ColorDirectionX, defaults.ColorDirectionX);
-			DrawStyleColor("Direction Y", ref style.ColorDirectionY, defaults.ColorDirectionY);
-			DrawStyleColor("Direction Z", ref style.ColorDirectionZ, defaults.ColorDirectionZ);
-			DrawStyleColor("Selected Color", ref style.ColorSelection, defaults.ColorSelection);
-			DrawStyleColor("Inactive Color", ref style.ColorInactive, defaults.ColorInactive);
+		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.general.title"))) {
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_x"), ref style.ColorDirectionX, defaults.ColorDirectionX);
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_y"), ref style.ColorDirectionY, defaults.ColorDirectionY);
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_z"), ref style.ColorDirectionZ, defaults.ColorDirectionZ);
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.selected"), ref style.ColorSelection, defaults.ColorSelection);
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.title"), ref style.ColorInactive, defaults.ColorInactive);
 		}
 
-		if (ImGui.CollapsingHeader("Position")) {
-			DrawStyleFloat("Line Thickness##PosThickness", ref style.TranslationLineThickness, defaults.TranslationLineThickness);
-			DrawStyleFloat("Arrow Size##PosArrowSize", ref style.TranslationLineArrowSize, defaults.TranslationLineArrowSize);
-			DrawStyleFloat("Hatched Axis Thickness", ref style.HatchedAxisLineThickness, defaults.HatchedAxisLineThickness);
-			DrawStyleFloat("Center Circle Size##PosCircleSize", ref style.CenterCircleSize, defaults.CenterCircleSize);
-			DrawStyleColor("Plane X##PosPlaneColorX", ref style.ColorPlaneX, defaults.ColorPlaneX);
-			DrawStyleColor("Plane Y##PosPlaneColorY", ref style.ColorPlaneY, defaults.ColorPlaneY);
-			DrawStyleColor("Plane Z##PosPlaneColorZ", ref style.ColorPlaneZ, defaults.ColorPlaneZ);
-			DrawStyleColor("Line Color##PosLineColor", ref style.ColorTranslationLine, defaults.ColorTranslationLine);
-			DrawStyleColor("Hatched Axis Color", ref style.ColorHatchedAxisLines, defaults.ColorHatchedAxisLines);
+		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.position.title"))) {
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.line_thick")}##PosThickness",
+				ref style.TranslationLineThickness,
+				defaults.TranslationLineThickness
+			);
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.arrow_size")}##PosArrowSize",
+				ref style.TranslationLineArrowSize,
+				defaults.TranslationLineArrowSize
+			);
+			DrawStyleFloat(
+				this._ctx.Locale.Translate("config.gizmo.editor.position.axis_thick"),
+				ref style.HatchedAxisLineThickness,
+				defaults.HatchedAxisLineThickness
+			);
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.circle_size")}##PosCircleSize",
+				ref style.CenterCircleSize,
+				defaults.CenterCircleSize
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_x")}##PosPlaneColorX",
+				ref style.ColorPlaneX,
+				defaults.ColorPlaneX
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_y")}##PosPlaneColorY",
+				ref style.ColorPlaneY,
+				defaults.ColorPlaneY
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_z")}##PosPlaneColorZ",
+				ref style.ColorPlaneZ,
+				defaults.ColorPlaneZ
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.line_color")}##PosLineColor",
+				ref style.ColorTranslationLine,
+				defaults.ColorTranslationLine
+			);
+			DrawStyleColor(
+				this._ctx.Locale.Translate("config.gizmo.editor.position.axis_color"),
+				ref style.ColorHatchedAxisLines,
+				defaults.ColorHatchedAxisLines
+			);
 		}
 
-		if (ImGui.CollapsingHeader("Rotation")) {
-			DrawStyleFloat("Inner Line Thickness##RotateThickness", ref style.RotationLineThickness, defaults.RotationLineThickness);
-			DrawStyleFloat("Outer Line Thickness##RotateThicknessOuter", ref style.RotationOuterLineThickness, defaults.RotationOuterLineThickness);
-			DrawStyleColor("Activated Border Color##RotateUsingBorder", ref style.ColorRotationUsingBorder, defaults.ColorRotationUsingBorder);
-			DrawStyleColor("Activated Fill Color##RotateUsingFill", ref style.ColorRotationUsingFill, defaults.ColorRotationUsingFill);
+		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.rotation.title"))) {
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.inner_thick")}##RotateThickness",
+				ref style.RotationLineThickness,
+				defaults.RotationLineThickness
+			);
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.outer_thick")}##RotateThicknessOuter",
+				ref style.RotationOuterLineThickness,
+				defaults.RotationOuterLineThickness
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.border_color")}##RotateUsingBorder",
+				ref style.ColorRotationUsingBorder,
+				defaults.ColorRotationUsingBorder
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.fill_color")}##RotateUsingFill",
+				ref style.ColorRotationUsingFill,
+				defaults.ColorRotationUsingFill
+			);
 		}
 
-		if (ImGui.CollapsingHeader("Scale")) {
-			DrawStyleFloat("Line Thickness##ScaleThickness", ref style.ScaleLineThickness, defaults.ScaleLineThickness);
-			DrawStyleFloat("Circle Size##ScaleSize", ref style.ScaleLineCircleSize, defaults.ScaleLineCircleSize);
-			DrawStyleColor("Activated Line Color##ScaleColor", ref style.ColorScaleLine, defaults.ColorScaleLine);
+		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.scale.title"))) {
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.line_thick")}##ScaleThickness",
+				ref style.ScaleLineThickness,
+				defaults.ScaleLineThickness
+			);
+			DrawStyleFloat(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.circle_size")}##ScaleSize",
+				ref style.ScaleLineCircleSize,
+				defaults.ScaleLineCircleSize
+			);
+			DrawStyleColor(
+				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.line_color")}##ScaleColor",
+				ref style.ColorScaleLine,
+				defaults.ColorScaleLine
+			);
 		}
 
-		if (ImGui.CollapsingHeader("Text")) {
-			DrawStyleColor("Text Color", ref style.ColorText, defaults.ColorText);
-			DrawStyleColor("Shadow Color", ref style.ColorTextShadow, defaults.ColorTextShadow);
+		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.text.title"))) {
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.text.color"), ref style.ColorText, defaults.ColorText);
+			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.text.shadow_color"), ref style.ColorTextShadow, defaults.ColorTextShadow);
 		}
 
 		this.Config.Gizmo.Style = style;

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -40,7 +40,7 @@ public class GizmoStyleEditor {
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_y"), ref style.ColorDirectionY, defaults.ColorDirectionY);
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_z"), ref style.ColorDirectionZ, defaults.ColorDirectionZ);
 			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.active"), ref style.ColorSelection, defaults.ColorSelection);
-			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.title"), ref style.ColorInactive, defaults.ColorInactive);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.inactive"), ref style.ColorInactive, defaults.ColorInactive);
 		}
 
 		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.position.title"))) {

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -16,6 +16,7 @@ namespace Ktisis.Interface.Components.Config;
 [Transient]
 public class GizmoStyleEditor {
 	private readonly ConfigManager _cfg;
+	private readonly LocaleManager _locale;
 
 	private Configuration Config => this._cfg.File;
 	
@@ -31,106 +32,106 @@ public class GizmoStyleEditor {
 		
 		using var frame = ImRaii.Child("##CfgStyleFrame", ImGui.GetContentRegionAvail(), true);
 
-		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.general.title"))) {
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_x"), ref style.ColorDirectionX, defaults.ColorDirectionX);
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_y"), ref style.ColorDirectionY, defaults.ColorDirectionY);
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.dir_z"), ref style.ColorDirectionZ, defaults.ColorDirectionZ);
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.selected"), ref style.ColorSelection, defaults.ColorSelection);
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.general.title"), ref style.ColorInactive, defaults.ColorInactive);
+		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.general.title"))) {
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_x"), ref style.ColorDirectionX, defaults.ColorDirectionX);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_y"), ref style.ColorDirectionY, defaults.ColorDirectionY);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.dir_z"), ref style.ColorDirectionZ, defaults.ColorDirectionZ);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.selected"), ref style.ColorSelection, defaults.ColorSelection);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.general.title"), ref style.ColorInactive, defaults.ColorInactive);
 		}
 
-		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.position.title"))) {
+		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.position.title"))) {
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.line_thick")}##PosThickness",
+				$"{this._locale.Translate("config.gizmo.editor.position.line_thick")}##PosThickness",
 				ref style.TranslationLineThickness,
 				defaults.TranslationLineThickness
 			);
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.arrow_size")}##PosArrowSize",
+				$"{this._locale.Translate("config.gizmo.editor.position.arrow_size")}##PosArrowSize",
 				ref style.TranslationLineArrowSize,
 				defaults.TranslationLineArrowSize
 			);
 			DrawStyleFloat(
-				this._ctx.Locale.Translate("config.gizmo.editor.position.axis_thick"),
+				this._locale.Translate("config.gizmo.editor.position.axis_thick"),
 				ref style.HatchedAxisLineThickness,
 				defaults.HatchedAxisLineThickness
 			);
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.circle_size")}##PosCircleSize",
+				$"{this._locale.Translate("config.gizmo.editor.position.circle_size")}##PosCircleSize",
 				ref style.CenterCircleSize,
 				defaults.CenterCircleSize
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_x")}##PosPlaneColorX",
+				$"{this._locale.Translate("config.gizmo.editor.position.plane_x")}##PosPlaneColorX",
 				ref style.ColorPlaneX,
 				defaults.ColorPlaneX
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_y")}##PosPlaneColorY",
+				$"{this._locale.Translate("config.gizmo.editor.position.plane_y")}##PosPlaneColorY",
 				ref style.ColorPlaneY,
 				defaults.ColorPlaneY
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.plane_z")}##PosPlaneColorZ",
+				$"{this._locale.Translate("config.gizmo.editor.position.plane_z")}##PosPlaneColorZ",
 				ref style.ColorPlaneZ,
 				defaults.ColorPlaneZ
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.position.line_color")}##PosLineColor",
+				$"{this._locale.Translate("config.gizmo.editor.position.line_color")}##PosLineColor",
 				ref style.ColorTranslationLine,
 				defaults.ColorTranslationLine
 			);
 			DrawStyleColor(
-				this._ctx.Locale.Translate("config.gizmo.editor.position.axis_color"),
+				this._locale.Translate("config.gizmo.editor.position.axis_color"),
 				ref style.ColorHatchedAxisLines,
 				defaults.ColorHatchedAxisLines
 			);
 		}
 
-		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.rotation.title"))) {
+		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.rotation.title"))) {
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.inner_thick")}##RotateThickness",
+				$"{this._locale.Translate("config.gizmo.editor.rotation.inner_thick")}##RotateThickness",
 				ref style.RotationLineThickness,
 				defaults.RotationLineThickness
 			);
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.outer_thick")}##RotateThicknessOuter",
+				$"{this._locale.Translate("config.gizmo.editor.rotation.outer_thick")}##RotateThicknessOuter",
 				ref style.RotationOuterLineThickness,
 				defaults.RotationOuterLineThickness
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.border_color")}##RotateUsingBorder",
+				$"{this._locale.Translate("config.gizmo.editor.rotation.border_color")}##RotateUsingBorder",
 				ref style.ColorRotationUsingBorder,
 				defaults.ColorRotationUsingBorder
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.rotation.fill_color")}##RotateUsingFill",
+				$"{this._locale.Translate("config.gizmo.editor.rotation.fill_color")}##RotateUsingFill",
 				ref style.ColorRotationUsingFill,
 				defaults.ColorRotationUsingFill
 			);
 		}
 
-		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.scale.title"))) {
+		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.scale.title"))) {
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.line_thick")}##ScaleThickness",
+				$"{this._locale.Translate("config.gizmo.editor.scale.line_thick")}##ScaleThickness",
 				ref style.ScaleLineThickness,
 				defaults.ScaleLineThickness
 			);
 			DrawStyleFloat(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.circle_size")}##ScaleSize",
+				$"{this._locale.Translate("config.gizmo.editor.scale.circle_size")}##ScaleSize",
 				ref style.ScaleLineCircleSize,
 				defaults.ScaleLineCircleSize
 			);
 			DrawStyleColor(
-				$"{this._ctx.Locale.Translate("config.gizmo.editor.scale.line_color")}##ScaleColor",
+				$"{this._locale.Translate("config.gizmo.editor.scale.line_color")}##ScaleColor",
 				ref style.ColorScaleLine,
 				defaults.ColorScaleLine
 			);
 		}
 
-		if (ImGui.CollapsingHeader(this._ctx.Locale.Translate("config.gizmo.editor.text.title"))) {
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.text.color"), ref style.ColorText, defaults.ColorText);
-			DrawStyleColor(this._ctx.Locale.Translate("config.gizmo.editor.text.shadow_color"), ref style.ColorTextShadow, defaults.ColorTextShadow);
+		if (ImGui.CollapsingHeader(this._locale.Translate("config.gizmo.editor.text.title"))) {
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.text.color"), ref style.ColorText, defaults.ColorText);
+			DrawStyleColor(this._locale.Translate("config.gizmo.editor.text.shadow_color"), ref style.ColorTextShadow, defaults.ColorTextShadow);
 		}
 
 		this.Config.Gizmo.Style = style;

--- a/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
+++ b/Ktisis/Interface/Components/Config/GizmoStyleEditor.cs
@@ -10,6 +10,7 @@ using ImGuiNET;
 using Ktisis.Core.Attributes;
 using Ktisis.Data.Config;
 using Ktisis.Data.Config.Sections;
+using Ktisis.Localization;
 
 namespace Ktisis.Interface.Components.Config;
 

--- a/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
+++ b/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
@@ -20,7 +20,7 @@ public class WindEditor : EditorBase {
 		
 		this.DrawAngle("Direction", ref state.Wind.Direction, 0.0f, 360.0f);
 		this.DrawAngle("Angle", ref state.Wind.Angle, 0.0f, 180.0f);
-		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.0f, 1.5f);
+		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.01f, 1.5f);
 	}
 
 	private void DrawAngle(string label, ref float angle, float min, float max) {

--- a/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
+++ b/Ktisis/Interface/Components/Environment/Editors/WindEditor.cs
@@ -20,7 +20,7 @@ public class WindEditor : EditorBase {
 		
 		this.DrawAngle("Direction", ref state.Wind.Direction, 0.0f, 360.0f);
 		this.DrawAngle("Angle", ref state.Wind.Angle, 0.0f, 180.0f);
-		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.01f, 1.5f);
+		ImGui.SliderFloat("Speed", ref state.Wind.Speed, 0.0f, 1.5f);
 	}
 
 	private void DrawAngle(string label, ref float angle, float min, float max) {

--- a/Ktisis/Interface/Windows/CameraWindow.cs
+++ b/Ktisis/Interface/Windows/CameraWindow.cs
@@ -78,13 +78,13 @@ public class CameraWindow : KtisisWindow {
 
 	private void DrawToggles(EditorCamera camera) {
 		var collide = !camera.Flags.HasFlag(CameraFlags.NoCollide);
-		if (ImGui.Checkbox("Collision", ref collide))
+		if (ImGui.Checkbox(this._ctx.Locale.Translate("camera_edit.toggles.collide"), ref collide))
 			camera.Flags ^= CameraFlags.NoCollide;
 		
 		ImGui.SameLine();
 		
 		var delimit = camera.Flags.HasFlag(CameraFlags.Delimit);
-		if (ImGui.Checkbox("Delimited", ref delimit))
+		if (ImGui.Checkbox(this._ctx.Locale.Translate("camera_edit.toggles.delimit"), ref delimit))
 			camera.SetDelimited(delimit);
 		
 		this.DrawOrthographicToggle(camera);
@@ -96,7 +96,7 @@ public class CameraWindow : KtisisWindow {
 		
 		ImGui.SameLine();
 		var enabled = camera.IsOrthographic;
-		if (ImGui.Checkbox("Orthographic", ref enabled))
+		if (ImGui.Checkbox(this._ctx.Locale.Translate("camera_edit.toggles.ortho"), ref enabled))
 			camera.SetOrthographic(enabled);
 	}
 	
@@ -110,7 +110,10 @@ public class CameraWindow : KtisisWindow {
 
 		var isFixed = camera.OrbitTarget != null;
 		var lockIcon = isFixed ? FontAwesomeIcon.Lock : FontAwesomeIcon.Unlock;
-		if (Buttons.IconButtonTooltip(lockIcon, isFixed ? "Unlock orbit target" : "Lock orbit target"))
+		var lockHint = isFixed
+			? this._ctx.Locale.Translate("camera_edit.orbit.unlock")
+			: this._ctx.Locale.Translate("camera_edit.orbit.lock");
+		if (Buttons.IconButtonTooltip(lockIcon, lockHint))
 			camera.OrbitTarget = isFixed ? null : target.ObjectIndex;
 
 		ImGui.SameLine();
@@ -123,7 +126,7 @@ public class CameraWindow : KtisisWindow {
 		
 		ImGui.SameLine();
 		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ImGui.GetContentRegionAvail().X - Buttons.CalcSize());
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sync, "Offset camera to target model")) {
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sync, this._ctx.Locale.Translate("camera_edit.offset.to_target"))) {
 			var gameObject = (GameObject*)target.Address;
 			var drawObject = gameObject->DrawObject;
 			if (drawObject != null)
@@ -146,7 +149,9 @@ public class CameraWindow : KtisisWindow {
 			pos -= camera.RelativeOffset;
 		
 		var lockIcon = isFixed ? FontAwesomeIcon.Lock : FontAwesomeIcon.Unlock;
-		var lockHint = isFixed ? "Unlock fixed position" : "Lock to fixed position";
+		var lockHint = isFixed
+			? this._ctx.Locale.Translate("camera_edit.position.unlock")
+			: this._ctx.Locale.Translate("camera_edit.position.lock");
 		if (Buttons.IconButtonTooltip(lockIcon, lockHint))
 			camera.FixedPosition = isFixed ? null : pos;
 
@@ -158,7 +163,7 @@ public class CameraWindow : KtisisWindow {
 	}
 
 	private void DrawRelativeOffset(EditorCamera camera) {
-		this.DrawIconAlign(FontAwesomeIcon.Plus, out var spacing);
+		this.DrawIconAlign(FontAwesomeIcon.Plus, out var spacing, this._ctx.Locale.Translate("camera_edit.offset.from_base"));
 		ImGui.SameLine(0, spacing);
 		this._relativePos.DrawPosition(ref camera.RelativeOffset, TransformFlags);
 	}
@@ -168,20 +173,21 @@ public class CameraWindow : KtisisWindow {
 	private unsafe void DrawAnglePan(EditorCamera camera) {
 		var ptr = camera.Camera;
 		if (ptr == null) return;
-		
+
 		// Camera angle
-		
-		this.DrawIconAlign(FontAwesomeIcon.ArrowsSpin, out var spacing);
+		var angleHint = this._ctx.Locale.Translate("camera_edit.angle");
+		this.DrawIconAlign(FontAwesomeIcon.ArrowsSpin, out var spacing, angleHint);
 		ImGui.SameLine(0, spacing);
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-		
+
 		var angleDeg = ptr->Angle * MathHelpers.Rad2Deg;
 		if (ImGui.DragFloat2("##CameraAngle", ref angleDeg, 0.25f))
 			ptr->Angle = angleDeg * MathHelpers.Deg2Rad;
 
 		// Camera pan
 		
-		this.DrawIconAlign(FontAwesomeIcon.ArrowsAlt, out spacing);
+		var panHint = this._ctx.Locale.Translate("camera_edit.pan");
+		this.DrawIconAlign(FontAwesomeIcon.ArrowsAlt, out spacing, panHint);
 		ImGui.SameLine(0, spacing);
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
 		
@@ -198,30 +204,35 @@ public class CameraWindow : KtisisWindow {
 	private unsafe void DrawSliders(EditorCamera camera) {
 		var ptr = camera.Camera;
 		if (ptr == null) return;
-		
-		this.DrawSliderAngle("##CameraRotate", FontAwesomeIcon.CameraRotate, ref ptr->Rotation, -180.0f, 180.0f, 0.5f);
-		this.DrawSliderAngle("##CameraZoom", FontAwesomeIcon.VectorSquare, ref ptr->Zoom, -40.0f, 100.0f, 0.5f);
-		this.DrawSliderFloat("##CameraDistance", FontAwesomeIcon.Moon, ref ptr->Distance, ptr->DistanceMin, ptr->DistanceMax, 0.05f);
-		if (camera.IsOrthographic)
-			this.DrawSliderFloat("##OrthographicZoom", FontAwesomeIcon.LocationCrosshairs, ref camera.OrthographicZoom, 0.1f, 10.0f, 0.01f);
+
+		var rotateHint = this._ctx.Locale.Translate("camera_edit.sliders.rotation");
+		var zoomHint = this._ctx.Locale.Translate("camera_edit.sliders.zoom");
+		var distanceHint = this._ctx.Locale.Translate("camera_edit.sliders.distance");
+		this.DrawSliderAngle("##CameraRotate", FontAwesomeIcon.CameraRotate, ref ptr->Rotation, -180.0f, 180.0f, 0.5f, rotateHint);
+		this.DrawSliderAngle("##CameraZoom", FontAwesomeIcon.VectorSquare, ref ptr->Zoom, -40.0f, 100.0f, 0.5f, zoomHint);
+		this.DrawSliderFloat("##CameraDistance", FontAwesomeIcon.Moon, ref ptr->Distance, ptr->DistanceMin, ptr->DistanceMax, 0.05f, distanceHint);
+		if (camera.IsOrthographic) {
+			var orthoHint = this._ctx.Locale.Translate("camera_edit.sliders.ortho_zoom");
+			this.DrawSliderFloat("##OrthographicZoom", FontAwesomeIcon.LocationCrosshairs, ref camera.OrthographicZoom, 0.1f, 10.0f, 0.01f, orthoHint);
+		}
 	}
 
-	private void DrawSliderAngle(string label, FontAwesomeIcon icon, ref float value, float min, float max, float drag) {
-		this.DrawSliderIcon(icon);
+	private void DrawSliderAngle(string label, FontAwesomeIcon icon, ref float value, float min, float max, float drag, string hint = "") {
+		this.DrawSliderIcon(icon, hint);
 		ImGui.SliderAngle(label, ref value, min, max, "", ImGuiSliderFlags.AlwaysClamp);
 		var deg = value * MathHelpers.Rad2Deg;
 		if (this.DrawSliderDrag(label, ref deg, min, max, drag, true))
 			value = deg * MathHelpers.Deg2Rad;
 	}
 
-	private void DrawSliderFloat(string label, FontAwesomeIcon icon, ref float value, float min, float max, float drag) {
-		this.DrawSliderIcon(icon);
+	private void DrawSliderFloat(string label, FontAwesomeIcon icon, ref float value, float min, float max, float drag, string hint = "") {
+		this.DrawSliderIcon(icon, hint);
 		ImGui.SliderFloat(label, ref value, min, max, "");
 		this.DrawSliderDrag(label, ref value, min, max, drag, false);
 	}
 
-	private void DrawSliderIcon(FontAwesomeIcon icon) {
-		this.DrawIconAlign(icon, out var spacing);
+	private void DrawSliderIcon(FontAwesomeIcon icon, string hint = "") {
+		this.DrawIconAlign(icon, out var spacing, hint);
 		ImGui.SameLine(0, spacing);
 		ImGui.SetNextItemWidth(ImGui.CalcItemWidth() - (ImGui.GetCursorPosX() - ImGui.GetCursorStartPos().X));
 	}
@@ -234,11 +245,16 @@ public class CameraWindow : KtisisWindow {
 	
 	// Alignment helpers
 
-	private void DrawIconAlign(FontAwesomeIcon icon, out float spacing) {
+	private void DrawIconAlign(FontAwesomeIcon icon, out float spacing, string hint = "") {
 		var padding = ImGui.GetStyle().CellPadding.X;
 		var iconSpace = (UiBuilder.IconFont.FontSize - Icons.CalcIconSize(icon).X) / 2;
+
 		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + padding + iconSpace);
 		Icons.DrawIcon(icon);
+		if (!string.IsNullOrEmpty(hint) && ImGui.IsItemHovered()) {
+			using var _ = ImRaii.Tooltip();
+			ImGui.Text(hint);
+		}
 		spacing = padding + iconSpace + ImGui.GetStyle().ItemInnerSpacing.X;
 	}
 }

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -56,12 +56,12 @@ public class ConfigWindow : KtisisWindow {
 	public override void Draw() {
 		using var tabs = ImRaii.TabBar("##ConfigTabs");
 		if (!tabs.Success) return;
-		DrawTab(this._ctx.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
-		DrawTab(this._ctx.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
-		DrawTab(this._ctx.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
-		DrawTab(this._ctx.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
-		DrawTab(this._ctx.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
-		DrawTab(this._ctx.Locale.Translate("config.input.title"), this.DrawInputTab);
+		DrawTab(this_context.Current.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
+		DrawTab(this_context.Current.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
+		DrawTab(this_context.Current.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
+		DrawTab(this_context.Current.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
+		DrawTab(this_context.Current.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
+		DrawTab(this_context.Current.Locale.Translate("config.input.title"), this.DrawInputTab);
 	}
 	
 	// Tabs
@@ -76,17 +76,17 @@ public class ConfigWindow : KtisisWindow {
 	// Categories
 
 	private void DrawCategoriesTab() {
-		if (ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
+		if (ImGui.Checkbox(this_context.Current.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
 			this._context.Current?.Scene.Refresh();
 		ImGui.SameLine();
 		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
 		if (ImGui.IsItemHovered()) {
 			using var _ = ImRaii.Tooltip();
-			ImGui.Text(this._ctx.Locale.Translate("config.categories.hint_nsfw"));
+			ImGui.Text(this_context.Current.Locale.Translate("config.categories.hint_nsfw"));
 		}
 		
 		ImGui.Spacing();
-		ImGui.Text(this._ctx.Locale.Translate("config.categories.header"));
+		ImGui.Text(this_context.Current.Locale.Translate("config.categories.header"));
 		ImGui.Spacing();
 		this._boneCategories.Draw();
 	}
@@ -94,10 +94,10 @@ public class ConfigWindow : KtisisWindow {
 	// Gizmo
 
 	private void DrawGizmoTab() {
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
 		
 		ImGui.Spacing();
-		ImGui.Text(this._ctx.Locale.Translate("config.gizmo.header"));
+		ImGui.Text(this_context.Current.Locale.Translate("config.gizmo.header"));
 		ImGui.Spacing();
 		this._gizmoStyle.Draw();
 	}
@@ -105,27 +105,27 @@ public class ConfigWindow : KtisisWindow {
 	// Overlay
 
 	private void DrawOverlayTab() {
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
 		ImGui.Spacing();
-		ImGui.DragFloat(this._ctx.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
-		ImGui.DragFloat(this._ctx.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
+		ImGui.DragFloat(this_context.Current.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
+		ImGui.DragFloat(this_context.Current.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
 		ImGui.Spacing();
-		ImGui.SliderFloat(this._ctx.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
-		ImGui.SliderFloat(this._ctx.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
+		ImGui.SliderFloat(this_context.Current.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
+		ImGui.SliderFloat(this_context.Current.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
 	}
 	
 	// Workspace
 	
 	private void DrawWorkspaceTab() {
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
 	}
 	
 	// Input
 
 	private void DrawInputTab() {
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
 		if (!this.Config.Keybinds.Enabled) return;
 		ImGui.Spacing();
 		this._keybinds.Draw();
@@ -137,18 +137,18 @@ public class ConfigWindow : KtisisWindow {
 	private void DrawAutoSaveTab() {
 		var cfg = this.Config.AutoSave;
 
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
-		ImGui.Checkbox(this._ctx.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
+		ImGui.Checkbox(this_context.Current.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
 		
 		ImGui.Spacing();
 
-		ImGui.SliderInt(this._ctx.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
-		ImGui.SliderInt(this._ctx.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
+		ImGui.SliderInt(this_context.Current.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
+		ImGui.SliderInt(this_context.Current.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
 		
 		ImGui.Spacing();
 		
-		ImGui.InputText(this._ctx.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
-		ImGui.InputText(this._ctx.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
+		ImGui.InputText(this_context.Current.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
+		ImGui.InputText(this_context.Current.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
 		
 		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled)))
 			ImGui.TextUnformatted($"Example folder name: {this._format.Replace(cfg.FolderFormat)}");

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -56,12 +56,12 @@ public class ConfigWindow : KtisisWindow {
 	public override void Draw() {
 		using var tabs = ImRaii.TabBar("##ConfigTabs");
 		if (!tabs.Success) return;
-		DrawTab(this_context.Current.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
-		DrawTab(this_context.Current.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
-		DrawTab(this_context.Current.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
-		DrawTab(this_context.Current.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
-		DrawTab(this_context.Current.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
-		DrawTab(this_context.Current.Locale.Translate("config.input.title"), this.DrawInputTab);
+		DrawTab(this._context.Current.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
+		DrawTab(this._context.Current.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
+		DrawTab(this._context.Current.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
+		DrawTab(this._context.Current.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
+		DrawTab(this._context.Current.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
+		DrawTab(this._context.Current.Locale.Translate("config.input.title"), this.DrawInputTab);
 	}
 	
 	// Tabs
@@ -76,17 +76,17 @@ public class ConfigWindow : KtisisWindow {
 	// Categories
 
 	private void DrawCategoriesTab() {
-		if (ImGui.Checkbox(this_context.Current.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
+		if (ImGui.Checkbox(this._context.Current.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
 			this._context.Current?.Scene.Refresh();
 		ImGui.SameLine();
 		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
 		if (ImGui.IsItemHovered()) {
 			using var _ = ImRaii.Tooltip();
-			ImGui.Text(this_context.Current.Locale.Translate("config.categories.hint_nsfw"));
+			ImGui.Text(this._context.Current.Locale.Translate("config.categories.hint_nsfw"));
 		}
 		
 		ImGui.Spacing();
-		ImGui.Text(this_context.Current.Locale.Translate("config.categories.header"));
+		ImGui.Text(this._context.Current.Locale.Translate("config.categories.header"));
 		ImGui.Spacing();
 		this._boneCategories.Draw();
 	}
@@ -94,10 +94,10 @@ public class ConfigWindow : KtisisWindow {
 	// Gizmo
 
 	private void DrawGizmoTab() {
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
 		
 		ImGui.Spacing();
-		ImGui.Text(this_context.Current.Locale.Translate("config.gizmo.header"));
+		ImGui.Text(this._context.Current.Locale.Translate("config.gizmo.header"));
 		ImGui.Spacing();
 		this._gizmoStyle.Draw();
 	}
@@ -105,27 +105,27 @@ public class ConfigWindow : KtisisWindow {
 	// Overlay
 
 	private void DrawOverlayTab() {
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
 		ImGui.Spacing();
-		ImGui.DragFloat(this_context.Current.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
-		ImGui.DragFloat(this_context.Current.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
+		ImGui.DragFloat(this._context.Current.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
+		ImGui.DragFloat(this._context.Current.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
 		ImGui.Spacing();
-		ImGui.SliderFloat(this_context.Current.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
-		ImGui.SliderFloat(this_context.Current.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
+		ImGui.SliderFloat(this._context.Current.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
+		ImGui.SliderFloat(this._context.Current.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
 	}
 	
 	// Workspace
 	
 	private void DrawWorkspaceTab() {
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
 	}
 	
 	// Input
 
 	private void DrawInputTab() {
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
 		if (!this.Config.Keybinds.Enabled) return;
 		ImGui.Spacing();
 		this._keybinds.Draw();
@@ -137,18 +137,18 @@ public class ConfigWindow : KtisisWindow {
 	private void DrawAutoSaveTab() {
 		var cfg = this.Config.AutoSave;
 
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
-		ImGui.Checkbox(this_context.Current.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
+		ImGui.Checkbox(this._context.Current.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
 		
 		ImGui.Spacing();
 
-		ImGui.SliderInt(this_context.Current.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
-		ImGui.SliderInt(this_context.Current.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
+		ImGui.SliderInt(this._context.Current.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
+		ImGui.SliderInt(this._context.Current.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
 		
 		ImGui.Spacing();
 		
-		ImGui.InputText(this_context.Current.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
-		ImGui.InputText(this_context.Current.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
+		ImGui.InputText(this._context.Current.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
+		ImGui.InputText(this._context.Current.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
 		
 		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled)))
 			ImGui.TextUnformatted($"Example folder name: {this._format.Replace(cfg.FolderFormat)}");

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -56,12 +56,12 @@ public class ConfigWindow : KtisisWindow {
 	public override void Draw() {
 		using var tabs = ImRaii.TabBar("##ConfigTabs");
 		if (!tabs.Success) return;
-		DrawTab("Categories", this.DrawCategoriesTab);
-		DrawTab("Gizmo", this.DrawGizmoTab);
-		DrawTab("Overlay", this.DrawOverlayTab);
-		DrawTab("Workspace", this.DrawWorkspaceTab);
-		DrawTab("AutoSave", this.DrawAutoSaveTab);
-		DrawTab("Input", this.DrawInputTab);
+		DrawTab(this._ctx.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
+		DrawTab(this._ctx.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
+		DrawTab(this._ctx.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
+		DrawTab(this._ctx.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
+		DrawTab(this._ctx.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
+		DrawTab(this._ctx.Locale.Translate("config.input.title"), this.DrawInputTab);
 	}
 	
 	// Tabs
@@ -76,17 +76,17 @@ public class ConfigWindow : KtisisWindow {
 	// Categories
 
 	private void DrawCategoriesTab() {
-		if (ImGui.Checkbox("Display NSFW categories", ref this.Config.Categories.ShowNsfwBones))
+		if (ImGui.Checkbox(this._ctx.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
 			this._context.Current?.Scene.Refresh();
 		ImGui.SameLine();
 		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
 		if (ImGui.IsItemHovered()) {
 			using var _ = ImRaii.Tooltip();
-			ImGui.Text("Requires IVCS or any custom skeleton.");
+			ImGui.Text(this._ctx.Locale.Translate("config.categories.hint_nsfw"));
 		}
 		
 		ImGui.Spacing();
-		ImGui.Text("Categories:");
+		ImGui.Text(this._ctx.Locale.Translate("config.categories.header"));
 		ImGui.Spacing();
 		this._boneCategories.Draw();
 	}
@@ -94,10 +94,10 @@ public class ConfigWindow : KtisisWindow {
 	// Gizmo
 
 	private void DrawGizmoTab() {
-		ImGui.Checkbox("Flip axis to face camera", ref this.Config.Gizmo.AllowAxisFlip);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
 		
 		ImGui.Spacing();
-		ImGui.Text("Style:");
+		ImGui.Text(this._ctx.Locale.Translate("config.gizmo.header"));
 		ImGui.Spacing();
 		this._gizmoStyle.Draw();
 	}
@@ -105,27 +105,27 @@ public class ConfigWindow : KtisisWindow {
 	// Overlay
 
 	private void DrawOverlayTab() {
-		ImGui.Checkbox("Draw lines on skeleton", ref this.Config.Overlay.DrawLines);
-		ImGui.Checkbox("Draw lines on skeleton while using gizmo", ref this.Config.Overlay.DrawLinesGizmo);
-		ImGui.Checkbox("Draw dots while using gizmo", ref this.Config.Overlay.DrawDotsGizmo);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
 		ImGui.Spacing();
-		ImGui.DragFloat("Dot radius", ref this.Config.Overlay.DotRadius, 0.1f);
-		ImGui.DragFloat("Line thickness", ref this.Config.Overlay.LineThickness, 0.1f);
+		ImGui.DragFloat(this._ctx.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
+		ImGui.DragFloat(this._ctx.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
 		ImGui.Spacing();
-		ImGui.SliderFloat("Line opacity", ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
-		ImGui.SliderFloat("Line opacity while using gizmo", ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
+		ImGui.SliderFloat(this._ctx.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
+		ImGui.SliderFloat(this._ctx.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
 	}
 	
 	// Workspace
 	
 	private void DrawWorkspaceTab() {
-		ImGui.Checkbox("Open on entering GPose", ref this.Config.Editor.OpenOnEnterGPose);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
 	}
 	
 	// Input
 
 	private void DrawInputTab() {
-		ImGui.Checkbox("Enable keybinds", ref this.Config.Keybinds.Enabled);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
 		if (!this.Config.Keybinds.Enabled) return;
 		ImGui.Spacing();
 		this._keybinds.Draw();
@@ -137,18 +137,18 @@ public class ConfigWindow : KtisisWindow {
 	private void DrawAutoSaveTab() {
 		var cfg = this.Config.AutoSave;
 
-		ImGui.Checkbox("Enable auto saves", ref cfg.Enabled);
-		ImGui.Checkbox("Clear auto saves on exit", ref cfg.ClearOnExit);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
+		ImGui.Checkbox(this._ctx.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
 		
 		ImGui.Spacing();
 
-		ImGui.SliderInt("Save interval", ref cfg.Interval, 10, 600, "%d s");
-		ImGui.SliderInt("Save count", ref cfg.Count, 1, 20);
+		ImGui.SliderInt(this._ctx.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
+		ImGui.SliderInt(this._ctx.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
 		
 		ImGui.Spacing();
 		
-		ImGui.InputText("Save path", ref cfg.FilePath, 256);
-		ImGui.InputText("Folder name", ref cfg.FolderFormat, 256);
+		ImGui.InputText(this._ctx.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
+		ImGui.InputText(this._ctx.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
 		
 		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled)))
 			ImGui.TextUnformatted($"Example folder name: {this._format.Replace(cfg.FolderFormat)}");

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -13,6 +13,7 @@ using Ktisis.Editor.Context;
 using Ktisis.Interface.Components.Config;
 using Ktisis.Interface.Types;
 using Ktisis.Services.Data;
+using Ktisis.Localization;
 
 namespace Ktisis.Interface.Windows;
 
@@ -25,6 +26,7 @@ public class ConfigWindow : KtisisWindow {
 	private readonly ActionKeybindEditor _keybinds;
 	private readonly BoneCategoryEditor _boneCategories;
 	private readonly GizmoStyleEditor _gizmoStyle;
+	public readonly LocaleManager Locale;
 
 	private Configuration Config => this._cfg.File;
 
@@ -34,7 +36,8 @@ public class ConfigWindow : KtisisWindow {
 		FormatService format,
 		ActionKeybindEditor keybinds,
 		BoneCategoryEditor boneCategories,
-		GizmoStyleEditor gizmoStyle
+		GizmoStyleEditor gizmoStyle,
+		LocaleManager locale
 	) : base("Ktisis Settings") {
 		this._cfg = cfg;
 		this._context = context;
@@ -42,6 +45,7 @@ public class ConfigWindow : KtisisWindow {
 		this._keybinds = keybinds;
 		this._boneCategories = boneCategories;
 		this._gizmoStyle = gizmoStyle;
+		this.Locale = locale;
 	}
 	
 	// Open
@@ -56,13 +60,12 @@ public class ConfigWindow : KtisisWindow {
 	public override void Draw() {
 		using var tabs = ImRaii.TabBar("##ConfigTabs");
 		if (!tabs.Success) return;
-		//??? : how to access locale in Draw(), null reference when opening outside gpose
-		DrawTab("Categories", this.DrawCategoriesTab);
-		DrawTab("Gizmo", this.DrawGizmoTab);
-		DrawTab("Overlay", this.DrawOverlayTab);
-		DrawTab("Workspace", this.DrawWorkspaceTab);
-		DrawTab("AutoSave", this.DrawAutoSaveTab);
-		DrawTab("Input", this.DrawInputTab);
+		DrawTab(this.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
+		DrawTab(this.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
+		DrawTab(this.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
+		DrawTab(this.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
+		DrawTab(this.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
+		DrawTab(this.Locale.Translate("config.input.title"), this.DrawInputTab);
 	}
 	
 	// Tabs
@@ -77,17 +80,17 @@ public class ConfigWindow : KtisisWindow {
 	// Categories
 
 	private void DrawCategoriesTab() {
-		if (ImGui.Checkbox(this._context.Current.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
+		if (ImGui.Checkbox(this.Locale.Translate("config.categories.allow_nsfw"), ref this.Config.Categories.ShowNsfwBones))
 			this._context.Current?.Scene.Refresh();
 		ImGui.SameLine();
 		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
 		if (ImGui.IsItemHovered()) {
 			using var _ = ImRaii.Tooltip();
-			ImGui.Text(this._context.Current.Locale.Translate("config.categories.hint_nsfw"));
+			ImGui.Text(this.Locale.Translate("config.categories.hint_nsfw"));
 		}
 		
 		ImGui.Spacing();
-		ImGui.Text(this._context.Current.Locale.Translate("config.categories.header"));
+		ImGui.Text(this.Locale.Translate("config.categories.header"));
 		ImGui.Spacing();
 		this._boneCategories.Draw();
 	}
@@ -95,10 +98,10 @@ public class ConfigWindow : KtisisWindow {
 	// Gizmo
 
 	private void DrawGizmoTab() {
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
+		ImGui.Checkbox(this.Locale.Translate("config.gizmo.flip"), ref this.Config.Gizmo.AllowAxisFlip);
 		
 		ImGui.Spacing();
-		ImGui.Text(this._context.Current.Locale.Translate("config.gizmo.header"));
+		ImGui.Text(this.Locale.Translate("config.gizmo.header"));
 		ImGui.Spacing();
 		this._gizmoStyle.Draw();
 	}
@@ -106,27 +109,27 @@ public class ConfigWindow : KtisisWindow {
 	// Overlay
 
 	private void DrawOverlayTab() {
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.lines.draw"), ref this.Config.Overlay.DrawLines);
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.lines.draw_gizmo"), ref this.Config.Overlay.DrawLinesGizmo);
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.dots.draw_gizmo"), ref this.Config.Overlay.DrawDotsGizmo);
 		ImGui.Spacing();
-		ImGui.DragFloat(this._context.Current.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
-		ImGui.DragFloat(this._context.Current.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
+		ImGui.DragFloat(this.Locale.Translate("config.overlay.dots.radius"), ref this.Config.Overlay.DotRadius, 0.1f);
+		ImGui.DragFloat(this.Locale.Translate("config.overlay.lines.thick"), ref this.Config.Overlay.LineThickness, 0.1f);
 		ImGui.Spacing();
-		ImGui.SliderFloat(this._context.Current.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
-		ImGui.SliderFloat(this._context.Current.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
+		ImGui.SliderFloat(this.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
+		ImGui.SliderFloat(this.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
 	}
 	
 	// Workspace
 	
 	private void DrawWorkspaceTab() {
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
+		ImGui.Checkbox(this.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
 	}
 	
 	// Input
 
 	private void DrawInputTab() {
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
+		ImGui.Checkbox(this.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
 		if (!this.Config.Keybinds.Enabled) return;
 		ImGui.Spacing();
 		this._keybinds.Draw();
@@ -138,18 +141,18 @@ public class ConfigWindow : KtisisWindow {
 	private void DrawAutoSaveTab() {
 		var cfg = this.Config.AutoSave;
 
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
-		ImGui.Checkbox(this._context.Current.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
+		ImGui.Checkbox(this.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
+		ImGui.Checkbox(this.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
 		
 		ImGui.Spacing();
 
-		ImGui.SliderInt(this._context.Current.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
-		ImGui.SliderInt(this._context.Current.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
+		ImGui.SliderInt(this.Locale.Translate("config.autosave.interval"), ref cfg.Interval, 10, 600, "%d s");
+		ImGui.SliderInt(this.Locale.Translate("config.autosave.count"), ref cfg.Count, 1, 20);
 		
 		ImGui.Spacing();
 		
-		ImGui.InputText(this._context.Current.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
-		ImGui.InputText(this._context.Current.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
+		ImGui.InputText(this.Locale.Translate("config.autosave.path"), ref cfg.FilePath, 256);
+		ImGui.InputText(this.Locale.Translate("config.autosave.dir"), ref cfg.FolderFormat, 256);
 		
 		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled)))
 			ImGui.TextUnformatted($"Example folder name: {this._format.Replace(cfg.FolderFormat)}");

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -56,12 +56,13 @@ public class ConfigWindow : KtisisWindow {
 	public override void Draw() {
 		using var tabs = ImRaii.TabBar("##ConfigTabs");
 		if (!tabs.Success) return;
-		DrawTab(this._context.Current.Locale.Translate("config.categories.title"), this.DrawCategoriesTab);
-		DrawTab(this._context.Current.Locale.Translate("config.gizmo.title"), this.DrawGizmoTab);
-		DrawTab(this._context.Current.Locale.Translate("config.overlay.title"), this.DrawOverlayTab);
-		DrawTab(this._context.Current.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
-		DrawTab(this._context.Current.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
-		DrawTab(this._context.Current.Locale.Translate("config.input.title"), this.DrawInputTab);
+		//??? : how to access locale in Draw(), null reference when opening outside gpose
+		DrawTab("Categories", this.DrawCategoriesTab);
+		DrawTab("Gizmo", this.DrawGizmoTab);
+		DrawTab("Overlay", this.DrawOverlayTab);
+		DrawTab("Workspace", this.DrawWorkspaceTab);
+		DrawTab("AutoSave", this.DrawAutoSaveTab);
+		DrawTab("Input", this.DrawInputTab);
 	}
 	
 	// Tabs

--- a/Ktisis/Interface/Windows/TransformWindow.cs
+++ b/Ktisis/Interface/Windows/TransformWindow.cs
@@ -187,13 +187,13 @@ public class TransformWindow : KtisisWindow {
 
 	private void DrawBoneTransformSetup() {
 		ImGui.Spacing();
-		if (!ImGui.CollapsingHeader("Bone Transforms")) return;
+		if (!ImGui.CollapsingHeader(this._ctx.Locale.Translate($"transform_edit.transforms.title"))) return;
 		ImGui.Spacing();
 		
 		var cfg = this._ctx.Config.Gizmo;
-		ImGui.Checkbox("Bone parenting", ref cfg.ParentBones);
+		ImGui.Checkbox(this._ctx.Locale.Translate($"transform_edit.transforms.parenting"), ref cfg.ParentBones);
 		ImGui.Spacing();
-		ImGui.Checkbox("Relative rotation", ref cfg.RelativeBones);
+		ImGui.Checkbox(this._ctx.Locale.Translate($"transform_edit.transforms.relative"), ref cfg.RelativeBones);
 	}
 	
 	// IK Setup
@@ -201,11 +201,11 @@ public class TransformWindow : KtisisWindow {
 
 	private void DrawIkSetup(IIkNode ik) {
 		ImGui.Spacing();
-		if (!ImGui.CollapsingHeader("Inverse Kinematics")) return;
+		if (!ImGui.CollapsingHeader(this._ctx.Locale.Translate($"transform_edit.ik.title"))) return;
 		ImGui.Spacing();
 
 		var enable = ik.IsEnabled;
-		if (ImGui.Checkbox("Enable IK constraints", ref enable))
+		if (ImGui.Checkbox(this._ctx.Locale.Translate($"transform_edit.ik.enable"), ref enable))
 			ik.Toggle();
 
 		if (!ik.IsEnabled) return;
@@ -224,7 +224,7 @@ public class TransformWindow : KtisisWindow {
 		if (Buttons.IconButton(FontAwesomeIcon.EllipsisH))
 			ImGui.OpenPopup("##IkAdvancedCfg");
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		ImGui.Text("Advanced parameters");
+		ImGui.Text(this._ctx.Locale.Translate($"transform_edit.ik.advanced"));
 	}
 	
 	// CCD
@@ -240,8 +240,8 @@ public class TransformWindow : KtisisWindow {
 		
 		ImGui.Spacing();
 		
-		ImGui.SliderFloat("Gain", ref ik.Group.Gain, 0.0f, 1.0f, "%.2f");
-		ImGui.SliderInt("Iterations", ref ik.Group.Iterations, 0, 60);
+		ImGui.SliderFloat(this._ctx.Locale.Translate($"transform_edit.ik.ccd.gain"), ref ik.Group.Gain, 0.0f, 1.0f, "%.2f");
+		ImGui.SliderInt(this._ctx.Locale.Translate($"transform_edit.ik.ccd.iterations"), ref ik.Group.Iterations, 0, 60);
 		
 		ImGui.Spacing();
 	}
@@ -250,12 +250,12 @@ public class TransformWindow : KtisisWindow {
 
 	private void DrawTwoJoints(ITwoJointsNode ik) {
 		ImGui.Spacing();
-		ImGui.Checkbox("Enforce end rotation", ref ik.Group.EnforceRotation);
+		ImGui.Checkbox(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.enforce"), ref ik.Group.EnforceRotation);
 		ImGui.Spacing();
 		
-		ImGui.Text("Transform mode:");
-		DrawMode("Fixed target", TwoJointsMode.Fixed, ik.Group);
-		DrawMode("Bone relative", TwoJointsMode.Relative, ik.Group);
+		ImGui.Text(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.mode"));
+		DrawMode(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.fixed"), TwoJointsMode.Fixed, ik.Group);
+		DrawMode(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.relative"), TwoJointsMode.Relative, ik.Group);
 
 		if (ImGui.IsPopupOpen("##IkAdvancedCfg"))
 			this.DrawTwoJointsAdvanced(ik);
@@ -267,7 +267,7 @@ public class TransformWindow : KtisisWindow {
 		
 		ImGui.Spacing();
 
-		ImGui.Text("Gain:");
+		ImGui.Text(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.gain"));
 		ImGui.Spacing();
 		ImGui.SliderFloat("Shoulder##FirstWeight", ref ik.Group.FirstBoneGain, 0.0f, 1.0f, "%.2f");
 		ImGui.SliderFloat("Elbow##SecondWeight", ref ik.Group.SecondBoneGain, 0.0f, 1.0f, "%.2f");
@@ -277,7 +277,7 @@ public class TransformWindow : KtisisWindow {
 		ImGui.Separator();
 		ImGui.Spacing();
 		
-		ImGui.Text("Hinges:");
+		ImGui.Text(this._ctx.Locale.Translate($"transform_edit.ik.two_joints.hinges"));
 		ImGui.Spacing();
 		ImGui.SliderFloat("Minimum", ref ik.Group.MinHingeAngle, -1.0f, 1.0f, "%.2f");
 		ImGui.SliderFloat("Maximum", ref ik.Group.MaxHingeAngle, -1.0f, 1.0f, "%.2f");

--- a/Ktisis/Interface/Windows/WorkspaceWindow.cs
+++ b/Ktisis/Interface/Windows/WorkspaceWindow.cs
@@ -78,30 +78,30 @@ public class WorkspaceWindow : KtisisWindow {
 	private void DrawContextButtons() {
 		var spacing = ImGui.GetStyle().ItemInnerSpacing.X;
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.ArrowsAlt, "Transform Editor"))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.ArrowsAlt, this._ctx.Locale.Translate("camera_edit.transform_edit.title")))
 			this.Interface.OpenTransformWindow();
 
 		ImGui.SameLine(0, spacing);
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sun, "Environment Editor"))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sun, this._ctx.Locale.Translate("camera_edit.env_edit.title")))
 			this.Interface.OpenEnvironmentWindow();
 
 		ImGui.SameLine(0, spacing);
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Cog, "Settings"))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Cog, this._ctx.Locale.Translate("camera_edit.config.title")))
 			this.Interface.OpenConfigWindow();
 
 		ImGui.SameLine(0, spacing);
 		ImGui.SetCursorPosX(ImGui.GetContentRegionMax().X - Buttons.CalcSize() * 2 - spacing);
 		
 		using (var _ = ImRaii.Disabled(!this._ctx.Actions.History.CanUndo))
-			if (Buttons.IconButtonTooltip(FontAwesomeIcon.StepBackward, "Undo"))
+			if (Buttons.IconButtonTooltip(FontAwesomeIcon.StepBackward, this._ctx.Locale.Translate("actions.History_Undo")))
 				this._ctx.Actions.History.Undo();
 		
 		ImGui.SameLine(0, spacing);
 		
 		using (var _ = ImRaii.Disabled(!this._ctx.Actions.History.CanRedo))
-			if (Buttons.IconButtonTooltip(FontAwesomeIcon.StepForward, "Redo"))
+			if (Buttons.IconButtonTooltip(FontAwesomeIcon.StepForward, this._ctx.Locale.Translate("actions.History_Redo")))
 				this._ctx.Actions.History.Redo();
 	}
 	

--- a/Ktisis/Interface/Windows/WorkspaceWindow.cs
+++ b/Ktisis/Interface/Windows/WorkspaceWindow.cs
@@ -78,17 +78,17 @@ public class WorkspaceWindow : KtisisWindow {
 	private void DrawContextButtons() {
 		var spacing = ImGui.GetStyle().ItemInnerSpacing.X;
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.ArrowsAlt, this._ctx.Locale.Translate("camera_edit.transform_edit.title")))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.ArrowsAlt, this._ctx.Locale.Translate("transform_edit.title")))
 			this.Interface.OpenTransformWindow();
 
 		ImGui.SameLine(0, spacing);
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sun, this._ctx.Locale.Translate("camera_edit.env_edit.title")))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Sun, this._ctx.Locale.Translate("env_edit.title")))
 			this.Interface.OpenEnvironmentWindow();
 
 		ImGui.SameLine(0, spacing);
 		
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Cog, this._ctx.Locale.Translate("camera_edit.config.title")))
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Cog, this._ctx.Locale.Translate("config.title")))
 			this.Interface.OpenConfigWindow();
 
 		ImGui.SameLine(0, spacing);

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -58,6 +58,7 @@
 	},
 	
 	"workspace": {
+		"title": "Ktisis Workspace",
 		"state": {
 			"dormant": "Waiting for scene...",
 			"select_count": {
@@ -93,6 +94,28 @@
 		"gizmo": {
 			"show": "Show rotation gizmo",
 			"hide": "Hide rotation gizmo"
+		},
+		"transforms": {
+			"title": "Bone Transforms",
+			"parenting": "Bone parenting",
+			"relative": "Relative rotation"
+		},
+		"ik": {
+			"title": "Inverse Kinematics",
+			"enable": "Enable IK constraints",
+			"advanced": "Advanced parameters",
+			"ccd": {
+				"gain": "Gain",
+				"iterations": "Iterations"
+			},
+			"two_joints": {
+				"enforce": "Enforce end rotation",
+				"mode": "Transform mode:",
+				"fixed": "Fixed target",
+				"relative": "Bone relative",
+				"gain": "Gain:",
+				"hinges": "Hinges:"
+			}
 		}
 	},
 	
@@ -102,11 +125,130 @@
 	},
 	
 	"camera_edit": {
-		"title": "Camera Editor"
+		"title": "Camera Editor",
+		"toggles": {
+			"collide": "Collision",
+			"delimit": "Delimited",
+			"ortho": "Orthographic"
+		},
+		"sliders": {
+			"rotation": "Camera rotation",
+			"zoom": "Camera zoom",
+			"distance": "Camera distance",
+			"ortho_zoom": "Orthographic camera zoom"
+		},
+		"position": {
+			"lock": "Lock to fixed position",
+			"unlock": "Unlock fixed position"
+		},
+		"orbit": {
+			"lock": "Lock orbit target",
+			"unlock": "Unlock orbit target"
+		},
+		"offset": {
+			"to_target": "Offset camera to target model",
+			"from_base": "Offset from base position"
+		},
+		"pan": "Camera pan",
+		"angle": "Camera orbit angle"
 	},
 	
 	"env_edit": {
 		"title": "Environment Editor"
+	},
+
+	"config": {
+		"title": "Ktisis Settings",
+		"categories": {
+			"title": "Categories",
+			"allow_nsfw": "Display NSFW categories",
+			"hint_nsfw": "Requires IVCS or any custom skeleton",
+			"header": "Categories:",
+			"editor": {
+				"color_header": "Colors:",
+				"group_color": "Group Color",
+				"bone_color": "Bone Color",
+				"subcategories": "Apply to subcategories",
+				"link_colors": "Link group & bone colors"
+			}
+		},
+		"gizmo": {
+			"title": "Gizmo",
+			"flip": "Flip axis to face camera",
+			"header": "Style:",
+			"editor": {
+				"general": {
+					"title": "General",
+					"dir_x": "Direction X",
+					"dir_y": "Direction Y",
+					"dir_z": "Direction Z",
+					"active": "Selected Color",
+					"inactive": "Inactive Color"
+				},
+				"position": {
+					"title": "Position",
+					"line_thick": "Line Thickness",
+					"line_color": "Line Color",
+					"axis_thick": "Hatched Axis Thickness",
+					"axis_color": "Hatched Axis Color",
+					"circle_size": "Center Circle Size",
+					"arrow_size": "Arrow Size",
+					"plane_x": "Plane X",
+					"plane_y": "Plane Y",
+					"plane_z": "Plane Z"
+				},
+				"rotation": {
+					"title": "Rotation",
+					"inner_thick": "Inner Line Thickness",
+					"outer_thick": "Outer Line Thickness",
+					"border_color": "Activated Border Color",
+					"fill_color": "Activated Fill Color"
+				},
+				"scale": {
+					"title": "Scale",
+					"line_thick": "Line Thickness",
+					"line_color": "Activated Line Color",
+					"circle_size": "Circle Size"
+				},
+				"text": {
+					"title": "Text",
+					"color": "Text Color",
+					"shadow_color": "Shadow Color"
+				},
+				"undo": "Reset to default"
+			}
+		},
+		"overlay": {
+			"title": "Overlay",
+			"lines": {
+				"draw": "Draw lines on skeleton",
+				"draw_gizmo": "Draw lines on skeleton while using gizmo",
+				"thick": "Line thickness",
+				"opacity": "Line opacity",
+				"opacity_gizmo": "Line opacity while using gizmo"
+			},
+			"dots": {
+				"draw_gizmo": "Draw dots while using gizmo",
+				"radius": "Dot radius"
+			}
+		},
+		"workspace": {
+			"title": "Workspace",
+			"init": "Open on entering GPose"
+		},
+		"input": {
+			"title": "Input",
+			"enable": "Enable keybinds"
+		},
+		"autosave": {
+			"title": "AutoSave",
+			"enable": "Enable auto saves",
+			"clear": "Clear auto saves on exit",
+			"interval": "Save interval",
+			"count": "Save count",
+			"path": "Save path",
+			"dir": "Folder name"
+		}
 	},
 
 	"bone": {


### PR DESCRIPTION
- expands the transform editor locale dict for new 0.3 functionality
- adds tooltips and locale strings for camera editor icons (restored functionality from main branch)
- adds locale dict for config/settings menus

left the environment editor strings as is til testing phase/0.3 release per https://github.com/ktisis-tools/Ktisis/pull/113#issuecomment-1883976124