### PR TITLE
fix IK targeting & alleviate TwoJoints child drift

### DIFF
--- a/Ktisis/Common/Utility/Transform.cs
+++ b/Ktisis/Common/Utility/Transform.cs
@@ -83,4 +83,9 @@ public class Transform {
 		Rotation = trans.Rotation,
 		Scale = trans.Scale
 	};
+
+	public bool Equals(Transform trans) =>
+		this.Position.Equals(trans.Position)
+		&& this.Rotation.Equals(trans.Rotation)
+		&& this.Scale.Equals(trans.Scale);
 }

--- a/Ktisis/Editor/Posing/Ik/TwoJoints/TwoJointsSolver.cs
+++ b/Ktisis/Editor/Posing/Ik/TwoJoints/TwoJointsSolver.cs
@@ -141,8 +141,13 @@ public class TwoJointsSolver(IkModule module) : IDisposable {
 			}
 
 			// only update child bone transforms (ex fingers, toes) if there's been a change since last frame!
+			// only works consistently with end rotation enforced
 			// TODO: just fix the local->model math below; this is a bandaid over IK bone drift
-			if (this.LastPoseInModel != null && this.LastPoseInModel.Equals(poseInModel)) continue;
+			if (
+				this.LastPoseInModel != null
+				&& this.IkSetup->m_enforceEndRotation
+				&& this.LastPoseInModel.Equals(poseInModel)
+			) continue;
 
 			var parentId = parents[i];
 			var local = HavokPosing.GetLocalTransform(poseIn, i)!;

--- a/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
@@ -77,7 +77,7 @@ public class PosePropertyList : ObjectPropertyList {
 			
 			var enabled = group.IsEnabled;
 			if (ImGui.Checkbox(" " + this._locale.Translate($"boneCategory.{name}"), ref enabled))
-				group.IsEnabled = enabled;
+				node.Toggle();
 
 			var btnSpace = Icons.CalcIconSize(FontAwesomeIcon.HandPointer).X
 				+ Icons.CalcIconSize(FontAwesomeIcon.EllipsisH).X

--- a/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
@@ -77,7 +77,7 @@ public class PosePropertyList : ObjectPropertyList {
 			
 			var enabled = group.IsEnabled;
 			if (ImGui.Checkbox(" " + this._locale.Translate($"boneCategory.{name}"), ref enabled))
-				node.Toggle();
+				group.IsEnabled = enabled;
 
 			var btnSpace = Icons.CalcIconSize(FontAwesomeIcon.HandPointer).X
 				+ Icons.CalcIconSize(FontAwesomeIcon.EllipsisH).X

--- a/Ktisis/Scene/Decor/Ik/IIkNode.cs
+++ b/Ktisis/Scene/Decor/Ik/IIkNode.cs
@@ -5,11 +5,4 @@ public interface IIkNode {
 	
 	public void Enable();
 	public void Disable();
-
-	public virtual void Toggle() {
-		if (this.IsEnabled)
-			this.Disable();
-		else
-			this.Enable();
-	}
 }

--- a/Ktisis/Scene/Decor/Ik/IIkNode.cs
+++ b/Ktisis/Scene/Decor/Ik/IIkNode.cs
@@ -5,4 +5,11 @@ public interface IIkNode {
 	
 	public void Enable();
 	public void Disable();
+
+	public virtual void Toggle() {
+		if (this.IsEnabled)
+			this.Disable();
+		else
+			this.Enable();
+	}
 }

--- a/Ktisis/Scene/Entities/Skeleton/Constraints/IkEndNode.cs
+++ b/Ktisis/Scene/Entities/Skeleton/Constraints/IkEndNode.cs
@@ -34,6 +34,13 @@ public abstract class IkEndNode : BoneNode, IIkNode {
 	}
 	
 	public virtual void Disable() => this.Parent?.Disable();
+
+	public virtual void Toggle() {
+		if (this.IsEnabled)
+			this.Disable();
+		else
+			this.Enable();
+	}
 	
 	// Target transform
 	

--- a/Ktisis/Scene/Entities/Skeleton/Constraints/IkEndNode.cs
+++ b/Ktisis/Scene/Entities/Skeleton/Constraints/IkEndNode.cs
@@ -34,13 +34,6 @@ public abstract class IkEndNode : BoneNode, IIkNode {
 	}
 	
 	public virtual void Disable() => this.Parent?.Disable();
-
-	public virtual void Toggle() {
-		if (this.IsEnabled)
-			this.Disable();
-		else
-			this.Enable();
-	}
 	
 	// Target transform
 	


### PR DESCRIPTION
### changes

- reinstates the .Toggle() behavior when enabling IK nodes -this way we keep a clean target position when turning them on, rather than setting to origin
- patches around the finger/toes IK bone drifting issue, by (when frozen & forcing end rotation) preventing recalculating child bones of the IK end node's transforms every frame. instead, we can calculate them only when we detect a change in the model transform of the end node.
  - something is specifically buggy with the local+model math in ApplyModelPoseStatic for TwoJoints IK, but this acts as a decent bandaid solution pending further looks
  - it ONLY prevents phalanges' drifting each frame when enforce end rotation is enabled (the default for ik groups)

not rigorously tested against Bone Relative solving yet