### PR TITLE
Add "Anchor group positions" for selected bone imports

### DIFF
--- a/Ktisis/Actions/Types/MultipleMemento.cs
+++ b/Ktisis/Actions/Types/MultipleMemento.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+using Ktisis.Actions.Types;
+using Ktisis.Editor.Posing.Types;
+
+namespace Ktisis.Editor.Posing.Data;
+
+public class MultipleMemento(IReadOnlyList<IMemento?> mementos) : IMemento {
+	public IReadOnlyList<IMemento?> Mementos => mementos;
+
+	public void Restore() {
+		for (int i = mementos.Count - 1; i >= 0; i--) {
+			mementos[i]?.Restore();
+		}
+	}
+		
+	public void Apply() {
+		for (int i = 0; i < mementos.Count; i++) {
+			mementos[i]?.Apply();
+		}
+	}
+}

--- a/Ktisis/Data/Config/Sections/FileConfig.cs
+++ b/Ktisis/Data/Config/Sections/FileConfig.cs
@@ -13,5 +13,6 @@ public class FileConfig {
 	public bool ImportNpcApplyOnSelect = false;
 	
 	public bool ImportPoseSelectedBones = false;
+	public bool AnchorPoseSelectedBones = false;
 	public PoseTransforms ImportPoseTransforms = PoseTransforms.Rotation;
 }

--- a/Ktisis/Editor/Posing/Data/EntityPoseConverter.cs
+++ b/Ktisis/Editor/Posing/Data/EntityPoseConverter.cs
@@ -87,10 +87,10 @@ public class EntityPoseConverter(EntityPose target) {
 	
 	// Filter container
 
-	public unsafe PoseContainer FilterSelectedBones(PoseContainer pose) {
+	public unsafe PoseContainer FilterSelectedBones(PoseContainer pose, bool all = true) {
 		var result = new PoseContainer();
 
-		var bones = this.GetSelectedBones().ToList();
+		var bones = this.GetSelectedBones(all).ToList();
 		foreach (var bone in bones) {
 			if (pose.TryGetValue(bone.Name, out var value))
 				result[bone.Name] = value;
@@ -157,22 +157,22 @@ public class EntityPoseConverter(EntityPose target) {
 	
 	// Iterate selected bones
 
-	public IEnumerable<PartialBoneInfo> GetSelectedBones() {
+	public IEnumerable<PartialBoneInfo> GetSelectedBones(bool all = true) {
 		var selected = target.Recurse()
 			.Prepend(target)
 			.Where(entity => entity is SkeletonNode { IsSelected: true })
 			.Cast<SkeletonNode>();
-		return this.GetBoneSelectionFrom(selected).Distinct();
+		return this.GetBoneSelectionFrom(selected, all).Distinct();
 	}
 
-	private IEnumerable<PartialBoneInfo> GetBoneSelectionFrom(IEnumerable<SkeletonNode> nodes) {
+	private IEnumerable<PartialBoneInfo> GetBoneSelectionFrom(IEnumerable<SkeletonNode> nodes, bool all = true) {
 		foreach (var node in nodes) {
 			switch (node) {
 				case BoneNode bone:
 					yield return bone.Info;
 					continue;
 				case SkeletonGroup group:
-					foreach (var bone in this.GetBoneSelectionFrom(group.GetAllBones()))
+					foreach (var bone in this.GetBoneSelectionFrom(all ? group.GetAllBones() : group.GetIndividualBones()))
 						yield return bone;
 					continue;
 				default:

--- a/Ktisis/Editor/Posing/Types/IPosingManager.cs
+++ b/Ktisis/Editor/Posing/Types/IPosingManager.cs
@@ -27,6 +27,6 @@ public interface IPosingManager : IDisposable {
 
 	public Task ApplyReferencePose(EntityPose pose);
 
-	public Task ApplyPoseFile(EntityPose pose, PoseFile file, PoseTransforms transforms = PoseTransforms.Rotation, bool selectedBones = false);
+	public Task ApplyPoseFile(EntityPose pose, PoseFile file, PoseTransforms transforms = PoseTransforms.Rotation, bool selectedBones = false, bool anchorGroups = false);
 	public Task<PoseFile> SavePoseFile(EntityPose pose);
 }

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -93,8 +93,12 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 	}
 
 	private void DrawApplyModes(bool isSelectBones) {
-		using var _ = ImRaii.Disabled(!isSelectBones);
-		ImGui.Checkbox("Apply selected bones", ref this._ctx.Config.File.ImportPoseSelectedBones);
+		using (ImRaii.Disabled(!isSelectBones))
+			ImGui.Checkbox("Apply selected bones", ref this._ctx.Config.File.ImportPoseSelectedBones);
+
+		var hasPosition = this._ctx.Config.File.ImportPoseTransforms.HasFlag(PoseTransforms.Position);
+		using (ImRaii.Disabled(!isSelectBones || !this._ctx.Config.File.ImportPoseSelectedBones || !hasPosition))
+			ImGui.Checkbox("Anchor group positions", ref this._ctx.Config.File.AnchorPoseSelectedBones);
 	}
 	
 	// Apply pose
@@ -108,6 +112,7 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 
 		var transforms = this._ctx.Config.File.ImportPoseTransforms;
 		var selectedBones = isSelectBones && this._ctx.Config.File.ImportPoseSelectedBones;
-		this._ctx.Posing.ApplyPoseFile(pose, file, transforms, selectedBones);
+		var anchorGroups = this._ctx.Config.File.AnchorPoseSelectedBones;
+		this._ctx.Posing.ApplyPoseFile(pose, file, transforms, selectedBones, anchorGroups);
 	}
 }


### PR DESCRIPTION
This PR adds a new toggle to the import window that saves and reapplies the individual bone positions of selected groups when importing poses on selected bones only. In other words: It anchors your shoulders and necks if you try to import poses with positions on those, making face pose imports with positions a bit less tedious to deal with.

I didn't want to mess too much with how poses get applied and keep my changes minimal, hence the addition of `MultipleMemento` to make "replicating" the manual steps automatically a bit easier.

https://github.com/user-attachments/assets/64859c5d-f91c-4cbf-8c92-a9e406f58c5e

