### PR TITLE
actor+npc QoL

### DIFF
--- a/Ktisis/Interface/Components/Chara/CharaImportUI.cs
+++ b/Ktisis/Interface/Components/Chara/CharaImportUI.cs
@@ -13,6 +13,11 @@ using Ktisis.Scene.Entities.Game;
 
 namespace Ktisis.Interface.Components.Chara;
 
+public enum LoadMethod {
+	File,
+	Npc
+}
+
 [Transient]
 public class CharaImportUI {
 	public IEditorContext Context { set; private get; } = null!;
@@ -50,13 +55,8 @@ public class CharaImportUI {
 	}
 	
 	// State
-	
-	private enum LoadMethod {
-		File,
-		Npc
-	}
 
-	private LoadMethod _method = LoadMethod.File;
+	public LoadMethod _method = LoadMethod.File;
 	
 	public bool HasSelection => this._method switch {
 		LoadMethod.File => this._select.IsFileOpened,

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -104,6 +104,7 @@ public class SceneEntityMenuBuilder {
 			.Separator()
 			.SubMenu("Import...", sub => {
 				var builder = sub.Action("Character (.chara)", () => this.Ui.OpenCharaImport(actor))
+					.Action("NPC", () => this.Ui.OpenCharaImport(actor, true))
 					.Action("Pose file (.pose)", () => this.Ui.OpenPoseImport(actor));
 				
 				if (this._ctx.Plugin.Ipc.IsAnyMcdfActive && actor.GetHuman() != null) {

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -67,8 +67,12 @@ public class SceneEntityMenuBuilder {
 
 		menu.Separator().Action("Rename", () => this.Ui.OpenRenameEntity(this._entity));
 
-		if (this._entity is IDeletable deletable)
-			menu.Separator().Action("Delete", () => deletable.Delete());
+		if (this._entity is IDeletable deletable) {
+			menu.Separator();
+			if (this._entity is ActorEntity actor)
+				menu.Action("Duplicate", () => this.DuplicateActor(actor));
+			menu.Action("Delete", () => deletable.Delete());
+		}
 	}
 	
 	// Entity types
@@ -125,6 +129,14 @@ public class SceneEntityMenuBuilder {
 
 	private void ImportMcdf(ActorEntity actor, string path) {
 		this._ctx.Characters.Mcdf.LoadAndApplyTo(path, actor.Actor);
+	}
+
+	private async void DuplicateActor(ActorEntity actor) {
+		// pack actor into a temp charafile to apply to new actor after creation
+		var file = await this._ctx.Characters.SaveCharaFile(actor);
+		this._ctx.Scene.Factory.CreateActor()
+			.WithAppearance(file)
+			.Spawn();
 	}
 	
 	// Poses

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -153,7 +153,11 @@ public class EditorInterface : IEditorInterface {
 	
 	// import/export wrappers
 
-	public void OpenCharaImport(ActorEntity actor) => this.OpenEditor<CharaImportDialog, ActorEntity>(actor);
+	public void OpenCharaImport(ActorEntity actor, bool toNpc = false) {
+		var editor = this._gui.GetOrCreate<CharaImportDialog>(this._ctx, toNpc);
+		editor.SetTarget(actor);
+		editor.Open();
+	}
 
 	public async Task OpenCharaExport(ActorEntity actor) {
 		var file = await this._ctx.Characters.SaveCharaFile(actor);

--- a/Ktisis/Interface/Editor/Types/IEditorInterface.cs
+++ b/Ktisis/Interface/Editor/Types/IEditorInterface.cs
@@ -41,7 +41,7 @@ public interface IEditorInterface {
 	
 	public void OpenEditorFor(SceneEntity entity);
 
-	public void OpenCharaImport(ActorEntity actor);
+	public void OpenCharaImport(ActorEntity actor, bool toNpc = false);
 	public Task OpenCharaExport(ActorEntity actor);
 	public void OpenPoseImport(ActorEntity actor);
 	public Task OpenPoseExport(EntityPose pose);

--- a/Ktisis/Interface/Windows/Editors/ActorWindow.cs
+++ b/Ktisis/Interface/Windows/Editors/ActorWindow.cs
@@ -12,6 +12,8 @@ using Ktisis.Interface.Types;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Structs.Actors;
 using Ktisis.Structs.Characters;
+using Ktisis.Interface.Components.Chara.Select;
+using Ktisis.GameData.Excel.Types;
 
 namespace Ktisis.Interface.Windows.Editors;
 
@@ -24,16 +26,21 @@ public class ActorWindow : EntityEditWindow<ActorEntity> {
 
 	private IAnimationManager Animation => this.Context.Animation;
 	private ICharacterManager Manager => this.Context.Characters;
+
+	private readonly NpcSelect _npcs;
 	
 	public ActorWindow(
 		IEditorContext ctx,
 		CustomizeEditorTab custom,
 		EquipmentEditorTab equip,
-		AnimationEditorTab anim
+		AnimationEditorTab anim,
+		NpcSelect npcs
 	) : base($"Actor Editor###{WindowId}", ctx) {
 		this._custom = custom;
 		this._equip = equip;
 		this._anim = anim;
+		this._npcs = npcs;
+		this._npcs.OnSelected += this.OnNpcSelect;
 	}
 	
 	// Target
@@ -55,6 +62,7 @@ public class ActorWindow : EntityEditWindow<ActorEntity> {
 	public override void OnOpen() {
 		this._custom.Setup();
 		this._anim.Setup();
+		this._npcs.FetchMonsters();
 	}
 
 	public override void PreDraw() {
@@ -83,11 +91,15 @@ public class ActorWindow : EntityEditWindow<ActorEntity> {
 	// Advanced tab
 
 	private unsafe void DrawMisc() {
+		var space = ImGui.GetStyle().ItemInnerSpacing.X;
 		ImGui.Spacing();
 		
 		var modelId = (int)this._editCustom.GetModelId();
 		if (ImGui.InputInt("Model ID", ref modelId))
 			this._editCustom.SetModelId((uint)modelId);
+
+		ImGui.SameLine(0, space);
+		this._npcs.DrawSearchIcon();
 
 		var chara = (CharacterEx*)this.Target.Character;
 		if (chara != null) {
@@ -138,4 +150,6 @@ public class ActorWindow : EntityEditWindow<ActorEntity> {
 			state.Wetness = chara != null ? chara->Wetness : null;
 		}
 	}
+
+	private void OnNpcSelect(INpcBase npc) => this._editCustom.SetModelId((uint)npc.GetModelId());
 }

--- a/Ktisis/Interface/Windows/Import/CharaImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/CharaImportDialog.cs
@@ -15,6 +15,7 @@ public class CharaImportDialog : EntityEditWindow<ActorEntity> {
 
 	public CharaImportDialog(
 		IEditorContext ctx,
+		bool toNpc,
 		CharaImportUI import
 	) : base(
 		"Import Appearance",
@@ -25,6 +26,8 @@ public class CharaImportDialog : EntityEditWindow<ActorEntity> {
 		this._import = import;
 		this._import.Context = ctx;
 		this._import.OnNpcSelected += this.OnNpcSelected;
+		if (toNpc)
+			this._import._method = LoadMethod.Npc;
 	}
 	
 	// Events


### PR DESCRIPTION
### Changes
- adds a right-click context option to Duplicate a target actor
- separates Import .Chara into Import Chara and Import NPC options in the right-click import menu
- adds a search button on the ActorEditor Misc tab to filter for any non-human NPCs

these are some quick-win enhancements short of a further exploration of bnpc/monster importing or other wide-ranging actor creation refactors. should simplify workflows involving multiple minion/monster props and make the npc importing features we surface more readily obvious to end-users