### PR TITLE
Draft: Add IPC support for bone matrix manipulation

### DIFF
--- a/Ktisis/Editor/Transforms/TransformHandler.cs
+++ b/Ktisis/Editor/Transforms/TransformHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Numerics;
 
@@ -53,8 +54,12 @@ public class TransformHandler : ITransformHandler {
 	
 	// Transformation
 
-	public ITransformMemento Begin(ITransformTarget target) {
-		target.Setup.Configure(this._context.Config.Gizmo);
+	public ITransformMemento Begin(ITransformTarget target) => this.Begin(target, s => s.Configure(this._context.Config.Gizmo));
+
+	public ITransformMemento Begin(ITransformTarget target, Action<TransformSetup> configure)
+	{
+		configure(target.Setup);
+		
 		return new TransformMemento(
 			this,
 			target

--- a/Ktisis/Editor/Transforms/Types/ITransformHandler.cs
+++ b/Ktisis/Editor/Transforms/Types/ITransformHandler.cs
@@ -1,7 +1,11 @@
-﻿namespace Ktisis.Editor.Transforms.Types;
+﻿using System;
+
+namespace Ktisis.Editor.Transforms.Types;
 
 public interface ITransformHandler {
 	public ITransformTarget? Target { get; }
 	
 	public ITransformMemento Begin(ITransformTarget target);
+
+	public ITransformMemento Begin(ITransformTarget target, Action<TransformSetup> configure);
 }

--- a/Ktisis/Interface/Windows/DebugWindow.cs
+++ b/Ktisis/Interface/Windows/DebugWindow.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Numerics;
 using System.Threading.Tasks;
 
 using Dalamud.Interface;
@@ -7,6 +9,7 @@ using Dalamud.Bindings.ImGui;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
+using Ktisis.Common.Utility;
 using Ktisis.Core.Attributes;
 using Ktisis.Data.Files;
 using Ktisis.Editor.Context;
@@ -17,6 +20,7 @@ using Ktisis.Data.Config;
 using Ktisis.Editor.Context;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Components.Config;
+using Ktisis.Interface.Components.Transforms;
 using Ktisis.Interface.Types;
 using Ktisis.Services.Data;
 using Ktisis.Localization;
@@ -28,6 +32,7 @@ namespace Ktisis.Interface.Windows;
 public class DebugWindow : KtisisWindow {
 	private readonly IEditorContext _ctx;
 	private readonly GuiManager _gui;
+    private readonly TransformTable _transformTable;
 
     // tester inputs
     private int _gameObjectId;
@@ -36,6 +41,10 @@ public class DebugWindow : KtisisWindow {
     // tester outputs
     private (int, int)? _apiVersion = null;
     private bool? _isPosing = null;
+    
+    //Transform stuff
+    private Transform _transform = new();
+    private string _boneName = string.Empty;
 
 
     // ktisis subscriptions
@@ -44,11 +53,16 @@ public class DebugWindow : KtisisWindow {
     private readonly ICallGateSubscriber<bool> _ktisisIsPosing;
     private readonly ICallGateSubscriber<uint, string, Task<bool>> _ktisisLoadPose;
     private readonly ICallGateSubscriber<uint, Task<string?>> _ktisisSavePose;
+    private readonly ICallGateSubscriber<Task<Dictionary<int, HashSet<string>>>> _ktisisSelectedBones;
+    private readonly ICallGateSubscriber<uint, string, Task<Matrix4x4?>> _ktisisGetMatrix;
+    private readonly ICallGateSubscriber<uint, string, Matrix4x4, Task<bool>> _ktisisSetMatrix;
 
-	public DebugWindow(
+    public DebugWindow(
 		IEditorContext ctx,
         GuiManager gui,
-		IDalamudPluginInterface dpi
+		IDalamudPluginInterface dpi,
+        ConfigManager cfg,
+        LocaleManager locale
     ) : base(
         "Debug Window"
     ) {
@@ -61,6 +75,10 @@ public class DebugWindow : KtisisWindow {
         this._ktisisIsPosing = dpi.GetIpcSubscriber<bool>("Ktisis.IsPosing");
         this._ktisisLoadPose = dpi.GetIpcSubscriber<uint, string, Task<bool>>("Ktisis.LoadPose");
         this._ktisisSavePose = dpi.GetIpcSubscriber<uint, Task<string?>>("Ktisis.SavePose");
+        this._ktisisSelectedBones = dpi.GetIpcSubscriber<Task<Dictionary<int, HashSet<string>>>>("Ktisis.SelectedBones");
+        this._ktisisGetMatrix = dpi.GetIpcSubscriber<uint, string, Task<Matrix4x4?>>("Ktisis.GetMatrix");
+        this._ktisisSetMatrix = dpi.GetIpcSubscriber<uint, string, Matrix4x4, Task<bool>>("Ktisis.SetMatrix");
+        this._transformTable = new TransformTable(cfg, locale);
     }
 
 	public override void Draw() {
@@ -82,7 +100,7 @@ public class DebugWindow : KtisisWindow {
 		handler.Invoke();
 	}
 
-	private async void DrawProviderTab() {
+    private async void DrawProviderTab() {
         ImGui.InputInt("GameObject Index", ref _gameObjectId);
         ImGui.Text($"Clipboard Pose Data: {_hasClip}");
         ImGui.Spacing();
@@ -134,6 +152,54 @@ public class DebugWindow : KtisisWindow {
                 Ktisis.Log.Debug($"[DEBUG] Exported pose to clipboard from actor {_gameObjectId}: {clip}");
             }
         ImGui.Spacing();
+        
+        ImGui.Text("Ktisis.SelectedBones");
+        if (ImGui.Button("GET##SelectedBones"))
+        {
+            var bones = await this._ktisisSelectedBones.InvokeFunc();
+            
+            foreach (var (actorId, boneSet) in bones) {
+                Ktisis.Log.Debug($"[DEBUG] Actor {actorId} selected bones: {string.Join(", ", boneSet)}");
+            }
+        }
+        
+        ImGui.Spacing();
+        ImGui.Text("Bone Transform Get/Set");
+        ImGui.InputText("Bone Name", ref _boneName, 64);
+        
+        using (ImRaii.Disabled(_gameObjectId < 1 || string.IsNullOrEmpty(_boneName)))
+        {
+            if (ImGui.Button("GET##GetBoneTransform"))
+            {
+                var matrix = await this._ktisisGetMatrix.InvokeFunc((uint)_gameObjectId, _boneName);
+                if (matrix != null)
+                {
+                    _transform = new Transform(matrix.Value);
+                    Ktisis.Log.Debug($"[DEBUG] Got matrix for bone {_boneName} on actor {_gameObjectId}");
+                } else
+                {
+                    Ktisis.Log.Warning($"[DEBUG] Failed to get matrix for bone {_boneName} on actor {_gameObjectId}");
+                }
+            }
+            
+            ImGui.Text("Transform Matrix:"); 
+            if (this._transformTable.Draw(_transform, out var result, TransformTableFlags.Default))
+                _transform = result;
+
+            if (ImGui.Button("SET##SetBoneTransform"))
+            {
+                var success = await this._ktisisSetMatrix.InvokeFunc((uint)_gameObjectId, _boneName, _transform.ComposeMatrix());
+                if (success)
+                {
+                    Ktisis.Log.Debug($"[DEBUG] Set matrix for bone {_boneName} on actor {_gameObjectId}");
+                }
+                else
+                {
+                    Ktisis.Log.Warning($"[DEBUG] Failed to set matrix for bone {_boneName} on actor {_gameObjectId}");
+                }
+            }
+        }
+        
     }
 
     private void DrawManagerTab() {

--- a/Ktisis/Interop/Ipc/IpcProvider.cs
+++ b/Ktisis/Interop/Ipc/IpcProvider.cs
@@ -28,10 +28,8 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
     private ICallGateProvider<bool> IpcIsPosing { get; } = dpi.GetIpcProvider<bool>("Ktisis.IsPosing");
     private ICallGateProvider<uint, string, Task<bool>> IpcLoadPose { get; } = dpi.GetIpcProvider<uint, string, Task<bool>>("Ktisis.LoadPose");
     private ICallGateProvider<uint, Task<string?>> IpcSavePose { get; } = dpi.GetIpcProvider<uint, Task<string?>>("Ktisis.SavePose");
-    #if DEBUG
     private ICallGateProvider<uint, string, Matrix4x4, Task<bool>> IpcSetMatrix { get; } = dpi.GetIpcProvider<uint, string, Matrix4x4, Task<bool>>("Ktisis.SetMatrix");
     private ICallGateProvider<uint, string, Task<Matrix4x4?>> IpcGetMatrix { get; } = dpi.GetIpcProvider<uint, string, Task<Matrix4x4?>>("Ktisis.GetMatrix");
-    #endif
     private ICallGateProvider<Task<Dictionary<int, HashSet<string>>>> IpcSelectedBones { get; } = dpi.GetIpcProvider<Task<Dictionary<int, HashSet<string>>>>("Ktisis.SelectedBones");
 
     private (int, int) GetVersion() => (1, 0);
@@ -160,6 +158,9 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
         // bone.SetMatrix(matrix);
         return true;
     }
+    #else
+    private async Task<Matrix4x4?> GetMatrix(uint index, string boneName) => null;
+    private async Task<bool> SetMatrix(uint index, string boneName, Matrix4x4 matrix) => false;
     #endif
     
     public void RegisterIpc()
@@ -169,10 +170,8 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
         IpcIsPosing.RegisterFunc(IsActive);
         IpcLoadPose.RegisterFunc(LoadPose);
         IpcSavePose.RegisterFunc(SavePose);
-        #if DEBUG
         IpcGetMatrix.RegisterFunc(GetMatrix);
         IpcSetMatrix.RegisterFunc(SetMatrix);
-        #endif
         IpcSelectedBones.RegisterFunc(SelectedBones);
     }
 }

--- a/Ktisis/Interop/Ipc/IpcProvider.cs
+++ b/Ktisis/Interop/Ipc/IpcProvider.cs
@@ -4,9 +4,14 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
+using Ktisis.Common.Utility;
 using Ktisis.Core.Attributes;
+using Ktisis.Data.Config.Sections;
 using Ktisis.Data.Files;
 using Ktisis.Editor.Context;
+using Ktisis.Editor.Posing;
+using Ktisis.Editor.Transforms;
+using Ktisis.ImGuizmo;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Entities.Skeleton;
@@ -23,8 +28,10 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
     private ICallGateProvider<bool> IpcIsPosing { get; } = dpi.GetIpcProvider<bool>("Ktisis.IsPosing");
     private ICallGateProvider<uint, string, Task<bool>> IpcLoadPose { get; } = dpi.GetIpcProvider<uint, string, Task<bool>>("Ktisis.LoadPose");
     private ICallGateProvider<uint, Task<string?>> IpcSavePose { get; } = dpi.GetIpcProvider<uint, Task<string?>>("Ktisis.SavePose");
+    #if DEBUG
     private ICallGateProvider<uint, string, Matrix4x4, Task<bool>> IpcSetMatrix { get; } = dpi.GetIpcProvider<uint, string, Matrix4x4, Task<bool>>("Ktisis.SetMatrix");
     private ICallGateProvider<uint, string, Task<Matrix4x4?>> IpcGetMatrix { get; } = dpi.GetIpcProvider<uint, string, Task<Matrix4x4?>>("Ktisis.GetMatrix");
+    #endif
     private ICallGateProvider<Task<Dictionary<int, HashSet<string>>>> IpcSelectedBones { get; } = dpi.GetIpcProvider<Task<Dictionary<int, HashSet<string>>>>("Ktisis.SelectedBones");
 
     private (int, int) GetVersion() => (1, 0);
@@ -92,7 +99,7 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
 
         return ret;
     }
-
+    #if DEBUG
     private async Task<Matrix4x4?> GetMatrix(uint index, string boneName)
     {
         var actor = ctxManager.Current?.Scene?.GetEntityForIndex(index);
@@ -103,15 +110,57 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
     
     private async Task<bool> SetMatrix(uint index, string boneName, Matrix4x4 matrix)
     {
-        var actor = ctxManager.Current?.Scene?.GetEntityForIndex(index);
+        var ctx = ctxManager.Current;
+        if (ctx is null)
+            return false;
+        
+        var actor = ctx.Scene?.GetEntityForIndex(index);
 
         var bone = actor?.Pose?.Recurse().OfType<BoneNode>().FirstOrDefault(b => b.Info.Name == boneName);
         if (bone is null)
             return false;
 
-        bone.SetMatrix(matrix);
+        var target = new TransformTarget(actor, [bone]);
+        var transform = ctx.Transform.Begin(target, setup =>
+        {
+            setup.MirrorRotation = true;
+            setup.ParentBones = true;
+            setup.RelativeBones = true;
+        });
+        
+        Ktisis.Log.Debug(target.GetTransform().ToString());
+        
+        transform.SetMatrix(matrix);
+        transform.Dispatch();
+        
+        
+        //
+        // unsafe
+        // {
+        //     var hkaPose = bone.GetPose();
+        //     if (hkaPose is null) return false;
+        //     
+        //     var initial = HavokPosing.GetModelTransform(hkaPose, bone.Info.BoneIndex);
+        //     
+        //     var transform = ctx.Transform.Begin(transformTarget);
+        //     
+        //     transform.SetTransform(new Transform(matrix));
+        //     transform.Dispatch();
+        //
+        //     if (!propogate)
+        //         return true;
+        //    
+        //     var target = HavokPosing.GetModelTransform(hkaPose, bone.Info.BoneIndex);
+        //     if (target is null) return false;
+        //         
+        //     HavokPosing.Propagate(bone.GetSkeleton(), bone.Info.PartialIndex, bone.Info.BoneIndex, target, initial);
+        // }
+
+
+        // bone.SetMatrix(matrix);
         return true;
     }
+    #endif
     
     public void RegisterIpc()
     {
@@ -120,8 +169,10 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
         IpcIsPosing.RegisterFunc(IsActive);
         IpcLoadPose.RegisterFunc(LoadPose);
         IpcSavePose.RegisterFunc(SavePose);
-        IpcSetMatrix.RegisterFunc(SetMatrix);
+        #if DEBUG
         IpcGetMatrix.RegisterFunc(GetMatrix);
+        IpcSetMatrix.RegisterFunc(SetMatrix);
+        #endif
         IpcSelectedBones.RegisterFunc(SelectedBones);
     }
 }

--- a/Ktisis/Interop/Ipc/IpcProvider.cs
+++ b/Ktisis/Interop/Ipc/IpcProvider.cs
@@ -1,10 +1,14 @@
-﻿using System.Threading.Tasks;
-using Dalamud.Game.ClientState.Objects.Types;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Ktisis.Core.Attributes;
 using Ktisis.Data.Files;
 using Ktisis.Editor.Context;
+using Ktisis.Scene.Entities.Game;
+using Ktisis.Scene.Entities.Skeleton;
 using Ktisis.Scene.Modules.Actors;
 using Newtonsoft.Json;
 
@@ -18,7 +22,10 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
     private ICallGateProvider<bool> IpcIsPosing { get; } = dpi.GetIpcProvider<bool>("Ktisis.IsPosing");
     private ICallGateProvider<uint, string, Task<bool>> IpcLoadPose { get; } = dpi.GetIpcProvider<uint, string, Task<bool>>("Ktisis.LoadPose");
     private ICallGateProvider<uint, Task<string?>> IpcSavePose { get; } = dpi.GetIpcProvider<uint, Task<string?>>("Ktisis.SavePose");
-   
+    private ICallGateProvider<uint, string, Matrix4x4, Task<bool>> IpcSetMatrix { get; } = dpi.GetIpcProvider<uint, string, Matrix4x4, Task<bool>>("Ktisis.SetMatrix");
+    private ICallGateProvider<uint, string, Task<Matrix4x4?>> IpcGetMatrix { get; } = dpi.GetIpcProvider<uint, string, Task<Matrix4x4?>>("Ktisis.GetMatrix");
+    private ICallGateProvider<Task<Dictionary<int, HashSet<string>>>> IpcSelectedBones { get; } = dpi.GetIpcProvider<Task<Dictionary<int, HashSet<string>>>>("Ktisis.SelectedBones");
+
     private (int, int) GetVersion() => (1, 0);
 
     private bool RefreshActors()
@@ -57,6 +64,48 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
         return JsonConvert.SerializeObject(file);
     }
 
+    private async Task<Dictionary<int, HashSet<string>>> SelectedBones()
+    {
+        var sceneChildren = ctxManager.Current?.Scene?.Children
+            .OfType<ActorEntity>()
+            .ToList();
+        
+        if (sceneChildren is null || sceneChildren.Count == 0)
+            return new ();
+
+        var ret = new Dictionary<int, HashSet<string>>();
+        
+        foreach (var actor in sceneChildren)
+        {
+            if (!actor.IsValid || actor.Pose is null)
+                continue;
+
+            ret[actor.Actor.ObjectIndex] = actor.Children.OfType<BoneNode>().Where(s => s.IsSelected).Select(s => s.Name).ToHashSet();
+        }
+
+        return ret;
+    }
+
+    private async Task<Matrix4x4?> GetMatrix(uint index, string boneName)
+    {
+        var actor = ctxManager.Current?.Scene?.GetEntityForIndex(index);
+
+        var bone = actor?.Pose?.Children.OfType<BoneNode>().FirstOrDefault(b => b.Name == boneName);
+        return bone?.GetMatrix();
+    }
+    
+    private async Task<bool> SetMatrix(uint index, string boneName, Matrix4x4 matrix)
+    {
+        var actor = ctxManager.Current?.Scene?.GetEntityForIndex(index);
+
+        var bone = actor?.Pose?.Children.OfType<BoneNode>().FirstOrDefault(b => b.Name == boneName);
+        if (bone is null)
+            return false;
+
+        bone.SetMatrix(matrix);
+        return true;
+    }
+    
     public void RegisterIpc()
     {
         IpcVersion.RegisterFunc(GetVersion);
@@ -64,5 +113,8 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
         IpcIsPosing.RegisterFunc(IsActive);
         IpcLoadPose.RegisterFunc(LoadPose);
         IpcSavePose.RegisterFunc(SavePose);
+        IpcSetMatrix.RegisterFunc(SetMatrix);
+        IpcGetMatrix.RegisterFunc(GetMatrix);
+        IpcSelectedBones.RegisterFunc(SelectedBones);
     }
 }


### PR DESCRIPTION
This adds the following IPCs:

- `Ktisis.SetMatrix`  input: `uint actorIndex, string boneName, Matrix4x4 matrix` returning `Task<bool>`
  - This will take a given input matrix and apply it to the given bone
  - The usage of the Matrix4x4 is to provide all transforms in one Object, you can derive position (Vec3), rotation (quaternion) and scale (vec3) from this.
- `Ktisis.GetMatrix` input: `uint actorindex, string bonename` returning `Task<Matrix4x4?>`
  - This allows retrieving current matrix.
- `Ktisis.SelectedBones` no input, returning `Dictonary<int, HashSet<string>>`
  - This provides a list of ALL selected bones across each actor.

Current bug to be fixed: when calling `Ktisis.SetMatrix` it will successfully set the bone's matrix, but it will not propogate down any other bones if required, which kinda kills the usage of it.