### PR TITLE
add optional localization tickbox to config.Categories

### DIFF
--- a/Ktisis/Data/Config/Sections/CategoryConfig.cs
+++ b/Ktisis/Data/Config/Sections/CategoryConfig.cs
@@ -14,6 +14,7 @@ public class CategoryConfig {
 
 	public bool ShowNsfwBones = true;
 	public bool ShowAllVieraEars = false;
+	public bool ShowFriendlyBoneNames = true;
     
 	// Default category
 	

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -94,6 +94,8 @@ public class ConfigWindow : KtisisWindow {
 		this.DrawHint("config.categories.hint_nsfw");
 		refresh |= ImGui.Checkbox(this.Locale.Translate("config.categories.show_all_viera_ears"), ref this.Config.Categories.ShowAllVieraEars);
 		this.DrawHint("config.categories.hint_viera_ears");
+		refresh |= ImGui.Checkbox(this.Locale.Translate("config.categories.show_friendly_bone_names"), ref this.Config.Categories.ShowFriendlyBoneNames);
+		this.DrawHint("config.categories.hint_friendly_bones");
 		if (refresh) this.RefreshScene();
 		
 		ImGui.Spacing();

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -94,7 +94,7 @@ public class ConfigWindow : KtisisWindow {
 		this.DrawHint("config.categories.hint_nsfw");
 		refresh |= ImGui.Checkbox(this.Locale.Translate("config.categories.show_all_viera_ears"), ref this.Config.Categories.ShowAllVieraEars);
 		this.DrawHint("config.categories.hint_viera_ears");
-		refresh |= ImGui.Checkbox(this.Locale.Translate("config.categories.show_friendly_bone_names"), ref this.Config.Categories.ShowFriendlyBoneNames);
+		ImGui.Checkbox(this.Locale.Translate("config.categories.show_friendly_bone_names"), ref this.Config.Categories.ShowFriendlyBoneNames);
 		this.DrawHint("config.categories.hint_friendly_bones");
 		if (refresh) this.RefreshScene();
 		

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -172,6 +172,8 @@
 			"hint_nsfw": "Requires IVCS or any custom skeleton",
 			"show_all_viera_ears": "Show unused ear bones",
 			"hint_viera_ears": "Show bones for all viera ears, including those for other ear options.",
+			"show_friendly_bone_names": "Display friendly bone names",
+			"hint_friendly_bones": "Use localized names for bones where available, rather than SE defaults.",
 			"header": "Categories:",
 			"editor": {
 				"color_header": "Colors:",

--- a/Ktisis/Localization/LocaleManager.cs
+++ b/Ktisis/Localization/LocaleManager.cs
@@ -50,7 +50,8 @@ public class LocaleManager {
 
 	public string GetBoneName(string name) {
 		var key = $"bone.{name}";
-		return this.HasTranslationFor(key) ? this.Translate(key) : name;
+		var friendly_bone_names = this._cfg.File.Categories.ShowFriendlyBoneNames;
+		return friendly_bone_names && this.HasTranslationFor(key) ? this.Translate(key) : name;
 	}
 
 	public string GetCategoryName(BoneCategory category) {


### PR DESCRIPTION
this may be a small use case so review at your discretion, but in the course of modding users will often need to check the weights/visibility of particular bones in the armature by referencing their formal SE/JP name instead of a localized one. this PR adds a checkbox (defaulted to true) to always show localized names where available when in use, which preserves the current behavior. when ticked off, untranslated names (ala j_kami, j_kao, iv_sippo_a) will be shown for bones in the node list and overlay instead. if there's ever an Experimental/goof-proof settings tab, this might belong in there instead

![image](https://github.com/user-attachments/assets/2ed216aa-297e-4b1f-86b4-696c2f98fe9f)
