### PR TITLE
Utilize event to disable preset if active before removing it

### DIFF
--- a/Ktisis/Data/Config/Sections/PresetConfig.cs
+++ b/Ktisis/Data/Config/Sections/PresetConfig.cs
@@ -4,5 +4,8 @@ using System.Collections.Immutable;
 namespace Ktisis.Data.Config.Sections;
 
 public class PresetConfig {
+	internal delegate void PresetRemoved(string presetName);
+	internal static PresetRemoved? PresetRemovedEvent;
+
 	public SortedDictionary<string, ImmutableHashSet<string>> Presets = new ();
 }

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -108,7 +108,8 @@ public class PresetEditor {
 
 	private void Delete() {
 		if (Selected is null) return;
-		
+
+		PresetConfig.PresetRemovedEvent?.Invoke(Selected);
 		Config.Presets.Remove(Selected);
 		Selected = null;
 	}


### PR DESCRIPTION
It has been discussed that the semantics of the static delegate aren't desired, while attempts achieve this without the event have not been as successful as we hoped.

_In an attempt to avoid using the event delegate, `IEditorContext` was to be passed through `ConfigWindow` and `PresetEditor` from `EditorInterface`._