### PR TITLE
Add option to refresh gpose actors.

### DIFF
--- a/Ktisis/Editor/Context/ContextBuilder.cs
+++ b/Ktisis/Editor/Context/ContextBuilder.cs
@@ -31,7 +31,8 @@ public class ContextBuilder {
 	private readonly IKeyState _keyState;
 	private readonly NamingService _naming;
 	private readonly FormatService _format;
-	
+	private readonly ActorService _actorService;
+
 	public ContextBuilder(
 		GPoseService gpose,
 		InteropService interop,
@@ -39,7 +40,8 @@ public class ContextBuilder {
 		IDataManager data,
 		IKeyState keyState,
 		NamingService naming,
-		FormatService format
+		FormatService format,
+		ActorService actorService
 	) {
 		this._gpose = gpose;
 		this._interop = interop;
@@ -48,6 +50,7 @@ public class ContextBuilder {
 		this._keyState = keyState;
 		this._naming = naming;
 		this._format = format;
+		this._actorService = actorService;
 	}
 
 	public IEditorContext Create(
@@ -69,7 +72,7 @@ public class ContextBuilder {
 			Animation = new AnimationManager(context, scope, this._data, this._framework),
 			Cameras = new CameraManager(context, scope),
 			Characters = new CharacterManager(context, scope, this._framework),
-			Interface = new EditorInterface(context, state.Gui),
+			Interface = new EditorInterface(context, state.Gui, this._actorService),
 			Posing = new PosingManager(context, scope, this._framework, attach, autoSave),
 			Scene = new SceneManager(context, scope, factory),
 			Selection = select,

--- a/Ktisis/Editor/Context/ContextBuilder.cs
+++ b/Ktisis/Editor/Context/ContextBuilder.cs
@@ -31,7 +31,6 @@ public class ContextBuilder {
 	private readonly IKeyState _keyState;
 	private readonly NamingService _naming;
 	private readonly FormatService _format;
-	private readonly ActorService _actorService;
 
 	public ContextBuilder(
 		GPoseService gpose,
@@ -40,8 +39,7 @@ public class ContextBuilder {
 		IDataManager data,
 		IKeyState keyState,
 		NamingService naming,
-		FormatService format,
-		ActorService actorService
+		FormatService format
 	) {
 		this._gpose = gpose;
 		this._interop = interop;
@@ -50,7 +48,6 @@ public class ContextBuilder {
 		this._keyState = keyState;
 		this._naming = naming;
 		this._format = format;
-		this._actorService = actorService;
 	}
 
 	public IEditorContext Create(
@@ -72,7 +69,7 @@ public class ContextBuilder {
 			Animation = new AnimationManager(context, scope, this._data, this._framework),
 			Cameras = new CameraManager(context, scope),
 			Characters = new CharacterManager(context, scope, this._framework),
-			Interface = new EditorInterface(context, state.Gui, this._actorService),
+			Interface = new EditorInterface(context, state.Gui),
 			Posing = new PosingManager(context, scope, this._framework, attach, autoSave),
 			Scene = new SceneManager(context, scope, factory),
 			Selection = select,

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -28,18 +28,15 @@ namespace Ktisis.Interface.Editor;
 public class EditorInterface : IEditorInterface {
 	private readonly IEditorContext _ctx;
 	private readonly GuiManager _gui;
-	private readonly ActorService _actors;
 
 	private readonly GizmoManager _gizmo;
 	
 	public EditorInterface(
 		IEditorContext ctx,
-		GuiManager gui,
-		ActorService actors
+		GuiManager gui
 	) {
 		this._ctx = ctx;
 		this._gui = gui;
-		this._actors = actors;
 		this._gizmo = new(ctx.Config);
 	}
 	
@@ -97,35 +94,8 @@ public class EditorInterface : IEditorInterface {
 
 	public void OpenOverworldActorList() => this._gui.CreatePopup<OverworldActorPopup>(this._ctx).Open();
 	
-	public void RefreshGposeActors() {
-		var scene = this._ctx.Scene;
-		var module = scene.GetModule<ActorModule>();
+	public void RefreshGposeActors() => this._ctx.Scene.GetModule<ActorModule>().RefreshGPoseActors();
 
-		var current = 	_ctx.Scene.Children
-			.Where(entity => entity is ActorEntity)
-			.Cast<ActorEntity>()
-			.ToList();
-
-		foreach (var actor in current) {
-			if (!actor.IsValid) continue;
-
-			var entityForActor = scene.GetEntityForActor(actor.Actor);
-			if (entityForActor == null) continue;
-
-			unsafe {
-				if ((IntPtr) entityForActor.Character != IntPtr.Zero) continue;
-			}
-			
-			module.Delete(entityForActor);
-		}
-		
-		foreach (var actor in this._actors.GetGPoseActors()) {
-			if (scene.GetEntityForActor(actor) is not null) continue;
-			
-			module.AddActor(actor, false);
-		}
-	}
-	
 	// Entity windows
 	
 	public void OpenRenameEntity(SceneEntity entity) => this._gui.CreatePopup<EntityRenameModal>(entity).Open();

--- a/Ktisis/Interface/Editor/Types/IEditorInterface.cs
+++ b/Ktisis/Interface/Editor/Types/IEditorInterface.cs
@@ -27,6 +27,8 @@ public interface IEditorInterface {
 	public void OpenAssignCollection(ActorEntity entity);
 	public void OpenAssignCProfile(ActorEntity entity);
 	public void OpenOverworldActorList();
+	
+	public void RefreshGposeActors();
 
 	public void OpenRenameEntity(SceneEntity entity);
 	

--- a/Ktisis/Interface/Windows/WorkspaceWindow.cs
+++ b/Ktisis/Interface/Windows/WorkspaceWindow.cs
@@ -114,6 +114,9 @@ public class WorkspaceWindow : KtisisWindow {
 	private void DrawSceneTreeButtons() {
 		if (Buttons.IconButton(FontAwesomeIcon.Plus))
 			this.Interface.OpenSceneCreateMenu();
+		ImGui.SameLine();
+		if (Buttons.IconButton(FontAwesomeIcon.Sync))
+			this.Interface.RefreshGposeActors();
 	}
 }
  

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -152,7 +152,7 @@ public class ActorModule : SceneModule {
 		return null;
 	}
 
-	private ActorEntity? AddActor(IGameObject actor, bool addCompanion) {
+	internal ActorEntity? AddActor(IGameObject actor, bool addCompanion) {
 		if (!actor.IsValid()) {
 			Ktisis.Log.Warning($"Actor address at 0x{actor.Address:X} is invalid.");
 			return null;


### PR DESCRIPTION
This allows for the usage of Brio spawned actors, or actors spawned by other plugins to be used within Ktisis.

This seems to be a side effect that the static list of actors is only updated on enter of gpose.

This also preserves the pose for the actors that are already posed before removing.

<details><summary>Preview</summary>
<p>

[ktisis-actorreload.webm](https://github.com/user-attachments/assets/654dd7f1-2bd2-44aa-b311-b036ce246013)

</p>
</details> 