### PR TITLE
fix for Highlander face customizations

### DIFF
--- a/Ktisis/Editor/Characters/CharacterModule.cs
+++ b/Ktisis/Editor/Characters/CharacterModule.cs
@@ -137,9 +137,16 @@ public class CharacterModule : HookModule {
 		if (state.Customize.IsSet(CustomizeIndex.Tribe) || state.Customize.IsSet(CustomizeIndex.FaceType)) {
 			var dataId = this._discovery.CalcDataIdFor(customize->Tribe, customize->Gender);
 			var isValid = this._discovery.IsFaceIdValidFor(dataId, customize->FaceType);
+
 			Ktisis.Log.Debug($"Face {customize->FaceType} for {dataId} is valid? {isValid}");
 			if (!isValid) {
-				var newId = this._discovery.FindBestFaceTypeFor(dataId, customize->FaceType);
+				// highlander patch
+				var newId = customize->FaceType;
+				if (customize->Tribe == Tribe.Highlander && newId < 101) {
+					newId += 100;
+				} else {
+					newId = this._discovery.FindBestFaceTypeFor(dataId, customize->FaceType);
+				}
 				Ktisis.Log.Debug($"\tSetting {newId} as next best face type");
 				state.Customize.SetIfActive(CustomizeIndex.FaceType, newId);
 				customize->FaceType = newId;

--- a/Ktisis/Editor/Characters/Make/MakeTypeData.cs
+++ b/Ktisis/Editor/Characters/Make/MakeTypeData.cs
@@ -210,10 +210,11 @@ public class MakeTypeData {
 			var dataId = discover.CalcDataIdFor(data.Tribe, data.Gender);
 			
 			var face = data.GetFeature(CustomizeIndex.FaceType);
+			// TODO cleanup highlander face selections
 			if (face != null) {
 				var faceIds = discover.GetFaceTypes(dataId)
 					.Except(face.Params.Select(param => param.Value));
-				if (data.Tribe is Tribe.Dunesfolk or Tribe.Hellsguard or Tribe.MoonKeeper)
+				if (data.Tribe is Tribe.Dunesfolk or Tribe.Hellsguard or Tribe.MoonKeeper or Tribe.Duskwight)
 					faceIds = faceIds.Except(face.Params.Select(param => (byte)(param.Value + 100)));
 				ConcatFeatIds(face, faceIds);
 			}


### PR DESCRIPTION
discord issue thread: [https://discord.com/channels/975894364020686878/1269256354342899823](https://discord.com/channels/975894364020686878/1269256354342899823)

### problem
M/F highlanders are unable to change faces from option 4 in the appearance editor
this is a byproduct of SE's wacko structuring of the highlander tribe vs all others. other ARR sub-races load different faces just fine as there's still a 000X facetype for them beneath the 010X where their own models are stored. highlanders though _only_ have 010X offset faces, despite the internal IDs of these and their icons being 1,2,3, and 4 (not 101-104)

### changes
- add an offset of 100 for Highlander FaceTypes when making a customize change, instead of using the FindBestFaceTypeFor fallback logic for them
- misc fix to prevent showing duskwight sub-race faces 101-104 like with other ARR sub-races

there's probably cleaner ways to do this as it makes the face selector a bit janky
![image](https://github.com/user-attachments/assets/24a2772c-caf6-407b-a5f5-2e15535dd179)
