### PR TITLE
Rework CI release flow for v0.3 testing branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,8 @@ jobs:
             Ktisis/bin/Release/Ktisis/checksums.sha512
 
       - name: Update repo.json
+        working-directory: ""
         run: |
-          cd ../
-
           release_version=$(echo ${{ github.ref_name }} | sed 's/^v//')
           repo_url=$(echo ${{ github.server_url }}/${{ github.repository }} | sed 's/#/\\#/g')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,16 +79,22 @@ jobs:
           release_version=$(echo ${{ github.ref_name }} | sed 's/^v//')
           repo_url=$(echo ${{ github.server_url }}/${{ github.repository }} | sed 's/#/\\#/g')
 
-          sed -i repo.json -E \
-              -e 's#"AssemblyVersion": "([0-9]*\.){2,3}[0-9]*"#"AssemblyVersion": "'"$release_version"'"#g' \
-              -e 's#"TestingAssemblyVersion": "([0-9]*\.){2,3}[0-9]*"#"TestingAssemblyVersion": "'"$release_version"'"#' \
-              -e 's#"DownloadLinkInstall": "[^"]*"#"DownloadLinkInstall": "'"$repo_url/releases/download/${{ github.ref_name }}/latest.zip"'"#g' \
-              -e 's#"DownloadLinkTesting": "[^"]*"#"DownloadLinkTesting": "'"$repo_url/releases/download/${{ github.ref_name }}/latest.zip"'"#g' \
-              -e 's#"DownloadLinkUpdate": "[^"]*"#"DownloadLinkUpdate": "'"$repo_url/releases/download/${{ github.ref_name }}/latest.zip"'"#g'
+          # we only need the current head
+          git fetch origin main --depth=1
+          # very carefully pull in main's repo.json only
+          git checkout --detach
+          git reset --mixed FETCH_HEAD
+          git checkout -- repo.json
 
+          # now edit it
+          sed -i repo.json -E \
+              -e 's#"TestingAssemblyVersion": "([0-9]*\.){2,3}[0-9]*"#"TestingAssemblyVersion": "'"$release_version"'"#' \
+              -e 's#"DownloadLinkTesting": "[^"]*"#"DownloadLinkTesting": "'"$repo_url/releases/download/${{ github.ref_name }}/latest.zip"'"#g' \
+
+          # and commit
           git add repo.json
           git config --local user.name "github-actions [bot]"
           git config --local user.email "github-actions@users.noreply.github.com"
-          git commit -m "Update repo.json for ${{ github.ref_name }}"
+          git commit -m "Update repo.json for testing ${{ github.ref_name }}"
           
           git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       IsCI: true
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true # Grab any submodules that may be required
 


### PR DESCRIPTION
This makes the CI on v0.3/main only update the testing branch variables.

It also shouldn't fail anymore.