### PR TITLE
Allow workspace to initialize when Gpose is already active

### DIFF
--- a/Ktisis/Editor/Context/ContextManager.cs
+++ b/Ktisis/Editor/Context/ContextManager.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 
+using Dalamud.Plugin.Services;
+
 using Ktisis.Core.Attributes;
 using Ktisis.Core.Types;
 using Ktisis.Editor.Context.Types;
@@ -12,15 +14,18 @@ namespace Ktisis.Editor.Context;
 public class ContextManager : IDisposable {
 	private readonly GPoseService _gpose;
 	private readonly ContextBuilder _builder;
+	private readonly IFramework _framework;
 	
 	public IEditorContext? Current => this._context is { IsValid: true } ctx ? ctx : null;
 	
 	public ContextManager(
 		GPoseService gpose,
-		ContextBuilder builder
+		ContextBuilder builder,
+		IFramework framework
 	) {
 		this._gpose = gpose;
 		this._builder = builder;
+		this._framework = framework;
 	}
 
 	private bool _isInit;
@@ -34,6 +39,9 @@ public class ContextManager : IDisposable {
 		this._plugin = context;
 		this._gpose.StateChanged += this.OnGPoseEvent;
 		this._gpose.Subscribe();
+		
+		if (this._gpose.IsGPosing && this._plugin.Config.File.Editor.OpenOnEnterGPose)
+			this._framework.RunOnTick(() => this.OnGPoseEvent(this, true));
 	}
 	
 	// Handlers


### PR DESCRIPTION
Adds a check to show `WorkspaceWindow` when Ktisis starts in GPose.

https://github.com/user-attachments/assets/3ce03751-c4f9-4ab1-ae29-b563f5994cba

It should be noted that compiling from source while in GPose has presented some problems for this, but toggling the plugin state (as shown in the demo) has not interfered with this _yet_.

- When reviewing the comparisons in functionality from v0.2, it would not be possible to show the workspace window when GPose is not active.
- The `/ktisis` chat command also fails to recognize when the context is available because it is created with the editor, which only happens if `OpenOnEnterGPose` is true.