### PR TITLE
Disable close functionality in MigratorWindow

### DIFF
--- a/Ktisis/Legacy/Interface/MigratorWindow.cs
+++ b/Ktisis/Legacy/Interface/MigratorWindow.cs
@@ -27,6 +27,8 @@ public class MigratorWindow : KtisisWindow {
 	) {
 		this._dpi = dpi;
 		this._migrator = migrator;
+		this.ShowCloseButton = false;
+		this.RespectCloseHotkey = false;
 	}
 	
 	private readonly Stopwatch _timer = new();
@@ -109,11 +111,6 @@ public class MigratorWindow : KtisisWindow {
 				this.Close();
 			}
 		}
-		
-		ImGui.SameLine();
-		
-		if (ImGui.Button("Close"))
-			this.Close();
 		
 		ImGui.Spacing();
 	}


### PR DESCRIPTION
This fixes a possible state-corruption where if a user closes the migrator window (currently not implemented) instead of clicking the "Begin" button, it will cause an invalid plugin state until the plugin is reloaded.