### PR TITLE
Fix Bone Node Selection when releasing Gizmo LMB

### DIFF
--- a/Ktisis/Interface/Overlay/OverlayWindow.cs
+++ b/Ktisis/Interface/Overlay/OverlayWindow.cs
@@ -57,7 +57,7 @@ public class OverlayWindow : KtisisWindow {
 		//t.Start();
 		
 		var gizmo = this.DrawGizmo();
-		this._sceneDraw.DrawScene(gizmo: gizmo);
+		this._sceneDraw.DrawScene(gizmo: gizmo, gizmo_isEnded: this._gizmo.IsEnded);
 		
 		//t.Stop();
 		//this.DrawDebug(t);

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -34,10 +34,10 @@ public class SceneDraw {
 
 	public void SetContext(IEditorContext ctx) => this._ctx = ctx;
 	
-	public void DrawScene(bool gizmo = false) {
+	public void DrawScene(bool gizmo = false, bool gizmo_isEnded = false) {
 		var frame = this._select.BeginFrame();
 		this.DrawEntities(frame, this._ctx.Scene.Children);
-		this.DrawSelect(frame, gizmo);
+		this.DrawSelect(frame, gizmo, gizmo_isEnded);
 	}
 	
 	private void DrawEntities(ISelectableFrame frame, IEnumerable<SceneEntity> entities) {
@@ -110,9 +110,10 @@ public class SceneDraw {
 		drawList.AddLine(fromPos2d, toPos2d, color.SetAlpha(opacity), this.Config.LineThickness);
 	}
 	
-	private void DrawSelect(ISelectableFrame frame, bool gizmo) {
+	private void DrawSelect(ISelectableFrame frame, bool gizmo, bool gizmo_isEnded) {
 		var result = this._select.Draw(frame, out var clicked, gizmo);
 		if (!result || clicked == null) return;
+		if (gizmo && gizmo_isEnded) return;
 		var mode = GuiHelpers.GetSelectMode();
 		this._ctx.Selection.Select(clicked, mode);
 	}


### PR DESCRIPTION
surfaces guizmo's `IsEnded` bool to SceneDraw.cs to add a check of whether or not LMB is being released over a selectable node on the same frame as the gizmo is being released; if so, prevents selection on that frame and keeps the gizmo bound to its active bone.

solves discord issue https://discord.com/channels/975894364020686878/1208582987034402866 , reported behavior is present in 0.3 and main branch

vid example of updated behavior (contrast with nanami's video in the issue thread)

https://github.com/ktisis-tools/Ktisis/assets/102061785/5acc590e-2a8f-4091-8784-85537ff9800b

