### PR TITLE
Disable confirmation & save on disable pose mode

### DIFF
--- a/Ktisis/Data/Config/Sections/AutoSaveConfig.cs
+++ b/Ktisis/Data/Config/Sections/AutoSaveConfig.cs
@@ -14,4 +14,5 @@ public class AutoSaveConfig {
 	public string FolderFormat = "AutoSave - %Date% %Time%";
 	public bool ClearOnExit = false;
 	public bool OnDisconnect = true;
+	public bool OnDisable = true;
 }

--- a/Ktisis/Data/Config/Sections/EditorConfig.cs
+++ b/Ktisis/Data/Config/Sections/EditorConfig.cs
@@ -10,6 +10,7 @@ public class EditorConfig {
 	// Values
 
 	public bool OpenOnEnterGPose = true;
+	public bool ConfirmExit = false;
 	
 	public Dictionary<EntityType, EntityDisplay> Display = EntityDisplay.GetDefaults();
 	
@@ -25,7 +26,7 @@ public class EditorConfig {
 
 	public bool PlayEmoteStart = true;
 	public bool ForceLoop = true;
-	
+
 	// Helpers
 
 	public EntityDisplay GetDisplayForType(EntityType type)

--- a/Ktisis/Editor/Posing/PosingManager.cs
+++ b/Ktisis/Editor/Posing/PosingManager.cs
@@ -106,6 +106,12 @@ public class PosingManager : IPosingManager {
 
 	public void SetEnabled(bool enable) {
 		if (enable && !this.IsValid) return;
+
+		if (!enable && this._context.Config.AutoSave.OnDisable) {
+			Ktisis.Log.Verbose("Posing disabled, triggering pose save.");
+			this.AutoSave.Save();
+		}
+		
 		this.PoseModule?.SetEnabled(enable);
 	}
 

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -155,6 +155,7 @@ public class ConfigWindow : KtisisWindow {
 
 		ImGui.Checkbox(this.Locale.Translate("config.autosave.enable"), ref cfg.Enabled);
 		ImGui.Checkbox(this.Locale.Translate("config.autosave.disconnect"), ref cfg.OnDisconnect);
+		ImGui.Checkbox(this.Locale.Translate("config.autosave.ondisable"), ref cfg.OnDisable);
 		ImGui.Checkbox(this.Locale.Translate("config.autosave.clear"), ref cfg.ClearOnExit);
 		
 		ImGui.Spacing();

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -135,6 +135,7 @@ public class ConfigWindow : KtisisWindow {
 	
 	private void DrawWorkspaceTab() {
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.init"), ref this.Config.Editor.OpenOnEnterGPose);
+		ImGui.Checkbox(this.Locale.Translate("config.workspace.confirm_exit"), ref this.Config.Editor.ConfirmExit);
 	}
 	
 	// Input

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -74,10 +74,12 @@
 		"posing": {
 			"toggle": {
 				"enable": "Posing Enabled",
+				"enable-blocked": "Posing Enabled, hold SHIFT & click to disable.",
 				"disable": "Posing Disabled"
 			},
 			"hint": {
 				"enable": "Bone manipulation is currently enabled.",
+				"enable-blocked": "To disable, hold SHIFT.",
 				"disable": "Bone manipulation is currently disabled."
 			}
 		},

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -260,6 +260,7 @@
 			"title": "AutoSave",
 			"enable": "Enable auto saves",
 			"clear": "Clear auto saves on exit",
+			"ondisable": "Always save on disabling posing mode",
 			"disconnect": "Always save on server disconnect",
 			"interval": "Save interval",
 			"count": "Save count",


### PR DESCRIPTION
This adds two features
 1. Require holding shift to disable pose mode (this is a default-off configuration option)
 2. Option to save from autosave when disabling pose mode (note: this could also be done on gpose exit too)