### PR TITLE
Visibility updates

### DIFF
--- a/Ktisis/Data/Config/Sections/OverlayConfig.cs
+++ b/Ktisis/Data/Config/Sections/OverlayConfig.cs
@@ -2,6 +2,7 @@
 
 public class OverlayConfig {
 	public bool Visible = true;
+	public bool BulkVisOverride = false;
 
 	public bool DrawLines = true;
 	public bool DrawLinesGizmo = true;

--- a/Ktisis/Interface/Components/Workspace/SceneTree.cs
+++ b/Ktisis/Interface/Components/Workspace/SceneTree.cs
@@ -241,7 +241,14 @@ public class SceneTree {
 
 		if (!isHover || !ImGui.IsItemHovered()) return;
 		using var _ = ImRaii.Tooltip();
-		var visibleType = vis is WorldEntity ? node.Type + " Root" : "Overlay";
+		var visibleType = vis switch {
+			WorldEntity => node.Type + " Root",
+			BoneNode => "Bone",
+			EntityPose => "Skeleton",
+			SkeletonGroup => "Bones",
+			_ => "Overlay"
+		};
+		// var visibleType = vis is WorldEntity ? node.Type + " Root" : "Overlay";
 		ImGui.Text((vis.Visible ? "Hide " : "Show ") + visibleType);
 	}
 

--- a/Ktisis/Interface/Components/Workspace/WorkspaceState.cs
+++ b/Ktisis/Interface/Components/Workspace/WorkspaceState.cs
@@ -13,6 +13,7 @@ using Ktisis.Editor.Context.Types;
 using Ktisis.Editor.Transforms;
 using Ktisis.Editor.Transforms.Types;
 using Ktisis.Interface.Widgets;
+using Ktisis.Scene.Decor;
 
 namespace Ktisis.Interface.Components.Workspace;
 
@@ -33,6 +34,7 @@ public class WorkspaceState {
 		using (ImRaii.ChildFrame(id, new Vector2(-1, height)))
 		{
 			this.DrawContext();
+			this.DrawShowAll();
 			this.DrawOverlayToggle();
 		}
 	}
@@ -162,6 +164,24 @@ public class WorkspaceState {
 		}
 	}
 
+	private void DrawShowAll() {
+		using var _ = ImRaii.PushId("##OverlayBulkVisButton");
+		using var bgCol = ImRaii.PushColor(ImGuiCol.Button, 0);
+
+		ImGui.SameLine();
+
+		var isActive = this._ctx.Config.Overlay.BulkVisOverride;
+		using var color = ImRaii.PushColor(ImGuiCol.Text, isActive ? 0xEFFFFFFF : 0x80FFFFFF);
+
+		var label = isActive ? "Hide All Bones" : "Show All Bones";
+
+		var avail = ImGui.GetContentRegionAvail();
+		var height = avail.Y - ImGui.GetCursorPosY() / 2;
+		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + avail.X - height*2 - ImGui.GetStyle().ItemInnerSpacing.X);
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.CircleNodes, label, new Vector2(height, height)))
+			this._ctx.Config.Overlay.BulkVisOverride = !isActive;
+	}
+
 	private void DrawOverlayToggle() {
 		using var _ = ImRaii.PushId("##OverlayToggleButton");
 		using var bgCol = ImRaii.PushColor(ImGuiCol.Button, 0);
@@ -172,11 +192,11 @@ public class WorkspaceState {
 		using var color = ImRaii.PushColor(ImGuiCol.Text, isActive ? 0xEFFFFFFF : 0x80FFFFFF);
 
 		var icon = isActive ? FontAwesomeIcon.Eye : FontAwesomeIcon.EyeSlash;
-		var label = this._ctx.Locale.Translate("actions.Overlay_Toggle");
+		var label = isActive ? this._ctx.Locale.Translate("workspace.overlay.hide") : this._ctx.Locale.Translate("workspace.overlay.show");
 		
 		var avail = ImGui.GetContentRegionAvail();
 		var height = avail.Y - ImGui.GetCursorPosY() / 2;
-		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + avail.X - height);
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		if (Buttons.IconButtonTooltip(icon, label, new Vector2(height, height)))
 			this._ctx.Config.Overlay.Visible = !isActive;
 	}

--- a/Ktisis/Interface/Overlay/OverlayWindow.cs
+++ b/Ktisis/Interface/Overlay/OverlayWindow.cs
@@ -62,6 +62,8 @@ public class OverlayWindow : KtisisWindow {
 	// Main draw function
 
 	public override void Draw() {
+		this._sceneDraw.DrawRefOverlay(); // draw ref images regardless of overall Overlay visibility
+
 		if (!this._ctx.Config.Overlay.Visible) {
 			this.CheckResetGizmo();
 			return;

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 using Dalamud.Bindings.ImGui;
@@ -43,7 +44,12 @@ public class SceneDraw {
 		this.DrawEntities(frame, this._ctx.Scene.Children);
 		this.DrawSelect(frame, gizmo, gizmoIsEnded);
 	}
-	
+
+	public void DrawRefOverlay() {
+		foreach (var image in this._ctx.Scene.Children.OfType<ReferenceImage>())
+			this._refs.DrawInstance(image);
+	}
+
 	private void DrawEntities(ISelectableFrame frame, IEnumerable<SceneEntity> entities) {
 		foreach (var entity in entities) {
 			switch (entity) {
@@ -55,9 +61,6 @@ public class SceneDraw {
 					if (position != null)
 						frame.AddItem(entity, position.Value, this._ctx);
 					break;
-				case ReferenceImage image:
-					this._refs.DrawInstance(image);
-					continue;
 			}
 
 			this.DrawEntities(frame, entity.Children);

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -70,7 +70,7 @@ public class SceneDraw {
 	// Skeletons
 
 	private unsafe void DrawSkeleton(ISelectableFrame frame, EntityPose pose) {
-		if (!pose.ShouldDraw()) return;
+		if (!pose.ShouldDraw() && !this.Config.BulkVisOverride) return;
 
 		var skeleton = pose.GetSkeleton();
 		if (skeleton == null || skeleton->PartialSkeletons == null) return;
@@ -91,10 +91,10 @@ public class SceneDraw {
 			var boneCt = hkaSkeleton->Bones.Length;
 			for (var i = 0; i < boneCt; i++) {
 				var node = pose.GetBoneFromMap(index, i);
-				if (node?.Visible != true) continue;
+				if (node?.Visible != true && !this.Config.BulkVisOverride) continue;
 
-				var transform = node.CalcTransformOverlay();
-				if (transform == null) continue;
+				var transform = node?.CalcTransformOverlay();
+				if (transform == null || node == null) continue;
 				
 				frame.AddItem(node, transform.Position, this._ctx);
 				
@@ -107,9 +107,9 @@ public class SceneDraw {
 					if (hkaSkeleton->ParentIndices[c] != i) continue;
 
 					var bone = pose.GetBoneFromMap(index, c);
-					if (bone?.Visible != true) continue;
+					if (bone?.Visible != true && !this.Config.BulkVisOverride) continue;
 
-					var lineTo = bone.CalcTransformOverlay();
+					var lineTo = bone?.CalcTransformOverlay();
 					if (lineTo == null) continue;
 
 					var display = this._ctx.Config.GetEntityDisplay(node);

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -106,7 +106,8 @@
 		"create": "Create new...",
 		"refresh_entities": "Refresh scene entities",
 		"edit_mode.hint": "Select editing mode",
-		"overlay.toggle": "Toggle screen overlay"
+		"overlay.hide": "Hide Ktisis overlay",
+		"overlay.show": "Show Ktisis overlay"
 	},
 	
 	"transform_edit": {


### PR DESCRIPTION
- allows reference images to draw even when global overlay visibility is disabled
- adds a Bulk Visibility Override button to the workspace header, which when toggled, forces visibility of all bones regardless of their IVisibility state
- updated tooltips for hovering IVisibility entries in the SceneTree - Bones now show as `Hide Bone`, Poses now show as `Hide Skeleton`, etc for better clarity
- updated wording of overlay toggle tooltip: `Hide/Show Ktisis overlay`