### PR TITLE
gizmo targeting for gaze control

### DIFF
--- a/Ktisis/Common/Utility/Transform.cs
+++ b/Ktisis/Common/Utility/Transform.cs
@@ -45,7 +45,7 @@ public class Transform : IEquatable<Transform> {
 		this.DecomposeMatrix(mx);
 	}
 
-	public Transform(ref Vector3 pos) {
+	public Transform(Vector3 pos) {
 		this.Position = pos;
 		this.Rotation = Quaternion.Identity;
 		this.Scale = Vector3.One;

--- a/Ktisis/Common/Utility/Transform.cs
+++ b/Ktisis/Common/Utility/Transform.cs
@@ -44,6 +44,12 @@ public class Transform : IEquatable<Transform> {
 	public Transform(Matrix4x4 mx) {
 		this.DecomposeMatrix(mx);
 	}
+
+	public Transform(ref Vector3 pos) {
+		this.Position = pos;
+		this.Rotation = Quaternion.Identity;
+		this.Scale = Vector3.One;
+	}
 	
 	// Matrix
 

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -50,7 +50,8 @@ public class EditorInterface : IEditorInterface {
 		this._gizmo.Initialize();
 		this._gui.GetOrCreate<OverlayWindow>(
 			this._ctx,
-			this._gizmo.Create(GizmoId.OverlayMain)
+			this._gizmo.Create(GizmoId.OverlayMain),
+			this._gizmo.Create(GizmoId.GazeTarget)
 		).Open();
 	}
 

--- a/Ktisis/Interface/Editor/Properties/ActorPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/ActorPropertyList.cs
@@ -8,6 +8,7 @@ using Dalamud.Bindings.ImGui;
 
 using GLib.Widgets;
 
+using Ktisis.Structs.Camera;
 using Ktisis.Data.Config;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Editor.Properties.Types;
@@ -208,9 +209,12 @@ public class ActorPropertyList : ObjectPropertyList {
 		using (ImRaii.PushColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive), IsGizmo[type])) {
 			if (Buttons.IconButtonTooltip(FontAwesomeIcon.LocationArrow, "Gizmo Tracking", Vector2.Zero)) {
 				result = true;
-				if (isTracking || !enabled) {
+				if (isTracking)
+					gaze.Mode = GazeMode.Target;
+				if (!enabled) {
 					gaze.Mode = GazeMode.Target;
 					enabled = true;
+					gaze.Pos = GetCameraLerpFor(actor);
 				}
 
 				// toggle this specific gizmotype
@@ -236,5 +240,10 @@ public class ActorPropertyList : ObjectPropertyList {
 		if (IsGizmo == null) return;
 		foreach (var key in IsGizmo.Keys)
 			IsGizmo[key] = false;
+	}
+
+	private unsafe Vector3 GetCameraLerpFor(ActorEntity actor) {
+		var camera = GameCameraEx.GetActive();
+		return camera != null ? Vector3.Lerp(actor.CsGameObject->Position, camera->Position, 0.5f) : actor.CsGameObject->Position;
 	}
 }

--- a/Ktisis/Interface/Editor/Properties/ActorPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/ActorPropertyList.cs
@@ -179,6 +179,9 @@ public class ActorPropertyList : ObjectPropertyList {
 
 		if (ImGui.Checkbox($"{type}", ref enabled)) {
 			result = true;
+			// if enabling via checkbox, set the position to a lerp instead of world origin
+			if (enabled)
+				gaze.Pos = GetCameraLerpFor(actor);
 			gaze.Mode = enabled ? GazeMode.Target : GazeMode.Disabled;
 		}
 

--- a/Ktisis/Interface/Overlay/Gizmo.cs
+++ b/Ktisis/Interface/Overlay/Gizmo.cs
@@ -10,7 +10,8 @@ namespace Ktisis.Interface.Overlay;
 public enum GizmoId : int {
 	Default = -1,
 	OverlayMain,
-	TransformEditor
+	TransformEditor,
+	GazeTarget
 }
 
 public interface IGizmo {

--- a/Ktisis/Interface/Overlay/OverlayWindow.cs
+++ b/Ktisis/Interface/Overlay/OverlayWindow.cs
@@ -121,8 +121,7 @@ public class OverlayWindow : KtisisWindow {
 	}
 
 	private bool DrawGazeGizmo() {
-		// todo: wack
-		// todo: prevent shift raycasting when manipulating a gazegizmo
+		// todo: kinda wack
 		if (!this._ctx.Config.Overlay.Visible) return false;
 		if (this.GazeTarget == null) return false;
 
@@ -131,7 +130,7 @@ public class OverlayWindow : KtisisWindow {
 		if (view == null || proj == null || this.Size == null)
 			return false;
 
-		// create transform target off of provided gaze position, empty rot and scale
+		// create transform target off position from ActorPropertyList if provided
 		var transform = new Transform((Vector3)this.GazeTarget);
 		var matrix = transform.ComposeMatrix();
 
@@ -144,7 +143,7 @@ public class OverlayWindow : KtisisWindow {
 		var size = this.Size.Value;
 		this._gizmoGaze.SetMatrix(view.Value, proj.Value);
 
-		// manipulate ref position with gaze gizmo
+		// set target to decomposed position for ActorPropertyList to consume
 		this._gizmoGaze.BeginFrame(Vector2.Zero, size);
 		var isManipulate = this._gizmoGaze.Manipulate(ref matrix, out _);
 		transform.DecomposeMatrix(matrix);

--- a/Ktisis/Interface/Overlay/OverlayWindow.cs
+++ b/Ktisis/Interface/Overlay/OverlayWindow.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Linq;
 using Matrix4x4 = System.Numerics.Matrix4x4;
+using Vector3 = System.Numerics.Vector3;
 
 using Dalamud.Bindings.ImGui;
 using Dalamud.Plugin.Services;
@@ -12,6 +13,7 @@ using Ktisis.Editor.Transforms.Types;
 using Ktisis.ImGuizmo;
 using Ktisis.Interface.Types;
 using Ktisis.Services.Game;
+using Ktisis.Common.Utility;
 
 namespace Ktisis.Interface.Overlay;
 
@@ -23,17 +25,20 @@ public class OverlayWindow : KtisisWindow {
 	
 	private readonly IEditorContext _ctx;
 	private readonly IGizmo _gizmo;
+	private readonly IGizmo _gizmoGaze;
 	private readonly SceneDraw _sceneDraw;
 
 	public OverlayWindow(
 		IGameGui gui,
 		IEditorContext ctx,
 		IGizmo gizmo,
+		IGizmo gizmoGaze,
 		SceneDraw draw
 	) : base("##KtisisOverlay", WindowFlags) {
 		this._gui = gui;
 		this._ctx = ctx;
 		this._gizmo = gizmo;
+		this._gizmoGaze = gizmoGaze;
 		this._sceneDraw = draw;
 		this._sceneDraw.SetContext(ctx);
 		this.PositionCondition = ImGuiCond.Always;
@@ -57,14 +62,14 @@ public class OverlayWindow : KtisisWindow {
 	public override void Draw() {
 		if (!this._ctx.Config.Overlay.Visible) return;
 		
-		//var t = new Stopwatch();
-		//t.Start();
+		// var t = new Stopwatch();
+		// t.Start();
 		
 		var gizmo = this.DrawGizmo();
 		this._sceneDraw.DrawScene(gizmo: gizmo, gizmoIsEnded: this._gizmo.IsEnded);
 		
-		//t.Stop();
-		//this.DrawDebug(t);
+		// t.Stop();
+		// this.DrawDebug(t);
 	}
 
 	private bool DrawGizmo() {
@@ -107,6 +112,39 @@ public class OverlayWindow : KtisisWindow {
 		return true;
 	}
 
+	public bool DrawGazeGizmo(ref Vector3 pos) {
+		// todo: wack
+		// todo: prevent shift raycasting when manipulating a gazegizmo
+		if (!this._ctx.Config.Overlay.Visible) return false;
+
+		var view = CameraService.GetViewMatrix();
+		var proj = CameraService.GetProjectionMatrix();
+		if (view == null || proj == null || this.Size == null)
+			return false;
+
+		// create transform target off of provided gaze position, empty rot and scale
+		var transform = new Transform(ref pos);
+		var matrix = transform.ComposeMatrix();
+
+		var cfg = this._ctx.Config.Gizmo;
+		this._gizmoGaze.Mode = Mode.World;
+		this._gizmoGaze.Operation = Operation.TRANSLATE;
+		this._gizmoGaze.AllowAxisFlip = cfg.AllowAxisFlip;
+		this._gizmoGaze.ScaleFactor = 0.075f;
+
+		var size = this.Size.Value;
+		this._gizmoGaze.SetMatrix(view.Value, proj.Value);
+
+		// manipulate ref position with gaze gizmo
+		this._gizmoGaze.BeginFrame(Vector2.Zero, size);
+		var isManipulate = this._gizmoGaze.Manipulate(ref matrix, out _);
+		transform.DecomposeMatrix(matrix);
+		pos = transform.Position;
+		this._gizmoGaze.EndFrame();
+
+		return isManipulate;
+	}
+
 	private bool HandleShiftRaycast(ref Matrix4x4 matrix) {
 		if (!this._ctx.Config.Gizmo.AllowRaySnap)
 			return false;
@@ -129,6 +167,7 @@ public class OverlayWindow : KtisisWindow {
 		ImGui.Text($"Scene: {this._ctx.Scene.GetHashCode():X} {this._ctx.Scene.UpdateTime:00.00}ms");
 		ImGui.Text($"Overlay: {this.GetHashCode()} {t.Elapsed.TotalMilliseconds:00.00}ms");
 		ImGui.Text($"Gizmo: {this._gizmo.GetHashCode():X} {this._gizmo.Id} ({this._gizmo.Operation}, {ImGuizmo.Gizmo.IsUsing})");
+		ImGui.Text($"Gaze Gizmo?: {this._gizmoGaze.GetHashCode():X} {this._gizmoGaze.Id} ({this._gizmoGaze.Operation}, {ImGuizmo.Gizmo.IsUsing})");
 		var target = this._ctx.Transform.Target;
 		ImGui.Text($"Target: {target?.GetHashCode() ?? 0:X7} {target?.GetType().Name ?? "NULL"} ({target?.Targets?.Count() ?? 0}, {target?.Primary?.Name ?? "NULL"})");
 		var history = this._ctx.Actions.History;

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -255,6 +255,7 @@ public class ActorModule : SceneModule {
 				var type = (GazeControl)i;
 				var ctrl = gaze[type];
 				if (ctrl.Mode != 0) {
+					// un-set fake followcam mode and modify position
 					if (ctrl.Mode == GazeMode._KtisisFollowCam_) {
 						var camera = GameCameraEx.GetActive();
 						if (camera != null) {
@@ -263,6 +264,10 @@ public class ActorModule : SceneModule {
 						}
 						ctrl.Mode = GazeMode.Target;
 					}
+
+					// un-set fake gizmo mode w/o modifications
+					if (ctrl.Mode == GazeMode._KtisisFollowGizmo_)
+						ctrl.Mode = GazeMode.Target;
 
 					this._actorLookAt(&detourCharacterEx->Gaze, &ctrl, type, IntPtr.Zero);
 

--- a/Ktisis/Structs/Actors/ActorGaze.cs
+++ b/Ktisis/Structs/Actors/ActorGaze.cs
@@ -71,5 +71,6 @@ public enum GazeMode : uint {
     Rotate = 2,
     Target = 3,
 
-    _KtisisFollowCam_ = 9
+    _KtisisFollowCam_ = 9,
+    _KtisisFollowGizmo_ = 10
 }


### PR DESCRIPTION
### changes
- reinstates gizmo targeting for gaze control fine-tuning
- allows the gaze editor to spawn a second gizmo via OverlayWindow for editing gaze coordinates
- tracks any gazes that should be driven by gizmo with _KtisisFollowGizmo_
- when first enabling a gaze controller, set the initial position to a friendly(ish) lerp between the actor and camera
- disables sliders when gaze or gizmo tracking, since they dont play nice

this brings us to feature parity with 0.2 on gaze control, but should be improved upon when we revisit (ex. when implementing actor targeting, etc)

### notes
- this is still a rough implementation even with changes from `72d337b9622b77b3d4bf3d7d12ae804b8a4f5aa2`, so we should still touchup in future