### PR TITLE
Bone presets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,4 @@
 
-[*.cs]
-indent_style = tab
-indent_size = tab
-tab_width = 4
-
 [*]
 
 # Microsoft .NET properties
@@ -71,3 +66,14 @@ resharper_wrap_before_primary_constructor_declaration_rpar = true
 resharper_wrap_chained_binary_patterns = chop_if_long
 resharper_wrap_list_pattern = chop_always
 resharper_wrap_object_and_collection_initializer_style = chop_always
+
+
+[*.cs]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.json]
+indent_style = tab
+indent_size = tab
+tab_width = 4

--- a/Ktisis/Data/Config/Bones/BoneCategory.cs
+++ b/Ktisis/Data/Config/Bones/BoneCategory.cs
@@ -19,4 +19,6 @@ public class BoneCategory(string name) {
 	
 	public TwoJointsGroupParams? TwoJointsGroup;
 	public CcdGroupParams? CcdGroup;
+
+	public List<string> Presets = new();
 }

--- a/Ktisis/Data/Config/ConfigManager.cs
+++ b/Ktisis/Data/Config/ConfigManager.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Diagnostics;
-
+using System.Linq;
 using Dalamud.Plugin;
 
 using Newtonsoft.Json;
@@ -43,6 +45,10 @@ public class ConfigManager : IDisposable {
 			if (cfg is { Version: < 10 }) {
 				cfg.Version = 10;
 				this.MigrateSchema(cfg);
+			}
+			if (cfg is { Version: < 11 }) {
+				cfg.Version = 11;
+				this.GenerateDefaultPresets(cfg);
 			}
 		} catch (Exception err) {
 			Ktisis.Log.Error($"Failed to load configuration:\n{err}");
@@ -90,6 +96,22 @@ public class ConfigManager : IDisposable {
 		}
 
 		cfg.Categories = categories;
+	}
+
+	private void GenerateDefaultPresets(Configuration cfg) {
+		var categories = SchemaReader.ReadCategories();
+
+		var allPresetNames = categories.CategoryList.SelectMany(x => x.Presets).Distinct().ToList();
+		Ktisis.Log.Info("All Presets: {0}", string.Join(", ", allPresetNames));
+		var presets = allPresetNames.ToDictionary(
+			x => x, 
+			key => categories.CategoryList.Where(x => x.Presets.Contains(key)).SelectMany(x => x.Bones.Select(y => y.Name)).ToImmutableHashSet()
+		);
+
+		foreach (var (preset, bones) in presets)
+		{
+			cfg.Presets.Presets.TryAdd(preset, bones);
+		}
 	}
 	
 	// TEMPORARY: v3 config file

--- a/Ktisis/Data/Config/Configuration.cs
+++ b/Ktisis/Data/Config/Configuration.cs
@@ -23,6 +23,7 @@ public class Configuration : IPluginConfiguration {
 	public LocaleConfig Locale = new();
 	public OverlayConfig Overlay = new();
 	public AutoSaveConfig AutoSave = new();
+	public PresetConfig Presets = new();
 
 	public EntityDisplay GetEntityDisplay(SceneEntity entity) {
 		var display = this.Editor.GetDisplayForType(entity.Type);

--- a/Ktisis/Data/Config/Sections/PresetConfig.cs
+++ b/Ktisis/Data/Config/Sections/PresetConfig.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Ktisis.Data.Config.Sections;
+
+public class PresetConfig {
+	public SortedDictionary<string, ImmutableHashSet<string>> Presets = new ();
+}

--- a/Ktisis/Data/Schema/Categories.xml
+++ b/Ktisis/Data/Schema/Categories.xml
@@ -12,6 +12,8 @@
 				j_kami_f_l
 				j_kami_f_r
 			</Bones>
+			<Preset Name="Head" />
+			<Preset Name="Hair" />
 		</Category>
 		<Category Id="Ears">
 			<Category Id="LeftEar">
@@ -27,6 +29,7 @@
 					j_zerd_b_l
 					j_ear_l
 				</Bones>
+				<Preset Name="Head"/>
 			</Category>
 			<Category Id="RightEar">
 				<Bones>
@@ -41,7 +44,9 @@
 					j_zerd_b_r
 					j_ear_r
 				</Bones>
+				<Preset Name="Head"/>
 			</Category>
+			<Preset Name="Head"/>
 		</Category>
 		<Category Id="Face">
 			<Bones>
@@ -57,6 +62,7 @@
 						j_f_miken_01_l
 						j_f_miken_02_l
 					</Bones>
+					<Preset Name="Face"/>
 				</Category>
 				<Category Id="RightBrow">
 					<Bones>
@@ -66,6 +72,7 @@
 						j_f_miken_01_r
 						j_f_miken_02_r
 					</Bones>
+					<Preset Name="Face"/>
 				</Category>
 			</Category>
 			<Category Id="Eyes">
@@ -81,12 +88,16 @@
 					j_f_noanim_eyesize_l
 					j_f_noanim_eyesize_r
 				</Bones>
+				<Preset Name="Face"/>
+				<Preset Name="Eyes"/>
 				<Category Id="LeftEye">
 					<Bones>
 						j_f_eye_l
 						j_f_eyepuru_l
 						j_f_mab_l
 					</Bones>
+					<Preset Name="Face"/>
+					<Preset Name="Eyes"/>
 					<Category Id="LeftEyelid">
 						<Bones>
 							j_f_umab_l
@@ -98,6 +109,8 @@
 							j_f_mabup_03in_l
 							j_f_mabdn_03in_l
 						</Bones>
+						<Preset Name="Face"/>
+						<Preset Name="Eyes"/>
 					</Category>
 				</Category>
 				<Category Id="RightEye">
@@ -106,6 +119,8 @@
 						j_f_eyepuru_r
 						j_f_mab_r
 					</Bones>
+					<Preset Name="Face"/>
+					<Preset Name="Eyes"/>
 					<Category Id="RightEyelid">
 						<Bones>
 							j_f_umab_r
@@ -117,6 +132,8 @@
 							j_f_mabup_03in_r
 							j_f_mabdn_03in_r
 						</Bones>
+						<Preset Name="Face"/>
+						<Preset Name="Eyes"/>
 					</Category>
 				</Category>
 			</Category>
@@ -128,6 +145,7 @@
 					j_f_hana_l
 					j_f_hana_r
 				</Bones>
+				<Preset Name="Face"/>
 			</Category>
 			<Category Id="Cheeks">
 				<Category Id="LeftCheek">
@@ -137,6 +155,7 @@
 						j_f_shoho_l
 						j_f_dmemoto_l
 					</Bones>
+					<Preset Name="Face"/>
 				</Category>
 				<Category Id="RightCheek">
 					<Bones>
@@ -145,6 +164,7 @@
 						j_f_shoho_r
 						j_f_dmemoto_r
 					</Bones>
+					<Preset Name="Face"/>
 				</Category>
 			</Category>
 			<Category Id="Mouth">
@@ -153,10 +173,12 @@
 					j_f_lip_l
 					j_f_lip_r
 				</Bones>
+				<Preset Name="Face"/>
 				<Category Id="UpperMouth">
 					<Bones>
 						j_f_hagukiup
 					</Bones>
+					<Preset Name="Face"/>
 					<Category Id="UpperLip">
 						<Bones>
 							j_f_ulip_a
@@ -172,6 +194,7 @@
 							j_f_uslip_l
 							j_f_uslip_r
 						</Bones>
+						<Preset Name="Face"/>
 					</Category>
 				</Category>
 				<Category Id="LowerMouth">
@@ -180,6 +203,7 @@
 						j_f_dago
 						j_f_hagukidn
 					</Bones>
+					<Preset Name="Face"/>
 					<Category Id="LowerLip">
 						<Bones>
 							j_f_dlip_a
@@ -195,6 +219,7 @@
 							j_f_dslip_l
 							j_f_dslip_r
 						</Bones>
+						<Preset Name="Face"/>
 					</Category>
 				</Category>
 				<Category Id="Tongue">
@@ -203,9 +228,12 @@
 						j_f_bero_02
 						j_f_bero_03
 					</Bones>
+					<Preset Name="Face"/>
 				</Category>
 			</Category>
 		</Category>
+		<Preset Name="Head" />
+		<Preset Name="Face" />
 	</Category>
 	<Category Id="Body">
 		<Category Id="Arms">
@@ -218,6 +246,7 @@
 					n_hhiji_l
 					iv_nitoukin_l
 				</Bones>
+				<Preset Name="Arms" />
 				<Category Id="LeftHand">
 					<TwoJointsIK Type="Arm">
 						<FirstBone>j_ude_a_l</FirstBone>
@@ -242,6 +271,7 @@
 						n_hte_l
 						j_hand_l
 					</Bones>
+					<Preset Name="Hands" /> 
 					<Category Id="LeftHandIvcs">
 						<Bones>
 							iv_ko_c_l
@@ -249,6 +279,7 @@
 							iv_naka_c_l
 							iv_hito_c_l
 						</Bones>
+						<Preset Name="Hands (Custom)" />
 					</Category>
 				</Category>
 			</Category>
@@ -261,6 +292,7 @@
 					n_hhiji_r
 					iv_nitoukin_r
 				</Bones>
+				<Preset Name="Arms" />
 				<Category Id="RightHand">
 					<TwoJointsIK Type="Arm">
 						<FirstBone>j_ude_a_r</FirstBone>
@@ -285,6 +317,7 @@
 						n_hte_r
 						j_hand_r
 					</Bones>
+					<Preset Name="Hands"/>
 					<Category Id="RightHandIvcs">
 						<Bones>
 							iv_ko_c_r
@@ -292,6 +325,7 @@
 							iv_naka_c_r
 							iv_hito_c_r
 						</Bones>
+						<Preset Name="Hands (Custom)" />
 					</Category>
 				</Category>
 			</Category>
@@ -304,6 +338,7 @@
 				j_sebo_b
 				j_sebo_c
 			</Bones>
+			<Preset Name="Body"/>
 			<Category Id="SkelomaeWings">
 				<Category Id="SkelomaeWingsLeft">
 					<Bones>
@@ -325,11 +360,13 @@
 				</Category>
 			</Category>
 			<Category Id="Breasts">
+				<Preset Name="Body"/>
 				<Bones>
 					j_mune_l
 					j_mune_r
 				</Bones>
 				<Category Id="BreastsIvcs">
+					<Preset Name="Body (Custom)" />
 					<Bones>
 						iv_c_mune_l
 						iv_c_mune_r
@@ -423,6 +460,7 @@
 					j_asi_b_l
 					j_asi_c_l
 				</Bones>
+				<Preset Name="Body" />
 				<Category Id="LeftFoot">
 					<TwoJointsIK Type="Leg">
 						<FirstBone>j_asi_a_l</FirstBone>
@@ -436,6 +474,7 @@
 						j_asi_e_l
 						j_foot_l
 					</Bones>
+					<Preset Name="Feet"/>
 					<Category Id="LeftFootIvcs">
 						<Bones>
 							iv_asi_oya_a_l
@@ -449,6 +488,7 @@
 							iv_asi_ko_a_l
 							iv_asi_ko_b_l
 						</Bones>
+						<Preset Name="Feet (Custom)" />
 					</Category>
 				</Category>
 			</Category>
@@ -458,6 +498,7 @@
 					j_asi_b_r
 					j_asi_c_r
 				</Bones>
+				<Preset Name="Body" />
 				<Category Id="RightFoot">
 					<TwoJointsIK Type="Leg">
 						<FirstBone>j_asi_a_r</FirstBone>
@@ -471,6 +512,7 @@
 						j_asi_e_r
 						j_foot_r
 					</Bones>
+					<Preset Name="Feet" />
 					<Category Id="RightFootIvcs">
 						<Bones>
 							iv_asi_oya_a_r
@@ -484,6 +526,7 @@
 							iv_asi_ko_a_r
 							iv_asi_ko_b_r
 						</Bones>
+						<Preset Name="Feet (Custom)" />
 					</Category>
 				</Category>
 			</Category>
@@ -506,6 +549,7 @@
 					j_penis
 					j_balls
 				</Bones>
+				<Preset Name="Body (Custom)" />
 			</Category>
 			<Category Id="VaginaIvcs" IsNsfw="true">
 				<Bones>
@@ -514,6 +558,7 @@
 					iv_inshin_l
 					iv_inshin_r
 				</Bones>
+				<Preset Name="Body (Custom)" />
 			</Category>
 		</Category>
 		<Category Id="BottomIvcs" IsNsfw="true">
@@ -524,6 +569,7 @@
 				iv_shiri_l
 				iv_shiri_r
 			</Bones>
+			<Preset Name="Body (Custom)" />
 		</Category>
 	</Category>
 	<Category Id="Tail">
@@ -540,6 +586,8 @@
 			n_sippo_e
 			j_tail
 		</Bones>
+		<Preset Name="Tail" />
+		<Preset Name="Body" />
 	</Category>
 	<Category Id="Clothing">
 		<Bones>
@@ -560,6 +608,7 @@
 			j_ex_met_va
 			j_ex_met_vb
 		</Bones>
+		<Preset Name="Clothing"/>
 		<Category Id="Cloth">
 			<Bones>
 				j_sk_b_b_l
@@ -581,6 +630,7 @@
 				j_sk_s_c_l
 				j_sk_s_c_r
 			</Bones>
+			<Preset Name="Clothing"/>
 		</Category>
 		<Category Id="Earring">
 			<Bones>
@@ -589,6 +639,8 @@
 				n_ear_b_l
 				n_ear_b_r
 			</Bones>
+			<Preset Name="Clothing"/>
+			<Preset Name="Earrings"/>
 		</Category>
 	</Category>
 	<Category Id="Weapons">
@@ -604,6 +656,7 @@
 			n_buki_tate_l
 			n_buki_tate_r
 		</Bones>
+		<Preset Name="Weapons" />
 	</Category>
 	<Category Id="Other" IsDefault="true">
 	</Category>

--- a/Ktisis/Data/Serialization/CategoryReader.cs
+++ b/Ktisis/Data/Serialization/CategoryReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -15,6 +16,7 @@ public static class CategoryReader {
 	private const string CategoryTag = "Category";
 	private const string TwoJointsIkTag = "TwoJointsIK";
 	private const string CcdIkTag = "CcdIK";
+	private const string PresetTag = "Preset";
 	
 	public static CategoryConfig ReadStream(Stream stream) {
 		var categories = new CategoryConfig();
@@ -52,6 +54,9 @@ public static class CategoryReader {
 					continue;
 				case XmlNodeType.Element when reader.Name is CcdIkTag:
 					category.CcdGroup = ReadCcdIkGroup(reader);
+					continue;
+				case XmlNodeType.Element when reader.Name is PresetTag:
+					category.Presets.Add(ReadPresetTag(reader));
 					continue;
 				case XmlNodeType.EndElement when reader.Name is CategoryTag:
 					return category;
@@ -141,4 +146,10 @@ public static class CategoryReader {
 		
 		return group;
 	}
+	
+	// Presets
+
+	private static string ReadPresetTag(XmlReader reader) 
+		=> reader.GetAttribute("Name") 
+			?? throw new InvalidDataException("Invalid name given to preset, please raise to the developers.");
 }

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -84,14 +84,14 @@ public class PresetEditor {
 		if (isValid && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.IsItemDeactivated()) Rename();
 		
 		ImGui.SameLine();
-		if (ImGui.Button("Rename")) Rename();
+		if (ImGui.Button(this._locale.Translate("config.presets.rename"))) Rename();
 
 		using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModShift))) {
-			if (ImGui.Button("Delete")) Delete();
+			if (ImGui.Button(this._locale.Translate("config.presets.delete"))) Delete();
 			
 			if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
 				using var _ = ImRaii.Tooltip();
-				ImGui.Text(this._locale.Translate("config.presets.delete"));
+				ImGui.Text(this._locale.Translate("config.presets.delete_tooltip"));
 			}
 		}
 	}

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -1,0 +1,114 @@
+﻿using System.Numerics;
+
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Utility.Raii;
+
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+using GLib.Widgets;
+
+using Ktisis.Core.Attributes;
+using Ktisis.Data.Config;
+using Ktisis.Data.Config.Sections;
+using Ktisis.Localization;
+
+namespace Ktisis.Interface.Components.Config;
+
+[Transient]
+public class PresetEditor {
+	private readonly ConfigManager _cfg;
+	private readonly LocaleManager _locale;
+
+	private PresetConfig Config => this._cfg.File.Presets;
+	
+	public PresetEditor(
+		ConfigManager cfg,
+		LocaleManager locale
+	) {
+		this._cfg = cfg;
+		this._locale = locale;
+	}
+
+	public void Setup() {
+		this.Selected = null;
+	}
+
+	private string? Selected = null;
+	private string PresetName = null;
+	
+	public void Draw() {
+		using var tablePad = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, new Vector2(10, 10));
+		using var table = ImRaii.Table("##PresetsTable", 2, ImGuiTableFlags.Resizable);
+		
+		if (!table.Success) return;
+			
+		ImGui.TableSetupColumn("PresetList");
+		ImGui.TableSetupColumn("PresetOptions");
+		ImGui.TableNextRow();
+
+		this.DrawPresetList();
+		this.DrawPresetConfig();
+	}
+	
+	private void DrawPresetList() {
+		ImGui.TableNextColumn();
+		
+		using var _ = ImRaii.PushStyle(ImGuiStyleVar.IndentSpacing, UiBuilder.DefaultFont.FontSize);
+		foreach (var (name, bones) in Config.Presets) {
+			var flags = ImGuiTreeNodeFlags.Leaf;
+
+			if (Selected == name) {
+				flags |= ImGuiTreeNodeFlags.Selected;
+			}
+			
+			using var node = ImRaii.TreeNode(name, flags);
+			
+			if (!ImGui.IsItemClicked())
+				continue;
+
+			if (!(ImGui.GetItemRectMin().X + ImGui.GetTreeNodeToLabelSpacing() < ImGui.GetMousePos().X))
+				continue;
+			
+			this.Selected = this.Selected != name ? name : null;
+			this.PresetName = name;
+		}
+	}
+
+	private void DrawPresetConfig() {
+		ImGui.TableNextColumn();
+		if (Selected == null) return;
+
+		ImGui.InputText("##Rename", ref this.PresetName);
+		var isValid = this.PresetName.Length > 0;
+		if (isValid && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.IsItemDeactivated()) Rename();
+		
+		ImGui.SameLine();
+		if (ImGui.Button("Rename")) Rename();
+
+		using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModShift))) {
+			if (ImGui.Button("Delete")) Delete();
+			
+			if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
+				using var _ = ImRaii.Tooltip();
+				ImGui.Text(this._locale.Translate("config.presets.delete"));
+			}
+		}
+	}
+
+	private void Rename() {
+		if (Selected is null) return;
+		if (Selected == PresetName) return;
+
+		var preset = Config.Presets[Selected];
+		Config.Presets[PresetName] = preset;
+		Config.Presets.Remove(Selected);
+		Selected = PresetName;
+	}
+
+	private void Delete() {
+		if (Selected is null) return;
+		
+		Config.Presets.Remove(Selected);
+	}
+}

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -110,5 +110,6 @@ public class PresetEditor {
 		if (Selected is null) return;
 		
 		Config.Presets.Remove(Selected);
+		Selected = null;
 	}
 }

--- a/Ktisis/Interface/Components/Objects/PropertyEditor.cs
+++ b/Ktisis/Interface/Components/Objects/PropertyEditor.cs
@@ -35,7 +35,8 @@ public class PropertyEditor {
 			.Create<PosePropertyList>(ctx)
 			.Create<LightPropertyList>()
 			.Create<ImagePropertyList>(ctx)
-			.Create<WeaponPropertyList>();
+			.Create<WeaponPropertyList>()
+			.Create<PresetPropertyList>(ctx);
 	}
 
 	private PropertyEditor Create<T>(params object[] parameters) where T : ObjectPropertyList {

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
-
+using Dalamud.Bindings.ImGui;
 using GLib.Popups.Context;
 
 using Ktisis.Common.Extensions;
@@ -9,6 +9,8 @@ using Ktisis.Editor.Context.Types;
 using Ktisis.Editor.Selection;
 using Ktisis.Interface.Editor.Types;
 using Ktisis.Interface.Nodes;
+using Ktisis.Interface.Widgets;
+using Ktisis.Scene;
 using Ktisis.Scene.Decor;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
@@ -40,10 +42,6 @@ public class SceneEntityMenuBuilder {
 	}
 
 	private void BuildEntityBaseTop(ContextMenuBuilder menu) {
-	#if DEBUG && false
-		var root = this._entity.Root;
-		menu.Action($"{root.Name} ({root.Type}) {root.GetType()}", () => this._entity.Root.Select(SelectMode.Force));
-	#endif
 		if (!this._entity.IsSelected)
 			menu.Action("Select", () => this._entity.Select(SelectMode.Multiple));
 		else
@@ -55,7 +53,7 @@ public class SceneEntityMenuBuilder {
 		if (this._entity.Root is ActorEntity actorEntity)
 			menu.SubMenu("Presets...", sub => {
 				foreach (var (name, isEnabled) in actorEntity.GetPresets()) {
-					sub.CheckableAction(name, isEnabled, () => actorEntity.TogglePreset(name));
+					sub.CheckableAction(name, isEnabled != PresetState.Disabled, () => actorEntity.TogglePreset(name));
 				}
 
 				sub.Separator()

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -40,7 +40,7 @@ public class SceneEntityMenuBuilder {
 	}
 
 	private void BuildEntityBaseTop(ContextMenuBuilder menu) {
-	#if DEBUG
+	#if DEBUG && false
 		var root = this._entity.Root;
 		menu.Action($"{root.Name} ({root.Type}) {root.GetType()}", () => this._entity.Root.Select(SelectMode.Force));
 	#endif

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -1,9 +1,14 @@
-﻿using GLib.Popups.Context;
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
+
+using GLib.Popups.Context;
 
 using Ktisis.Common.Extensions;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Editor.Selection;
 using Ktisis.Interface.Editor.Types;
+using Ktisis.Interface.Nodes;
 using Ktisis.Scene.Decor;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
@@ -35,13 +40,27 @@ public class SceneEntityMenuBuilder {
 	}
 
 	private void BuildEntityBaseTop(ContextMenuBuilder menu) {
+	#if DEBUG
+		var root = this._entity.Root;
+		menu.Action($"{root.Name} ({root.Type}) {root.GetType()}", () => this._entity.Root.Select(SelectMode.Force));
+	#endif
 		if (!this._entity.IsSelected)
 			menu.Action("Select", () => this._entity.Select(SelectMode.Multiple));
 		else
 			menu.Action("Unselect", this._entity.Unselect);
-		
+
 		if (this._entity is IVisibility vis)
 			menu.Action("Toggle display", () => vis.Toggle());
+
+		if (this._entity.Root is ActorEntity actorEntity)
+			menu.SubMenu("Presets...", sub => {
+				foreach (var (name, isEnabled) in actorEntity.GetPresets()) {
+					sub.CheckableAction(name, isEnabled, () => actorEntity.TogglePreset(name));
+				}
+
+				sub.Separator()
+					.Action("Save New", () => this.Ui.OpenSavePreset(actorEntity));
+			});
 	}
 
 	private void BuildEntityBaseBottom(ContextMenuBuilder menu) {

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -118,7 +118,8 @@ public class EditorInterface : IEditorInterface {
 	// Entity windows
 	
 	public void OpenRenameEntity(SceneEntity entity) => this._gui.CreatePopup<EntityRenameModal>(entity).Open();
-
+	public void OpenSavePreset(ActorEntity entity) => this._gui.CreatePopup<PresetSaveModal>(entity).Open();
+	
 	public void OpenActorEditor(ActorEntity actor) {
 		if (!this._ctx.Config.Editor.UseLegacyWindowBehavior)
 			actor.Select(SelectMode.Force);

--- a/Ktisis/Interface/Editor/Popup/PresetSaveModal.cs
+++ b/Ktisis/Interface/Editor/Popup/PresetSaveModal.cs
@@ -1,0 +1,43 @@
+﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility.Raii;
+
+using Ktisis.Interface.Types;
+using Ktisis.Scene.Entities.Game;
+
+namespace Ktisis.Interface.Editor.Popup;
+
+public class PresetSaveModal(ActorEntity entity)  : KtisisPopup("##PresetSave", ImGuiWindowFlags.Modal) {
+	private bool _isFirstDraw = true;
+	
+	private string Name = "";
+	
+	protected override void OnDraw() {
+		ImGui.Text($"Save Preset':");
+		
+		ImGui.InputText("##NameInput", ref this.Name, 100);
+		
+		var isValid = this.Name.Length > 0;
+		if (isValid && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.IsItemDeactivated())
+			this.Confirm();
+
+		if (this._isFirstDraw) {
+			this._isFirstDraw = false;
+			ImGui.SetKeyboardFocusHere(-1);
+		}
+		
+		ImGui.Spacing();
+		
+		using (var _ = ImRaii.Disabled(!isValid))
+			if (ImGui.Button("Confirm"))
+				this.Confirm();
+		
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+		if (ImGui.Button("Cancel"))
+			this.Close();
+	}
+
+	private void Confirm() {
+		entity.SavePreset(this.Name);
+		this.Close();
+	}
+}

--- a/Ktisis/Interface/Editor/Popup/PresetSaveModal.cs
+++ b/Ktisis/Interface/Editor/Popup/PresetSaveModal.cs
@@ -2,11 +2,12 @@
 using Dalamud.Interface.Utility.Raii;
 
 using Ktisis.Interface.Types;
+using Ktisis.Localization;
 using Ktisis.Scene.Entities.Game;
 
 namespace Ktisis.Interface.Editor.Popup;
 
-public class PresetSaveModal(ActorEntity entity)  : KtisisPopup("##PresetSave", ImGuiWindowFlags.Modal) {
+public class PresetSaveModal(ActorEntity entity, LocaleManager locale)  : KtisisPopup("##PresetSave", ImGuiWindowFlags.Modal) {
 	private bool _isFirstDraw = true;
 	
 	private string Name = "";
@@ -28,11 +29,11 @@ public class PresetSaveModal(ActorEntity entity)  : KtisisPopup("##PresetSave", 
 		ImGui.Spacing();
 		
 		using (var _ = ImRaii.Disabled(!isValid))
-			if (ImGui.Button("Confirm"))
+			if (ImGui.Button(locale.Translate("preset_edit.add.save")))
 				this.Confirm();
 		
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		if (ImGui.Button("Cancel"))
+		if (ImGui.Button(locale.Translate("preset_edit.add.cancel")))
 			this.Close();
 	}
 

--- a/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility.Raii;
+
+using Ktisis.Editor.Context.Types;
+using Ktisis.Interface.Editor.Properties.Types;
+using Ktisis.Scene.Entities;
+using Ktisis.Scene.Entities.Game;
+
+namespace Ktisis.Interface.Editor.Properties;
+
+public class PresetPropertyList(IEditorContext ctx) : ObjectPropertyList {
+
+	public override void Invoke(IPropertyListBuilder builder, SceneEntity entity) {
+		if (entity.Root is not ActorEntity actor) return;
+		
+		builder.AddHeader("Presets", () => DrawPresets(actor), priority: 100);
+	}
+
+	private string _name = ""; 
+	
+	private void DrawPresets(ActorEntity actor) {
+		var spacing = ImGui.GetStyle().ItemInnerSpacing.X;
+
+		foreach (var (name, currentState) in actor.GetPresets()) {
+			var enabled = currentState;
+			ImGui.Checkbox(name, ref enabled);
+
+			if (enabled != currentState) {
+				actor.TogglePreset(name, enabled); 
+			}
+		}
+		
+		ImGui.Separator();
+		
+		ImGui.InputText("Preset Name", ref _name);
+		var isValid = _name.Length > 0 && !ctx.Config.Presets.Presets.ContainsKey(_name);
+
+		if (isValid && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.IsItemDeactivated()) {
+			SavePreset(actor);
+		}
+
+		using (var _ = ImRaii.Disabled(!isValid)) {
+			if (ImGui.Button("Save")) {
+				SavePreset(actor);
+			}
+		}
+	}
+	private void SavePreset(ActorEntity actor) {
+		actor.SavePreset(_name);
+		_name = "";
+	}
+}

--- a/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
@@ -5,17 +5,18 @@ using Dalamud.Interface.Utility.Raii;
 
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Editor.Properties.Types;
+using Ktisis.Localization;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
 
 namespace Ktisis.Interface.Editor.Properties;
 
-public class PresetPropertyList(IEditorContext ctx) : ObjectPropertyList {
+public class PresetPropertyList(IEditorContext ctx, LocaleManager locale) : ObjectPropertyList {
 
 	public override void Invoke(IPropertyListBuilder builder, SceneEntity entity) {
 		if (entity.Root is not ActorEntity actor) return;
 		
-		builder.AddHeader("Presets", () => DrawPresets(actor), priority: 100);
+		builder.AddHeader(locale.Translate("preset_edit.title"), () => DrawPresets(actor), priority: 100);
 	}
 
 	private string _name = ""; 
@@ -33,8 +34,8 @@ public class PresetPropertyList(IEditorContext ctx) : ObjectPropertyList {
 		}
 		
 		ImGui.Separator();
-		
-		ImGui.InputText("Preset Name", ref _name);
+		ImGui.Text(locale.Translate("preset_edit.add.title"));
+		ImGui.InputText(locale.Translate("preset_edit.add.label"), ref _name);
 		var isValid = _name.Length > 0 && !ctx.Config.Presets.Presets.ContainsKey(_name);
 
 		if (isValid && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.IsItemDeactivated()) {
@@ -42,7 +43,7 @@ public class PresetPropertyList(IEditorContext ctx) : ObjectPropertyList {
 		}
 
 		using (var _ = ImRaii.Disabled(!isValid)) {
-			if (ImGui.Button("Save")) {
+			if (ImGui.Button(locale.Translate("preset_edit.add.save"))) {
 				SavePreset(actor);
 			}
 		}

--- a/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PresetPropertyList.cs
@@ -5,7 +5,9 @@ using Dalamud.Interface.Utility.Raii;
 
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Editor.Properties.Types;
+using Ktisis.Interface.Widgets;
 using Ktisis.Localization;
+using Ktisis.Scene;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
 
@@ -25,11 +27,10 @@ public class PresetPropertyList(IEditorContext ctx, LocaleManager locale) : Obje
 		var spacing = ImGui.GetStyle().ItemInnerSpacing.X;
 
 		foreach (var (name, currentState) in actor.GetPresets()) {
-			var enabled = currentState;
-			ImGui.Checkbox(name, ref enabled);
-
-			if (enabled != currentState) {
-				actor.TogglePreset(name, enabled); 
+			var enabled = (byte)currentState;
+			
+			if (ImGui.CheckboxFlags(name, ref enabled, (byte) (PresetState.Enabled))) {
+				actor.TogglePreset(name, (PresetState) enabled == PresetState.Enabled); 
 			}
 		}
 		

--- a/Ktisis/Interface/Editor/Types/IEditorInterface.cs
+++ b/Ktisis/Interface/Editor/Types/IEditorInterface.cs
@@ -31,6 +31,8 @@ public interface IEditorInterface {
 	public void RefreshGposeActors();
 
 	public void OpenRenameEntity(SceneEntity entity);
+	public void OpenSavePreset(ActorEntity actorEntity);
+	
 	
 	public void OpenActorEditor(ActorEntity actor);
 	public void OpenLightEditor(LightEntity light);

--- a/Ktisis/Interface/Nodes/CheckableNode.cs
+++ b/Ktisis/Interface/Nodes/CheckableNode.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+
+using GLib.Popups.Context;
+using GLib.Widgets;
+
+namespace Ktisis.Interface.Nodes;
+
+public class CheckableNode : IContextMenuNode {
+	private readonly string _name;
+	private readonly bool _state;
+	private readonly Action _handler;
+	
+	public string? Shortcut;
+	
+	public CheckableNode(string name, bool state, Action handler) {
+		_name = name;
+		_state = state;
+		_handler = handler;
+
+	}
+	
+	public void Draw() {
+		var invoke = this.Shortcut switch {
+			not null => ImGui.MenuItem(this._name, this.Shortcut, _state),
+			_ => ImGui.MenuItem(this._name, _state)
+		};
+			
+		if (invoke) this._handler.Invoke();
+	}
+}

--- a/Ktisis/Interface/Nodes/Extensions.cs
+++ b/Ktisis/Interface/Nodes/Extensions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+using GLib.Popups.Context;
+
+namespace Ktisis.Interface.Nodes;
+
+public static class Extensions {
+	public static ContextMenuBuilder CheckableAction(this ContextMenuBuilder builder, string name, bool state, Action handler) {
+		return builder.AddNode(new CheckableNode(name, state, handler));
+	}
+}

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Numerics;
 
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
+
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using GLib.Widgets;
 
@@ -25,6 +28,7 @@ public class ConfigWindow : KtisisWindow {
 	private readonly ActionKeybindEditor _keybinds;
 	private readonly BoneCategoryEditor _boneCategories;
 	private readonly GizmoStyleEditor _gizmoStyle;
+	private readonly PresetEditor _presetEditor;
 	public readonly LocaleManager Locale;
 
 	private Configuration Config => this._cfg.File;
@@ -36,6 +40,7 @@ public class ConfigWindow : KtisisWindow {
 		ActionKeybindEditor keybinds,
 		BoneCategoryEditor boneCategories,
 		GizmoStyleEditor gizmoStyle,
+		PresetEditor presetEditor,
 		LocaleManager locale
 	) : base("Ktisis Settings") {
 		this._cfg = cfg;
@@ -44,6 +49,7 @@ public class ConfigWindow : KtisisWindow {
 		this._keybinds = keybinds;
 		this._boneCategories = boneCategories;
 		this._gizmoStyle = gizmoStyle;
+		this._presetEditor = presetEditor;
 		this.Locale = locale;
 	}
 	
@@ -52,6 +58,7 @@ public class ConfigWindow : KtisisWindow {
 	public override void OnOpen() {
 		this._keybinds.Setup();
 		this._boneCategories.Setup();
+		this._presetEditor.Setup();
 	}
 	
 	// Draw
@@ -65,6 +72,7 @@ public class ConfigWindow : KtisisWindow {
 		DrawTab(this.Locale.Translate("config.workspace.title"), this.DrawWorkspaceTab);
 		DrawTab(this.Locale.Translate("config.autosave.title"), this.DrawAutoSaveTab);
 		DrawTab(this.Locale.Translate("config.input.title"), this.DrawInputTab);
+		DrawTab(this.Locale.Translate("config.presets.title"), this.DrawPresetsTab);
 	}
 
 	private void DrawHint(string localeHandle) {
@@ -200,6 +208,19 @@ public class ConfigWindow : KtisisWindow {
 			ImGui.TableNextColumn();
 			ImGui.TextUnformatted(text);
 		}
+	}
+	
+	//Presets
+
+	public void DrawPresetsTab() {
+		var cfg = this.Config.Presets;
+
+		this._presetEditor.Draw();
+		
+		var style = ImGui.GetStyle();
+		var dummy = ImGui.GetContentRegionAvail() with { X = 0.0f };
+		dummy.Y -= style.ItemSpacing.Y + style.CellPadding.Y;
+		ImGui.Dummy(dummy);
 	}
 	
 	// Handlers

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -127,6 +127,15 @@
 		}
 	},
 	
+	"preset_edit": {
+		"title": "Presets",
+		"add": {
+			"title": "Add new preset",
+			"label": "Preset Name",
+			"save": "Save"
+		}
+	},
+	
 	"chara_edit": {
 		"title": "Appearance Editor",
 		"hint": "Edit appearance"

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -274,6 +274,10 @@
 			"count": "Save count",
 			"path": "Save path",
 			"dir": "Folder name"
+		},
+		"presets": {
+			"title": "Presets",
+			"delete": "Hold shift to delete"
 		}
 	},
 

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -132,7 +132,8 @@
 		"add": {
 			"title": "Add new preset",
 			"label": "Preset Name",
-			"save": "Save"
+			"save": "Save",
+			"cancel": "Cancel"
 		}
 	},
 	
@@ -286,7 +287,9 @@
 		},
 		"presets": {
 			"title": "Presets",
-			"delete": "Hold shift to delete"
+			"delete_tooltip": "Hold shift to delete",
+			"delete": "Delete",
+			"rename": "Rename"
 		}
 	},
 

--- a/Ktisis/Scene/Entities/Game/ActorEntity.cs
+++ b/Ktisis/Scene/Entities/Game/ActorEntity.cs
@@ -144,12 +144,12 @@ public class ActorEntity : CharaEntity, IDeletable {
 		}
 	}
 	
-	public bool TogglePreset(string presetName) {
+	public bool TogglePreset(string presetName, bool? state = null) {
 		//check if key exists
 		if (!this.Scene.Context.Config.Presets.Presets.TryGetValue(presetName, out var preset))
 			return false;
 
-		var op = !this.EnabledPresets.Contains(presetName);
+		var op = state ?? !this.EnabledPresets.Contains(presetName);
 		
 		this.ToggleView(preset, op);
 
@@ -186,7 +186,12 @@ public class ActorEntity : CharaEntity, IDeletable {
 			return false;
 		}
 
-		this.Scene.Context.Config.Presets.Presets[presetName] = this.GetEnabledBones();
+		var bones = this.GetEnabledBones();
+		if (bones.IsEmpty) {
+			return false;
+		}
+		
+		this.Scene.Context.Config.Presets.Presets[presetName] = bones;
 		this.EnabledPresets.Add(presetName);
 		return true;
 	}

--- a/Ktisis/Scene/Entities/Game/ActorEntity.cs
+++ b/Ktisis/Scene/Entities/Game/ActorEntity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -188,6 +189,7 @@ public class ActorEntity : CharaEntity, IDeletable {
 
 		var bones = this.GetEnabledBones();
 		if (bones.IsEmpty) {
+			Ktisis.Log.Warning("No bones selected.");
 			return false;
 		}
 		

--- a/Ktisis/Scene/Entities/SceneEntity.cs
+++ b/Ktisis/Scene/Entities/SceneEntity.cs
@@ -96,27 +96,23 @@ public abstract class SceneEntity : IComposite {
 	}
 	
 	//Presetting
-	public void ToggleView(ImmutableHashSet<string> names, bool newState) {
-		
+	protected void ToggleView(ImmutableHashSet<string> names, bool newState) {
 		if (this is BoneNode node && names.Contains(node.Info.Name)) {
 			node.Visible = newState;
 			((IVisibility) node).Toggle();
 		}
-		//recursively search children for name.
 	
 		foreach (var sceneEntity in this.Recurse()) {
-			
 			if (sceneEntity is not BoneNode n)
 				continue;
 			
-			Ktisis.Log.Debug("Checking if {0} is in {1}", n.Info.Name, names.Contains(n.Info.Name));
 			if (names.Contains(n.Info.Name)) {
 				n.Visible = newState;
 			}
 		}
 	}
 
-	public ImmutableHashSet<string> GetEnabledBones() {
+	protected ImmutableHashSet<string> GetEnabledBones() {
 		HashSet<string> bones = new(128);
 
 		foreach (var sceneEntity in this.Recurse()) {

--- a/Ktisis/Scene/Entities/SceneEntity.cs
+++ b/Ktisis/Scene/Entities/SceneEntity.cs
@@ -1,7 +1,12 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
 using Ktisis.Editor.Selection;
+using Ktisis.Scene.Decor;
+using Ktisis.Scene.Entities.Skeleton;
 using Ktisis.Scene.Types;
 
 namespace Ktisis.Scene.Entities;
@@ -13,6 +18,7 @@ public abstract class SceneEntity : IComposite {
 	public EntityType Type { get; protected init; }
 
 	public virtual bool IsValid => this.Scene.IsValid && this.Parent != null;
+	public SceneEntity Root => this.Parent is null or { Type: EntityType.Invalid } ? this : this.Parent.Root;
 	
 	protected SceneEntity(
 		ISceneManager scene
@@ -87,5 +93,40 @@ public abstract class SceneEntity : IComposite {
 			parent = parent.Parent;
 		}
 		return false;
+	}
+	
+	//Presetting
+	public void ToggleView(ImmutableHashSet<string> names, bool newState) {
+		
+		if (this is BoneNode node && names.Contains(node.Info.Name)) {
+			node.Visible = newState;
+			((IVisibility) node).Toggle();
+		}
+		//recursively search children for name.
+	
+		foreach (var sceneEntity in this.Recurse()) {
+			
+			if (sceneEntity is not BoneNode n)
+				continue;
+			
+			Ktisis.Log.Debug("Checking if {0} is in {1}", n.Info.Name, names.Contains(n.Info.Name));
+			if (names.Contains(n.Info.Name)) {
+				n.Visible = newState;
+			}
+		}
+	}
+
+	public ImmutableHashSet<string> GetEnabledBones() {
+		HashSet<string> bones = new(128);
+
+		foreach (var sceneEntity in this.Recurse()) {
+			if (sceneEntity is not BoneNode b) 
+				continue;
+			
+			if (b.Visible)
+				bones.Add(b.Info.Name);
+		}
+		
+		return bones.ToImmutableHashSet();
 	}
 }

--- a/Ktisis/Scene/Entities/SceneEntity.cs
+++ b/Ktisis/Scene/Entities/SceneEntity.cs
@@ -102,12 +102,9 @@ public abstract class SceneEntity : IComposite {
 			((IVisibility) node).Toggle();
 		}
 	
-		foreach (var sceneEntity in this.Recurse()) {
-			if (sceneEntity is not BoneNode n)
-				continue;
-			
-			if (names.Contains(n.Info.Name)) {
-				n.Visible = newState;
+		foreach (var bone in this.Recurse().OfType<BoneNode>()) {
+			if (names.Contains(bone.Info.Name)) {
+				bone.Visible = newState;
 			}
 		}
 	}
@@ -115,12 +112,9 @@ public abstract class SceneEntity : IComposite {
 	protected ImmutableHashSet<string> GetEnabledBones() {
 		HashSet<string> bones = new(128);
 
-		foreach (var sceneEntity in this.Recurse()) {
-			if (sceneEntity is not BoneNode b) 
-				continue;
-			
-			if (b.Visible)
-				bones.Add(b.Info.Name);
+		foreach (var bone in this.Recurse().OfType<BoneNode>()) {
+			if (bone.Visible)
+				bones.Add(bone.Info.Name);
 		}
 		
 		return bones.ToImmutableHashSet();

--- a/Ktisis/Scene/PresetState.cs
+++ b/Ktisis/Scene/PresetState.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ktisis.Scene;
+
+public enum PresetState : byte {
+    Disabled = 0b00,
+    Implicit = 0b01,
+    Enabled  = 0b11,
+}


### PR DESCRIPTION
This adds functionality for creating and editing bone visibility presets.

At this point, we need to go through and create reasonable defaults, this is at least the basic framework.

I have a whole `Presets` key in the config to allow us to expand with a default visibility presets or further.