### PR TITLE
Correct Handling of Partial sklbs with >1 Root Bone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## More VS shit
 
+.vscode/
 .vs/
 obj/
 bin/

--- a/Ktisis/Editor/Posing/HavokPosing.cs
+++ b/Ktisis/Editor/Posing/HavokPosing.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Collections.Generic;
 
 using Dalamud.Utility;
 
@@ -78,23 +79,37 @@ public static class HavokPosing {
 		for (var p = 0; p < skele->PartialSkeletonCount; p++) {
 			var subPartial = skele->PartialSkeletons[p];
 			var subPose = subPartial.GetHavokPose(0);
+			var subSkele = subPose->Skeleton;
 			if (subPose == null) continue;
 
-			var rootBone = subPartial.ConnectedBoneIndex;
-			var parentBone = subPartial.ConnectedParentBoneIndex;
-			if (parentBone != boneIx && !IsBoneDescendantOf(hkaSkele->ParentIndices, parentBone, boneIx))
-				continue;
-			
-			Propagate(subPose, rootBone, sourcePos, deltaPos, deltaRot);
+			if (!IsMultiRootSkeleton(subSkele->ParentIndices)) {
+				// propagate normally if this is a single-binding partial (i.e. hair, face to j_kao)
+				var rootBone = subPartial.ConnectedBoneIndex;
+				var parentBone = subPartial.ConnectedParentBoneIndex;
+				if (parentBone != boneIx && !IsBoneDescendantOf(hkaSkele->ParentIndices, parentBone, boneIx)) continue;
+				Propagate(subPose, rootBone, sourcePos, deltaPos, deltaRot);
+			} else {
+				// propagate against each root in a multi-root partial (i.e. j_ex_top_a_l to j_ude_a_l && j_ex_top_a_r to j_ude_a_r)
+				var multi_roots = GetMultiRoots(subSkele->ParentIndices);
+				foreach(int root_idx in multi_roots) {
+					var parent_root_idx = TryGetBoneNameIndex(pose, subSkele->Bones[root_idx].Name.String);
+
+					// account for either:
+					// 1. boneIx being posed refers to the same bone as a root_idx
+					// 2. boneIx being posed is the parent of a root_idx within the parent skeleton
+					bool manipulated_bone_is_multi_root = hkaSkele->Bones[boneIx].Name.String == subSkele->Bones[root_idx].Name.String;
+					bool manipulated_bone_is_parent = parent_root_idx != -1 ? IsBoneDescendantOf(hkaSkele->ParentIndices, parent_root_idx, boneIx) : false;
+					if (manipulated_bone_is_multi_root || manipulated_bone_is_parent) Propagate(subPose, root_idx, sourcePos, deltaPos, deltaRot);
+				}
+			}
 		}
 	}
 
 	private unsafe static void Propagate(hkaPose* pose, int boneIx, Vector3 sourcePos, Vector3 deltaPos, Quaternion deltaRot) {
 		var hkaSkele = pose->Skeleton;
 		for (var i = boneIx; i < hkaSkele->Bones.Length; i++) {
-			if (!IsBoneDescendantOf(hkaSkele->ParentIndices, i, boneIx))
-				continue;
-			
+			if (!IsBoneDescendantOf(hkaSkele->ParentIndices, i, boneIx)) continue;
+
 			var trans = GetModelTransform(pose, i)!;
 			var scm = Matrix4x4.CreateScale(trans.Scale);
 			var rtm = Matrix4x4.CreateFromQuaternion(deltaRot * trans.Rotation);
@@ -176,7 +191,9 @@ public static class HavokPosing {
 	// Bone descendants
 
 	public static bool IsBoneDescendantOf(hkArray<short> indices, int bone, int parent) {
-		if (parent < 1) return true;
+		// only shortcut out of descendant evaluation if this is a single-root skeleton,
+		// and parent is the 0 index
+		if (!IsMultiRootSkeleton(indices) && parent < 1) return true;
 		
 		var p = indices[bone];
 		while (p != -1) {
@@ -185,5 +202,19 @@ public static class HavokPosing {
 			p = indices[p];
 		}
 		return false;
+	}
+
+	// Helpers for multi-binding partials
+	public static bool IsMultiRootSkeleton(hkArray<short> indices) {
+		if (GetMultiRoots(indices).Count > 1) return true;
+		return false;
+	}
+
+	public static List<int> GetMultiRoots(hkArray<short> indices) {
+		List<int> parent_indices = new();
+		for(var p = 0; p < indices.Length; p++) {
+			if (indices[p] == -1) parent_indices.Add(p);
+		}
+		return parent_indices;
 	}
 }

--- a/Ktisis/Editor/Posing/HavokPosing.cs
+++ b/Ktisis/Editor/Posing/HavokPosing.cs
@@ -78,10 +78,12 @@ public static class HavokPosing {
 		var hkaSkele = pose->Skeleton;
 		for (var p = 0; p < skele->PartialSkeletonCount; p++) {
 			var subPartial = skele->PartialSkeletons[p];
+			if (subPartial.HavokPoses == null) continue;
+
 			var subPose = subPartial.GetHavokPose(0);
-			var subSkele = subPose->Skeleton;
 			if (subPose == null) continue;
 
+			var subSkele = subPose->Skeleton;
 			if (!IsMultiRootSkeleton(subSkele->ParentIndices)) {
 				// propagate normally if this is a single-binding partial (i.e. hair, face to j_kao)
 				var rootBone = subPartial.ConnectedBoneIndex;

--- a/Ktisis/Editor/Posing/Types/BoneEnumerator.cs
+++ b/Ktisis/Editor/Posing/Types/BoneEnumerator.cs
@@ -40,6 +40,8 @@ public class BoneEnumerator {
 
 			if (this.Index == 0 && name == "j_ago") continue; // :)
 
+			if (parents[i] == -1) continue; // handle multi-root partials; should we instead filter out any bones from bones with -1?
+
 			yield return new PartialBoneInfo {
 				Name = name,
 				BoneIndex = i,


### PR DESCRIPTION
### Issue
via [two different](https://discord.com/channels/975894364020686878/1230653736343441468) discord [issue reports](https://discord.com/channels/975894364020686878/1156744104005341314), Ktisis has historically failed to handle propagating bone transform changes to portions of partial extra skeletons which have more than 1 root node or binding point. propagation is applied to all bones in the partial skeleton when transforming the first-identified root node in the partial, and does not apply when transforming bones that should parent/propagate to those in the partial related to any latter root nodes. this behavior is present on v0.3 and main branch

this can be observed with the extra sklb loaded by the  Far Eastern Schoolgirl's and Schoolboy's Hakama, as well as any other sklbs which define multiple root nodes (usually used with long-sleeved gear for physics)

### Gap
HavokPosing's interpretation of partial skeletons assumes:
- a partial will only have one bind point to the parent skeleton; i.e. only one entry in ParentIndices for a partial will have a -1 value
- the singular binding node will be at index 0 of hkaSkele->ParentIndices with a value of -1
- so long as a partial's bind point is a descendant of the boneIx being manipulated in the parent skeleton, all bones defined by the partial must be descendants of boneIx and propagate accordingly

### Fix
to avoid rewriting the entire HavokPosing file or establishing a completely new way of handling child-parent bone relations (ala VFXEdit's use of [LayerOffset](https://github.com/aers/FFXIVClientStructs/blob/9eebb0e213a9765e7ea8fedbaf0e1d49b15e4a82/FFXIVClientStructs/FFXIV/Client/System/Resource/Handle/SkeletonResourceHandle.cs#L12) values to determine roots/priority, or brio's custom mapping into bone relationships), this commit:
- adds helpers to determine when a given sklb has >1 root node (determined by multiple `-1` values in `hkaSkeleton->ParentIndices`)
- checks for a multi-root skeleton before running the `parent < 1` shortcut in `IsBoneDescendantOf()`
- allows `Propagate()` to trigger a partial propagate onto either a single-root partial or a multi-root partial
  - single-root logic is unchanged
  - multi-root logic evaluates the following for each bind point in a multi-root sklb:
    - if the bone being posed is a hierarchical parent of this root bone on the parent skeleton, call Propagate on this subPose for the partial index
    - if the bone being posed IS the root bone (determined by name comparison btwn partial and parent skeleton), call Propagate

### Addtl Fixes
1. correct a NullReference exception which can occur from HavokPosing when a partial skeleton index exists but has no data behind it due to the character having changed gear, but not fully reinstanced/cleaned out partial data. if a null subPartial is identified in Propagate, should be skipped to prevent jitters and error throws - https://discord.com/channels/975894364020686878/1004359659613859910/1233494906547474523
2. prevents BoneEnumerator from adding an additional copy of a multi-root partial skeleton's secondary/tertiary binding bones in the same hierarchy position as the main skeleton's version of that bone. multi-roots should now correctly parent both/all sections to the root skeleton, rather than just one (thanks Cordelia for showing me this) - https://discord.com/channels/975894364020686878/1004359659613859910/1233279681915125771