### PR TITLE
reinstate left/right click blocking

### DIFF
--- a/Ktisis/Data/Config/Actions/InputConfig.cs
+++ b/Ktisis/Data/Config/Actions/InputConfig.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 namespace Ktisis.Data.Config.Actions;
 
 public class InputConfig {
+	public bool BlockTargetLeftClick;
+	public bool BlockTargetRightClick;
 	public bool Enabled;
 
 	public Dictionary<string, ActionKeybind> Keybinds = new();

--- a/Ktisis/Editor/Actions/Input/InputManager.cs
+++ b/Ktisis/Editor/Actions/Input/InputManager.cs
@@ -47,7 +47,7 @@ public class InputManager : IInputManager {
 	private InputModule? Module { get; set; }
 
 	public void Initialize() {
-		this.Module = this._scope.Create<InputModule>();
+		this.Module = this._scope.Create<InputModule>(_context);
 		this.Module.Initialize();
 		this.Module.OnKeyEvent += this.OnKeyEvent;
 		this.Module.EnableAll();

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -150,6 +150,8 @@ public class ConfigWindow : KtisisWindow {
 	// Input
 
 	private void DrawInputTab() {
+		ImGui.Checkbox(this.Locale.Translate("config.input.blockLeft"), ref this.Config.Keybinds.BlockTargetLeftClick);
+		ImGui.Checkbox(this.Locale.Translate("config.input.blockRight"), ref this.Config.Keybinds.BlockTargetRightClick);
 		ImGui.Checkbox(this.Locale.Translate("config.input.enable"), ref this.Config.Keybinds.Enabled);
 		if (!this.Config.Keybinds.Enabled) return;
 		ImGui.Text(this.Locale.Translate("config.input.help"));

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -263,7 +263,9 @@
 		"input": {
 			"title": "Input",
 			"enable": "Enable keybinds",
-			"help": "Click keybinds to modify them. Right click to clear."
+			"help": "Click keybinds to modify them. Right click to clear.",
+			"blockLeft": "Disable change target on left click",
+			"blockRight": "Disable change target on right click"
 		},
 		"autosave": {
 			"title": "AutoSave",


### PR DESCRIPTION
### changes
- InputModule.cs
    - readds ProcessMouseStateDelegate and ProcessMouseStateDetour hooking from main branch
    - this detour allows us to revert any attempted target changes with left or right click pending the new config vars being enabled by the user.
- InputConfig.cs
    - adds BlockTargetLeftClick and BlockTargetRightClick to the input settings tab