### PR TITLE
allow enabling presets by default

### DIFF
--- a/Ktisis/Data/Config/Sections/PresetConfig.cs
+++ b/Ktisis/Data/Config/Sections/PresetConfig.cs
@@ -9,9 +9,9 @@ public class PresetConfig {
 	internal static PresetRemoved? PresetRemovedEvent;
 
 	public SortedDictionary<string, ImmutableHashSet<string>> Presets = new ();
-	public List<string> DefaultPresets = new List<string>();
+	public HashSet<string> DefaultPresets = new ();
 
 	public bool PresetIsDefault(string name) {
-		return this.DefaultPresets.FirstOrDefault(x => x == name) != null;
+		return this.DefaultPresets.Contains(name);
 	}
 }

--- a/Ktisis/Data/Config/Sections/PresetConfig.cs
+++ b/Ktisis/Data/Config/Sections/PresetConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Ktisis.Data.Config.Sections;
 
@@ -8,4 +9,9 @@ public class PresetConfig {
 	internal static PresetRemoved? PresetRemovedEvent;
 
 	public SortedDictionary<string, ImmutableHashSet<string>> Presets = new ();
+	public List<string> DefaultPresets = new List<string>();
+
+	public bool PresetIsDefault(string name) {
+		return this.DefaultPresets.FirstOrDefault(x => x == name) != null;
+	}
 }

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -41,6 +41,10 @@ public class PresetEditor {
 	private bool IsDefault = false;
 	
 	public void Draw() {
+		ImGui.Text(this._locale.Translate("config.presets.description"));
+		ImGui.Text(this._locale.Translate("config.presets.defaults"));
+		ImGui.Spacing();
+
 		using var tablePad = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, new Vector2(10, 10));
 		using var table = ImRaii.Table("##PresetsTable", 2, ImGuiTableFlags.Resizable);
 		
@@ -71,15 +75,20 @@ public class PresetEditor {
 			using var c = ImRaii.PushColor(ImGuiCol.Text, isDefault ? ColorYellow : ImGui.GetColorU32(ImGuiCol.Text));
 			using var node = ImRaii.TreeNode(name, flags);
 			
-			if (!ImGui.IsItemClicked())
-				continue;
-
-			if (!(ImGui.GetItemRectMin().X + ImGui.GetTreeNodeToLabelSpacing() < ImGui.GetMousePos().X))
-				continue;
-			
-			this.Selected = this.Selected != name ? name : null;
-			this.PresetName = name;
-			this.IsDefault = isDefault;
+			if (ImGui.IsItemClicked(ImGuiMouseButton.Left)) {
+				this.Selected = this.Selected != name ? name : null;
+				this.PresetName = name;
+				this.IsDefault = isDefault;
+			} else if (ImGui.IsItemClicked(ImGuiMouseButton.Right)) {
+				if (isDefault) {
+					Config.DefaultPresets.Remove(name);
+					this.IsDefault = false;
+				}
+				else {
+					Config.DefaultPresets.Add(name);
+					this.IsDefault = true;
+				}
+			}
 		}
 	}
 
@@ -93,14 +102,6 @@ public class PresetEditor {
 		
 		ImGui.SameLine();
 		if (ImGui.Button(this._locale.Translate("config.presets.rename"))) Rename();
-
-		ImGui.Spacing();
-		if (ImGui.Checkbox($"GPose Default", ref this.IsDefault)) {
-			if (IsDefault)
-				Config.DefaultPresets.Add(Selected);
-			else
-				Config.DefaultPresets.Remove(Selected);
-		}
 
 		using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModShift))) {
 			if (ImGui.Button(this._locale.Translate("config.presets.delete"))) Delete();

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -21,6 +21,8 @@ public class PresetEditor {
 	private readonly LocaleManager _locale;
 
 	private PresetConfig Config => this._cfg.File.Presets;
+
+	private const uint ColorYellow = 0xFF00FFFF;
 	
 	public PresetEditor(
 		ConfigManager cfg,
@@ -57,12 +59,16 @@ public class PresetEditor {
 		
 		using var _ = ImRaii.PushStyle(ImGuiStyleVar.IndentSpacing, UiBuilder.DefaultFont.FontSize);
 		foreach (var (name, bones) in Config.Presets) {
-			var flags = ImGuiTreeNodeFlags.Leaf;
+			var flags = ImGuiTreeNodeFlags.Leaf | ImGuiTreeNodeFlags.SpanAvailWidth;
+			var isDefault = Config.PresetIsDefault(name);
 
-			if (Selected == name) {
+			if (isDefault)
+				flags |= ImGuiTreeNodeFlags.Bullet;
+
+			if (Selected == name)
 				flags |= ImGuiTreeNodeFlags.Selected;
-			}
-			
+
+			using var c = ImRaii.PushColor(ImGuiCol.Text, isDefault ? ColorYellow : ImGui.GetColorU32(ImGuiCol.Text));
 			using var node = ImRaii.TreeNode(name, flags);
 			
 			if (!ImGui.IsItemClicked())
@@ -73,7 +79,7 @@ public class PresetEditor {
 			
 			this.Selected = this.Selected != name ? name : null;
 			this.PresetName = name;
-			this.IsDefault = Config.PresetIsDefault(name);
+			this.IsDefault = isDefault;
 		}
 	}
 

--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -36,6 +36,7 @@ public class PresetEditor {
 
 	private string? Selected = null;
 	private string PresetName = null;
+	private bool IsDefault = false;
 	
 	public void Draw() {
 		using var tablePad = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, new Vector2(10, 10));
@@ -72,6 +73,7 @@ public class PresetEditor {
 			
 			this.Selected = this.Selected != name ? name : null;
 			this.PresetName = name;
+			this.IsDefault = Config.PresetIsDefault(name);
 		}
 	}
 
@@ -85,6 +87,14 @@ public class PresetEditor {
 		
 		ImGui.SameLine();
 		if (ImGui.Button(this._locale.Translate("config.presets.rename"))) Rename();
+
+		ImGui.Spacing();
+		if (ImGui.Checkbox($"GPose Default", ref this.IsDefault)) {
+			if (IsDefault)
+				Config.DefaultPresets.Add(Selected);
+			else
+				Config.DefaultPresets.Remove(Selected);
+		}
 
 		using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModShift))) {
 			if (ImGui.Button(this._locale.Translate("config.presets.delete"))) Delete();
@@ -102,7 +112,10 @@ public class PresetEditor {
 
 		var preset = Config.Presets[Selected];
 		Config.Presets[PresetName] = preset;
+		if (IsDefault)
+			Config.DefaultPresets.Add(PresetName);
 		Config.Presets.Remove(Selected);
+		Config.DefaultPresets.Remove(Selected);
 		Selected = PresetName;
 	}
 
@@ -111,6 +124,7 @@ public class PresetEditor {
 
 		PresetConfig.PresetRemovedEvent?.Invoke(Selected);
 		Config.Presets.Remove(Selected);
+		Config.DefaultPresets.Remove(Selected);
 		Selected = null;
 	}
 }

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -309,6 +309,8 @@
 		},
 		"presets": {
 			"title": "Presets",
+			"description": "View and edit your defined presets below.",
+			"defaults": "Right click any preset to mark it as Default. Default presets will be initially enabled for any GPose actors.",
 			"delete_tooltip": "Hold shift to delete",
 			"delete": "Delete",
 			"rename": "Rename"

--- a/Ktisis/Scene/Entities/Game/ActorEntity.cs
+++ b/Ktisis/Scene/Entities/Game/ActorEntity.cs
@@ -30,6 +30,7 @@ public class ActorEntity : CharaEntity, IDeletable {
 	public readonly IGameObject Actor;
 
 	public bool IsManaged { get; set; }
+	private bool DefaultsInitialized = false;
 
 	public override bool IsValid => base.IsValid && this.Actor.IsValid();
 
@@ -67,6 +68,10 @@ public class ActorEntity : CharaEntity, IDeletable {
 		if (!this.IsObjectValid) return;
 		this.UpdateChara();
 		base.Update();
+
+		// after we're drawing, run the default presetter once
+		if (!this.DefaultsInitialized)
+			this.SetDefaultPresets();
 	}
 
 	private unsafe void UpdateChara() {
@@ -185,6 +190,19 @@ public class ActorEntity : CharaEntity, IDeletable {
 		CheckImplicitlyEnabled();
 
 		return true;
+	}
+
+	private void SetDefaultPresets() {
+		var allBones = this.Recurse().OfType<BoneNode>().ToList()!;
+		if (!allBones.Any())
+			return;
+
+		var presets = this.Scene.Context.Config.Presets.DefaultPresets;
+		foreach (var preset in presets) {
+			Ktisis.Log.Debug($"toggling default preset {preset}");
+			this.TogglePreset(preset, true);
+		}
+		this.DefaultsInitialized = true;
 	}
 
 	private void EnsurePresetVisibility() {


### PR DESCRIPTION
### changes
- adds a GPose Default checkbox to preset list entries, which controls their addition to a DefaultPresets list on preset config
- when drawing actor entities, attempt once (when their bones exist to reference) to set active any default presets
  - we do this in Draw instead of init since gameobject data may need some time to propagate; see when entering gpose for the first time, or when creating new actors

<img width="1123" height="941" alt="image" src="https://github.com/user-attachments/assets/b4690e5c-e21a-4447-8011-1811a817fe18" />
