### PR TITLE
Fix TransformTable deactivation logic

### DIFF
--- a/Ktisis/Interface/Components/Transforms/TransformTable.cs
+++ b/Ktisis/Interface/Components/Transforms/TransformTable.cs
@@ -47,7 +47,8 @@ public class TransformTable {
 	// State
 
 	private bool IsUsed;
-	
+	private bool WasUsed;
+
 	public bool IsActive { get; private set; }
 	public bool IsDeactivated { get; private set; }
 
@@ -97,6 +98,13 @@ public class TransformTable {
 			this.DrawRotate(ref transOut.Rotation, op);
 		if (flags.HasFlag(TransformTableFlags.Scale) && this.DrawScale(ref transOut.Scale, op))
 			transOut.Scale = Vector3.Max(transOut.Scale, MinScale);
+
+		if (this.IsUsed)
+			this.WasUsed = true;
+		if (!ImGui.IsWindowFocused(ImGuiFocusedFlags.AnyWindow) && this.WasUsed)
+			this.IsDeactivated = true;
+		if (this.IsDeactivated && this.WasUsed)
+			this.WasUsed = false;
 
 		return this.IsUsed;
 	}
@@ -210,7 +218,7 @@ public class TransformTable {
 		}
 	
 		this.IsActive |= ImGui.IsItemActive();
-		this.IsDeactivated |= ImGui.IsItemDeactivatedAfterEdit() | !ImGui.IsWindowFocused();
+		this.IsDeactivated |= ImGui.IsItemDeactivatedAfterEdit();
 		return result;
 	}
 	


### PR DESCRIPTION
This addresses issue where Transform.Dispatch would be spammed (causing many unwanted History additions) when manipulating transform with Object Editor gizmo.

Also correctly handles cases where TransformTable manipulation is interrupted by focus loss (whether game focus or imgui focus).