### PR TITLE
fix(ipc): Ktisis.SavePose would return malformed pose json

### DIFF
--- a/Ktisis/Data/Json/JsonFileSerializer.cs
+++ b/Ktisis/Data/Json/JsonFileSerializer.cs
@@ -1,10 +1,12 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using Ktisis.Core.Attributes;
 using Ktisis.Data.Json.Converters;
 
 namespace Ktisis.Data.Json;
 
+[Singleton]
 public class JsonFileSerializer {
 	private readonly JsonSerializerOptions Options;
 	private readonly JsonSerializerOptions DeserializeOptions;

--- a/Ktisis/Editor/Posing/PosingModule.cs
+++ b/Ktisis/Editor/Posing/PosingModule.cs
@@ -10,6 +10,7 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 using FFXIVClientStructs.Havok.Animation.Rig;
 using FFXIVClientStructs.Havok.Common.Base.Math.QsTransform;
 
+using Ktisis.Data.Json;
 using Ktisis.Editor.Context;
 using Ktisis.Interop.Hooking;
 using Ktisis.Interop.Ipc;
@@ -33,11 +34,12 @@ public sealed class PosingModule : HookModule {
 		PosingManager manager,
 		ActorService actors,
 		ContextManager contextManager,
-		IDalamudPluginInterface dpi
+		IDalamudPluginInterface dpi,
+		JsonFileSerializer fileSerializer
 	) : base(hook) {
 		this.Manager = manager;
 		this._actors = actors;
-		this._ipc = new IpcProvider(contextManager, dpi);
+		this._ipc = new IpcProvider(contextManager, dpi, fileSerializer);
 	}
 	
 	// Module interface

--- a/Ktisis/Interop/Ipc/IpcProvider.cs
+++ b/Ktisis/Interop/Ipc/IpcProvider.cs
@@ -7,8 +7,10 @@ using System.Threading.Tasks;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 
+using Ktisis.Common.Utility;
 using Ktisis.Core.Attributes;
 using Ktisis.Data.Files;
+using Ktisis.Data.Json;
 using Ktisis.Editor.Context;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Editor.Posing.Data;
@@ -16,14 +18,11 @@ using Ktisis.Editor.Transforms;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Entities.Skeleton;
 using Ktisis.Scene.Modules.Actors;
-using Ktisis.Common.Utility;
-
-using Newtonsoft.Json;
 
 namespace Ktisis.Interop.Ipc;
 
 [Singleton]
-public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi) : IDisposable {
+public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi, JsonFileSerializer fileSerializer) : IDisposable {
 	private ICallGateProvider<(int, int)> IpcVersion { get; } = dpi.GetIpcProvider<(int, int)>("Ktisis.ApiVersion");
 	private ICallGateProvider<bool> IpcRefreshActions { get; } = dpi.GetIpcProvider<bool>("Ktisis.RefreshActors");
 	private ICallGateProvider<bool> IpcIsPosing { get; } = dpi.GetIpcProvider<bool>("Ktisis.IsPosing");
@@ -66,7 +65,7 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
 		if (ctxManager.Current is null)
 			return false;
 
-		var file = JsonConvert.DeserializeObject<PoseFile>(json);
+		var file = fileSerializer.Deserialize<PoseFile>(json);
 		var actor = ctxManager.Current.Scene.GetEntityForIndex(index);
 
 		if (actor is null || file is null)
@@ -90,7 +89,7 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
 			return null;
 
 		var file = await ctxManager.Current.Posing.SavePoseFile(actor.Pose);
-		return JsonConvert.SerializeObject(file);
+		return fileSerializer.Serialize(file);
 	}
 
 	private async Task<Dictionary<int, HashSet<string>>> SelectedBones() {
@@ -131,6 +130,7 @@ public class IpcProvider(ContextManager ctxManager, IDalamudPluginInterface dpi)
 	private async Task<Matrix4x4?> GetMatrix(uint index, string boneName, bool useWorldSpace) {
 		var actor = GetEntity(index);
 		var bone = actor?.Pose?.FindBoneByName(boneName);
+
 		if (bone is null) return null;
 		//ws
 		if (useWorldSpace) return bone.GetMatrix();


### PR DESCRIPTION

Small bug due to using Newtonsoft.JSON instead of STJ.
Would cause poses to come up with a structured response, not the string joined Quat/Vec/Transform.

Set JsonFileSerializer to a singleton as that is required as the IPCProvider pulls it up, but that's safe anyway.