### PR TITLE
add addtl ear type checks for isbunny

### DIFF
--- a/Ktisis/Scene/Entities/Skeleton/EntityPose.cs
+++ b/Ktisis/Scene/Entities/Skeleton/EntityPose.cs
@@ -158,7 +158,14 @@ public class EntityPose : SkeletonGroup, ISkeleton, IConfigurable {
 	// Human features
 
 	private bool HasTail() => this.FindBoneByName("n_sippo_a") != null;
-	private bool HasEars() => this.FindBoneByName("j_zera_a_l") != null;
+	private bool HasEars() {
+		return (
+			this.FindBoneByName("j_zera_a_l") != null
+			|| this.FindBoneByName("j_zerb_a_l") != null
+			|| this.FindBoneByName("j_zerc_a_l") != null
+			|| this.FindBoneByName("j_zerd_a_l") != null
+		);
+	}
 	
 	public void CheckFeatures(out bool hasTail, out bool isBunny) {
 		hasTail = this.HasTail();


### PR DESCRIPTION
should check for all of zera thru zerd now
NOTE: if ears change style on the actor mid-pose thru glamourer, ktisis may fall out of sync for the pose view bone pips. this doesn't happen when using ktisis' appearance editor tho
![image](https://github.com/user-attachments/assets/9f707080-558e-4b6f-903e-eda25cc8b962)
