### PR TITLE
Target/Selection Enhancements

### DIFF
--- a/Ktisis/Data/Config/Sections/EditorConfig.cs
+++ b/Ktisis/Data/Config/Sections/EditorConfig.cs
@@ -17,6 +17,7 @@ public class EditorConfig {
 	
 	public bool ToggleEditorOnSelect = true;
 	public bool CloseEditorOnDeselect = false;
+	public bool SelectOnTarget = false;
 
 	public bool IncognitoPlayerNames = false;
 

--- a/Ktisis/Data/Config/Sections/OverlayConfig.cs
+++ b/Ktisis/Data/Config/Sections/OverlayConfig.cs
@@ -9,7 +9,7 @@ public class OverlayConfig {
 	public bool DrawDotsGizmo = true;
 
 	public bool DimOverlayForInactiveActors = false;
-	public ActiveState ActiveStateType = ActiveState.Selection;
+	public ActiveState ActiveStateType = ActiveState.Target;
 	public float InactiveOpacity = 0.5f;
 
 	public float DotRadius = 7.0f;
@@ -21,7 +21,7 @@ public class OverlayConfig {
 }
 
 public enum ActiveState {
-	Selection,
 	Target,
+	Selection,
 	Both
 }

--- a/Ktisis/Data/Config/Sections/OverlayConfig.cs
+++ b/Ktisis/Data/Config/Sections/OverlayConfig.cs
@@ -9,6 +9,7 @@ public class OverlayConfig {
 	public bool DrawDotsGizmo = true;
 
 	public bool DimOverlayForInactiveActors = false;
+	public bool PresetsOnActiveActor = false;
 	public ActiveState ActiveStateType = ActiveState.Target;
 	public float InactiveOpacity = 0.5f;
 

--- a/Ktisis/Data/Config/Sections/OverlayConfig.cs
+++ b/Ktisis/Data/Config/Sections/OverlayConfig.cs
@@ -8,10 +8,20 @@ public class OverlayConfig {
 	public bool DrawLinesGizmo = true;
 	public bool DrawDotsGizmo = true;
 
+	public bool DimOverlayForInactiveActors = false;
+	public ActiveState ActiveStateType = ActiveState.Selection;
+	public float InactiveOpacity = 0.5f;
+
 	public float DotRadius = 7.0f;
 	public float LineThickness = 2.0f;
 	public float LineOpacity = 0.95f;
 	public float LineOpacityUsing = 0.15f;
 	
 	public bool DrawReferenceTitle = true;
+}
+
+public enum ActiveState {
+	Selection,
+	Target,
+	Both
 }

--- a/Ktisis/Editor/Context/ContextBuilder.cs
+++ b/Ktisis/Editor/Context/ContextBuilder.cs
@@ -67,7 +67,7 @@ public class ContextBuilder {
 		var input = new InputManager(context, scope, this._keyState);
 		var actions = new ActionManager(context, input);
 		var factory = new EntityFactory(context, this._naming, this._mcdf);
-		var select = new SelectManager(context);
+		var select = new SelectManager(context, this._gpose);
 		var attach = new AttachManager();
 		var autoSave = new PoseAutoSave(context, this._framework, this._format);
 

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Dalamud.Game.ClientState.Objects.Types;
+
 using Ktisis.Editor.Context.Types;
 using Ktisis.Events;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Entities.Skeleton;
+using Ktisis.Services.Game;
 
 namespace Ktisis.Editor.Selection;
 
@@ -41,6 +44,7 @@ public interface ISelectManager {
 
 public class SelectManager : ISelectManager {
 	private readonly IEditorContext _context;
+	private readonly GPoseService _gpose;
 
 	private readonly Event<Action<ISelectManager>> _changed = new();
 	public event SelectChangedHandler Changed {
@@ -49,18 +53,31 @@ public class SelectManager : ISelectManager {
 	}
 
 	private readonly List<SceneEntity> Selected = new();
+	private IGameObject? Targeted;
 	
 	public SelectManager(
-		IEditorContext context
+		IEditorContext context,
+		GPoseService gpose
 	) {
 		this._context = context;
+		this._gpose = gpose;
 	}
 	
 	// Update handler
 
 	public void Update() {
+		// remove any invalid entities and flag selection changed if we do
 		var remove = this.Selected.RemoveAll(item => !item.IsValid);
 		if (remove > 0) this.InvokeChanged();
+
+		// check SelectOnTarget and update selection if we should
+		if (this._context.Config.Editor.SelectOnTarget && this.Targeted is not null && this._gpose.GPoseTarget is not null && !this.Targeted.Equals(this._gpose.GPoseTarget)) {
+			var actor = this._context.Scene.GetEntityForIndex(this._gpose.GPoseTarget.ObjectIndex);
+			if (actor is not null)
+				this.Select(actor, SelectMode.Force);
+		}
+		// update internal previous target to compare next frame
+		this.Targeted = this._gpose.GPoseTarget;
 	}
 	
 	// Selection

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -4,8 +4,10 @@ using System.Linq;
 
 using Dalamud.Game.ClientState.Objects.Types;
 
+using Ktisis.Data.Config.Sections;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Events;
+using Ktisis.Scene;
 using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Entities.Skeleton;
@@ -52,6 +54,7 @@ public class SelectManager : ISelectManager {
 		remove => this._changed.Remove(value.Invoke);
 	}
 
+	private readonly HashSet<ActorEntity> PreviousActors = new();
 	private readonly List<SceneEntity> Selected = new();
 	private IGameObject? Targeted;
 	
@@ -76,6 +79,48 @@ public class SelectManager : ISelectManager {
 			if (actor is not null)
 				this.Select(actor, SelectMode.Force);
 		}
+
+		// handle application of presets on any changed active actors
+		if (this._context.Config.Overlay.PresetsOnActiveActor) {
+			// handle preset update based on gpose target change
+			if (this._context.Config.Overlay.ActiveStateType is ActiveState.Target or ActiveState.Both) {
+				if (this.Targeted is not null && this._gpose.GPoseTarget is not null && !this.Targeted.Equals(this._gpose.GPoseTarget)) {
+					var prevTarget = this._context.Scene.GetEntityForIndex(this.Targeted.ObjectIndex);
+					var newTarget = this._context.Scene.GetEntityForIndex(this._gpose.GPoseTarget.ObjectIndex);
+					if (prevTarget is not null && newTarget is not null)
+						foreach (var preset in prevTarget.GetPresets().Where(p => p.isEnabled == PresetState.Enabled)) {
+							newTarget.TogglePreset(preset.name, true);
+							prevTarget.TogglePreset(preset.name, false);
+						}
+				}
+			}
+
+			// handle preset update based on selection change
+			if (this._context.Config.Overlay.ActiveStateType is ActiveState.Selection or ActiveState.Both) {
+				var actorsInSelection = this._context.Scene.Children.OfType<ActorEntity>().Where(this.IsActorSelected).ToList();
+
+				// only need to do any preset stuff if we had actor/s selected previously
+				if (this.PreviousActors.Count > 0) {
+					// all selected actors will have equivalent presets to work with
+					var presets = this.PreviousActors.First().GetPresets().ToList();
+
+					// for actors in selection and not prev, post their presets
+					foreach (var actor in actorsInSelection.Except(this.PreviousActors))
+						foreach (var preset in presets.Where(p => p.isEnabled == PresetState.Enabled))
+							actor.TogglePreset(preset.name, true);
+
+					// for actors in prev and not selection, clear their presets
+					foreach (var actor in this.PreviousActors.Except(actorsInSelection))
+						foreach (var preset in presets.Where(p => p.isEnabled == PresetState.Enabled))
+							actor.TogglePreset(preset.name, false);
+				}
+
+				// flush and update internal previous selections for next frame comparisons
+				this.PreviousActors.Clear();
+				this.PreviousActors.UnionWith(actorsInSelection);
+			}
+		}
+
 		// update internal previous target to compare next frame
 		this.Targeted = this._gpose.GPoseTarget;
 	}

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -102,16 +102,16 @@ public class SelectManager : ISelectManager {
 				// only need to do any preset stuff if we had actor/s selected previously
 				if (this.PreviousActors.Count > 0) {
 					// all selected actors will have equivalent presets to work with
-					var presets = this.PreviousActors.First().GetPresets().ToList();
+					var presets = this.PreviousActors.First().GetPresets().Where(p => p.isEnabled == PresetState.Enabled).ToList();
 
 					// for actors in selection and not prev, post their presets
 					foreach (var actor in actorsInSelection.Except(this.PreviousActors))
-						foreach (var preset in presets.Where(p => p.isEnabled == PresetState.Enabled))
+						foreach (var preset in presets)
 							actor.TogglePreset(preset.name, true);
 
 					// for actors in prev and not selection, clear their presets
 					foreach (var actor in this.PreviousActors.Except(actorsInSelection))
-						foreach (var preset in presets.Where(p => p.isEnabled == PresetState.Enabled))
+						foreach (var preset in presets)
 							actor.TogglePreset(preset.name, false);
 				}
 

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -14,6 +14,7 @@ using Ktisis.Data.Config.Sections;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Scene.Decor;
 using Ktisis.Scene.Entities;
+using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Entities.Skeleton;
 using Ktisis.Scene.Entities.Utility;
 using Ktisis.Services.Game;
@@ -26,15 +27,18 @@ public class SceneDraw {
 	private readonly RefOverlay _refs;
 	
 	private IEditorContext _ctx = null!;
+	private readonly GPoseService _gpose;
 
 	private OverlayConfig Config => this._ctx.Config.Overlay;
 
 	public SceneDraw(
 		SelectableGui select,
-		RefOverlay refs
+		RefOverlay refs,
+		GPoseService gpose
 	) {
 		this._select = select;
 		this._refs = refs;
+		this._gpose = gpose;
 	}
 
 	public void SetContext(IEditorContext ctx) => this._ctx = ctx;
@@ -113,17 +117,23 @@ public class SceneDraw {
 					if (lineTo == null) continue;
 
 					var display = this._ctx.Config.GetEntityDisplay(node);
-					this.DrawLine(camera, drawList, transform.Position, lineTo.Position, display.Color);
+					float? opacity = null;
+					if (pose.Parent is ActorEntity actor)
+						opacity = this.GetOpacityMultiplier(actor);
+
+					this.DrawLine(camera, drawList, transform.Position, lineTo.Position, display.Color, opacity);
 				}
 			}
 		}
 	}
 	
-	private unsafe void DrawLine(Camera* camera, ImDrawListPtr drawList, Vector3 fromPos, Vector3 toPos, uint color) {
+	private unsafe void DrawLine(Camera* camera, ImDrawListPtr drawList, Vector3 fromPos, Vector3 toPos, uint color, float? opacityMultiplier) {
 		if (!CameraService.WorldToScreen(camera, fromPos, out var fromPos2d)) return;
 		if (!CameraService.WorldToScreen(camera, toPos, out var toPos2d)) return;
 
 		var opacity = ImGuizmo.IsUsing() ? this.Config.LineOpacityUsing : this.Config.LineOpacity;
+		if (opacityMultiplier is not null)
+			opacity *= opacityMultiplier.Value;
 		drawList.AddLine(fromPos2d, toPos2d, color.SetAlpha(opacity), this.Config.LineThickness);
 	}
 	
@@ -133,5 +143,19 @@ public class SceneDraw {
 		if (gizmo && gizmoIsEnded) return;
 		var mode = GuiHelpers.GetSelectMode();
 		this._ctx.Selection.Select(clicked, mode);
+	}
+
+	private float GetOpacityMultiplier(ActorEntity actor) {
+		if (!this.Config.DimOverlayForInactiveActors) return 1.0f;
+
+		if (this.Config.ActiveStateType is ActiveState.Target or ActiveState.Both) {
+			if (this._gpose.GPoseTarget?.ObjectIndex == actor.Actor.ObjectIndex)
+				return 1.0f;
+		} else if (this.Config.ActiveStateType is ActiveState.Selection or ActiveState.Both) {
+			if (actor.IsSelected || actor.Recurse().Any(x => x.IsSelected))
+				return 1.0f;
+		}
+
+		return this.Config.InactiveOpacity;
 	}
 }

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -54,7 +54,7 @@ public class SceneDraw {
 			this._refs.DrawInstance(image);
 	}
 
-	private void DrawEntities(ISelectableFrame frame, IEnumerable<SceneEntity> entities) {
+	private void DrawEntities(ISelectableFrame frame, IEnumerable<SceneEntity> entities, float opacity = 1.0f) {
 		foreach (var entity in entities) {
 			switch (entity) {
 				case EntityPose pose:
@@ -63,11 +63,14 @@ public class SceneDraw {
 				case IVisibility { Visible: true } and ITransform manip:
 					var position = manip.GetTransform()?.Position;
 					if (position != null)
-						frame.AddItem(entity, position.Value, this._ctx);
+						frame.AddItem(entity, position.Value, this._ctx, opacity);
 					break;
 			}
 
-			this.DrawEntities(frame, entity.Children);
+			if (entity is ActorEntity actor)
+				this.DrawEntities(frame, entity.Children, this.GetOpacityMultiplier(actor));
+			else
+				this.DrawEntities(frame, entity.Children);
 		}
 	}
 	
@@ -84,6 +87,10 @@ public class SceneDraw {
 
 		var drawList = ImGui.GetWindowDrawList();
 
+		float? opacity = null;
+		if (pose.Parent is ActorEntity actor)
+			opacity = this.GetOpacityMultiplier(actor);
+
 		var partialCt = skeleton->PartialSkeletonCount;
 		for (var index = 0; index < partialCt; index++) {
 			var partial = skeleton->PartialSkeletons[index];
@@ -93,6 +100,7 @@ public class SceneDraw {
 
 			var hkaSkeleton = hkaPose->Skeleton;
 			var boneCt = hkaSkeleton->Bones.Length;
+
 			for (var i = 0; i < boneCt; i++) {
 				var node = pose.GetBoneFromMap(index, i);
 				if (node?.Visible != true && !this.Config.BulkVisOverride) continue;
@@ -100,7 +108,10 @@ public class SceneDraw {
 				var transform = node?.CalcTransformOverlay();
 				if (transform == null || node == null) continue;
 				
-				frame.AddItem(node, transform.Position, this._ctx);
+				if (opacity is not null)
+					frame.AddItem(node, transform.Position, this._ctx, opacity.Value);
+				else
+					frame.AddItem(node, transform.Position, this._ctx);
 				
 				// Draw lines to children.
 
@@ -117,10 +128,6 @@ public class SceneDraw {
 					if (lineTo == null) continue;
 
 					var display = this._ctx.Config.GetEntityDisplay(node);
-					float? opacity = null;
-					if (pose.Parent is ActorEntity actor)
-						opacity = this.GetOpacityMultiplier(actor);
-
 					this.DrawLine(camera, drawList, transform.Position, lineTo.Position, display.Color, opacity);
 				}
 			}

--- a/Ktisis/Interface/Overlay/SelectableGui.cs
+++ b/Ktisis/Interface/Overlay/SelectableGui.cs
@@ -177,7 +177,7 @@ public class SelectableGui {
 		drawList.AddCircle(
 			pos2d,
 			radius,
-			0xFF000000,
+			0xFF000000.SetAlpha(finalAlpha),
 			16,
 			isSelect ? 2.5f : 1.0f
 		);

--- a/Ktisis/Interface/Overlay/SelectableGui.cs
+++ b/Ktisis/Interface/Overlay/SelectableGui.cs
@@ -27,7 +27,7 @@ namespace Ktisis.Interface.Overlay;
 public interface ISelectableFrame {
 	public IEnumerable<IItemSelect> GetItems();
 	
-	public void AddItem(SceneEntity entity, Vector3 worldPos, IEditorContext ctx);
+	public void AddItem(SceneEntity entity, Vector3 worldPos, IEditorContext ctx, float opacityMultiplier = 1.0f);
 }
 
 public interface IItemSelect {
@@ -37,6 +37,7 @@ public interface IItemSelect {
 	public Vector2 ScreenPos { get; }
 	
 	public float Distance { get; }
+	public float OpacityMultiplier { get; }
 	
 	public bool IsHovered { get; set; }
 }
@@ -83,7 +84,7 @@ public class SelectableGui {
 
 			var isSelect = item.Entity.IsSelected;
 			item.IsHovered = display.Mode switch {
-				DisplayMode.Dot => this.DrawPrimDot(drawList, item.ScreenPos, display, isSelect),
+				DisplayMode.Dot => this.DrawPrimDot(drawList, item.ScreenPos, display, item.OpacityMultiplier, isSelect),
 				DisplayMode.Icon => this.DrawIconDot(drawList, item.ScreenPos, display, isSelect),
 				_ => false
 			};
@@ -158,14 +159,18 @@ public class SelectableGui {
 	
 	// Draw UI dots
 
-	private bool DrawPrimDot(ImDrawListPtr drawList, Vector2 pos2d, EntityDisplay display, bool isSelect = false) {
+	private bool DrawPrimDot(ImDrawListPtr drawList, Vector2 pos2d, EntityDisplay display, float opacityMultiplier, bool isSelect = false) {
 		var radius = this.Config.Overlay.DotRadius;
 		if (isSelect) radius += 1.0f;
-		
+
+		var alpha = (byte)((display.Color & 0xFF000000) >> 24);
+		var finalAlpha = alpha == 0 ? opacityMultiplier : (alpha / 255.0f) * opacityMultiplier;
+		var col = display.Color.SetAlpha(finalAlpha);
+
 		drawList.AddCircleFilled(
 			pos2d,
 			radius,
-			display.Color,
+			col,
 			16
 		);
 
@@ -218,14 +223,14 @@ public class SelectableGui {
 
 		public IEnumerable<IItemSelect> GetItems() => this.Items.AsReadOnly();
 		
-		public unsafe void AddItem(SceneEntity entity, Vector3 worldPos, IEditorContext ctx) {
+		public unsafe void AddItem(SceneEntity entity, Vector3 worldPos, IEditorContext ctx, float opacityMultiplier = 1.0f) {
 			var camera = CameraService.GetSceneCamera();
 			if (camera == null) return;
 
 			if (!CameraService.WorldToScreen(camera, worldPos, out var pos2d)) return;
 
 			var dist = Vector3.Distance(camera->Object.Position, worldPos);
-			var select = new ItemSelect(entity, pos2d, dist);
+			var select = new ItemSelect(entity, pos2d, dist, opacityMultiplier);
 			this.Items.Add(select);
 
 			// render a short ray in the facing-direction for LightEntities
@@ -282,14 +287,16 @@ public class SelectableGui {
 		public Vector2 ScreenPos { get; }
 
 		public float Distance { get; }
+		public float OpacityMultiplier { get; }
 		public readonly int SortPriority;
 
 		public bool IsHovered { get; set; }
 
-		public ItemSelect(SceneEntity entity, Vector2 screenPos, float dist) {
+		public ItemSelect(SceneEntity entity, Vector2 screenPos, float dist, float opacityMultiplier) {
 			this.Entity = entity;
 			this.ScreenPos = screenPos;
 			this.Distance = dist;
+			this.OpacityMultiplier = opacityMultiplier;
 		}
 	}
 }

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -219,6 +219,8 @@ public class ConfigWindow : KtisisWindow {
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.confirmExit"), ref this.Config.Editor.ConfirmExit);
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.openTray"), ref this.Config.Editor.OpenTrayOnWorkspaceClose);
 		this.DrawHint("config.workspace.hintTrayIcon");
+		ImGui.Checkbox(this.Locale.Translate("config.workspace.selectTarget"), ref this.Config.Editor.SelectOnTarget);
+		this.DrawHint("config.workspace.hintSelectTarget");
 
 		ImGui.Spacing();
 

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -15,6 +15,7 @@ using GLib.Widgets;
 
 using Ktisis.Common.Utility;
 using Ktisis.Data.Config;
+using Ktisis.Data.Config.Sections;
 using Ktisis.Editor.Context;
 using Ktisis.Interface.Components.Config;
 using Ktisis.Interface.Types;
@@ -195,6 +196,22 @@ public class ConfigWindow : KtisisWindow {
 		ImGui.Spacing();
 		ImGui.SliderFloat(this.Locale.Translate("config.overlay.lines.opacity"), ref this.Config.Overlay.LineOpacity, 0.0f, 1.0f);
 		ImGui.SliderFloat(this.Locale.Translate("config.overlay.lines.opacity_gizmo"), ref this.Config.Overlay.LineOpacityUsing, 0.0f, 1.0f);
+
+		ImGui.Spacing();
+		ImGui.Separator();
+		ImGui.Spacing();
+
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.dim_inactive"), ref this.Config.Overlay.DimOverlayForInactiveActors);
+		ImGui.Spacing();
+		using (ImRaii.Disabled(!this.Config.Overlay.DimOverlayForInactiveActors)) {
+			using (var _combo = ImRaii.Combo(this.Locale.Translate("config.overlay.active_state_chooser"), this.Config.Overlay.ActiveStateType.ToString()))
+				if (_combo.Success)
+					foreach (var stateType in Enum.GetValues<ActiveState>())
+						if (ImGui.Selectable(stateType.ToString(), stateType == this.Config.Overlay.ActiveStateType))
+							this.Config.Overlay.ActiveStateType = stateType;
+
+			ImGui.SliderFloat(this.Locale.Translate("config.overlay.inactive_opacity"), ref this.Config.Overlay.InactiveOpacity, 0.0f, 1.0f);
+		}
 	}
 	
 	// Workspace

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -201,17 +201,16 @@ public class ConfigWindow : KtisisWindow {
 		ImGui.Separator();
 		ImGui.Spacing();
 
-		ImGui.Checkbox(this.Locale.Translate("config.overlay.dim_inactive"), ref this.Config.Overlay.DimOverlayForInactiveActors);
+		using (var _combo = ImRaii.Combo(this.Locale.Translate("config.overlay.active_state_chooser"), this.Config.Overlay.ActiveStateType.ToString()))
+			if (_combo.Success)
+				foreach (var stateType in Enum.GetValues<ActiveState>())
+					if (ImGui.Selectable(stateType.ToString(), stateType == this.Config.Overlay.ActiveStateType))
+						this.Config.Overlay.ActiveStateType = stateType;
 		ImGui.Spacing();
-		using (ImRaii.Disabled(!this.Config.Overlay.DimOverlayForInactiveActors)) {
-			using (var _combo = ImRaii.Combo(this.Locale.Translate("config.overlay.active_state_chooser"), this.Config.Overlay.ActiveStateType.ToString()))
-				if (_combo.Success)
-					foreach (var stateType in Enum.GetValues<ActiveState>())
-						if (ImGui.Selectable(stateType.ToString(), stateType == this.Config.Overlay.ActiveStateType))
-							this.Config.Overlay.ActiveStateType = stateType;
-
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.keep_presets_on_active"), ref this.Config.Overlay.PresetsOnActiveActor);
+		ImGui.Checkbox(this.Locale.Translate("config.overlay.dim_inactive"), ref this.Config.Overlay.DimOverlayForInactiveActors);
+		if (this.Config.Overlay.DimOverlayForInactiveActors)
 			ImGui.SliderFloat(this.Locale.Translate("config.overlay.inactive_opacity"), ref this.Config.Overlay.InactiveOpacity, 0.0f, 1.0f);
-		}
 	}
 	
 	// Workspace

--- a/Ktisis/Legacy/Interface/V2MigratorWindow.cs
+++ b/Ktisis/Legacy/Interface/V2MigratorWindow.cs
@@ -69,6 +69,8 @@ public class V2MigratorWindow {
 		DialogHelpers.BuildDialog(ref this._migrator._tempConfig.Overlay.LineOpacity, 0.95f, string.Empty, this.Locale.Translate("migrator.v2.overlay.lineOpacity"), string.Empty);
 		DialogHelpers.BuildDialog(ref this._migrator._tempConfig.Overlay.LineOpacityUsing, 0.15f, string.Empty, this.Locale.Translate("migrator.v2.overlay.lineOpacityUsing"), string.Empty);
 		DialogHelpers.BuildDialog(ref this._migrator._tempConfig.Overlay.DotRadius, 7.0f, string.Empty, this.Locale.Translate("migrator.v2.overlay.dotRadius"), string.Empty);
+		DialogHelpers.BuildDialog(ref this._migrator._tempConfig.Editor.SelectOnTarget, false, string.Empty, this.Locale.Translate("migrator.v2.overlay.selectTarget"), this.Locale.Translate("migrator.v2.overlay.selectTargetTip"));
+		DialogHelpers.BuildDialog(ref this._migrator._tempConfig.Overlay.DimOverlayForInactiveActors, false, string.Empty, this.Locale.Translate("migrator.v2.overlay.dimInactive"), this.Locale.Translate("migrator.v2.overlay.dimInactiveTip"));
 	}
 
 	public void DrawAutoSave() {

--- a/Ktisis/Legacy/LegacyMigrator.cs
+++ b/Ktisis/Legacy/LegacyMigrator.cs
@@ -127,6 +127,8 @@ public class LegacyMigrator {
 		cfg.Keybinds.Enabled = this._legacyCfg?.EnableKeybinds ?? cfg.Keybinds.Enabled;
 
 		cfg.Editor.UseToolbar = true; // teehee
+		cfg.Editor.SelectOnTarget = true;
+		cfg.Overlay.DimOverlayForInactiveActors = true; // set these also for v2 enjoyers
 
 		// File
 		if (this._legacyCfg?.SavedDirPaths?.Count > 0) {

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -701,7 +701,10 @@
 			"dots": {
 				"draw_gizmo": "Draw dots while using gizmo",
 				"radius": "Dot radius"
-			}
+			},
+			"dim_inactive": "Dim bones on inactive actors",
+			"active_state_chooser": "Active state for actors",
+			"inactive_opacity": "Opacity while inactive"
 		},
 		"references": {
 			"draw_title": "Draw title for reference images"

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -702,6 +702,7 @@
 				"draw_gizmo": "Draw dots while using gizmo",
 				"radius": "Dot radius"
 			},
+			"keep_presets_on_active": "Keep Presets enabled when active actor changes",
 			"dim_inactive": "Dim bones on inactive actors",
 			"active_state_chooser": "Active state for actors",
 			"inactive_opacity": "Opacity while inactive"

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -730,6 +730,8 @@
 			"hint_AutoResizeObj": "This disables the ability to resize the editors height, but you can still change its width",
 			"openTray": "When closing the workspace in GPose, open a Ktisis Tray icon",
 			"hintTrayIcon": "The widget is movable when you click and drag, and will reopen the workspace when clicked",
+			"selectTarget": "Automatically Select actors when Targeted",
+			"hintSelectTarget": "An actor is Targeted when clicked or tabbed-to with vanilla GPose controls.\nThis toggle will override Ktisis' current Selection to your new Target when one is chosen.",
 			"workcam": {
 				"speed": "Work camera speed",
 				"fastMulti": "Work camera fast-multiplier",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -932,7 +932,11 @@
 				"lineThickness": "Line thickness",
 				"lineOpacity": "Line opacity",
 				"lineOpacityUsing": "Line opacity using",
-				"dotRadius": "Dot radius"
+				"dotRadius": "Dot radius",
+				"selectTarget": "Select actors when Targeted",
+				"selectTargetTip": "Unlike v0.2, Ktisis v0.3 allows multiple actors to be edited simultaneously, allowing the camera to orbit independently of your selected actor's skeleton. This setting links camera targeting to actor selection for a more familiar muscle memory to v0.2.",
+				"dimInactive": "Dim bones on inactive actors",
+				"dimInactiveTip": "If multiple skeletons are visible, this setting will add a transparency/dimming effect to those not in focus. This can be further customized in the Overlay settings after migration."
 			},
 			"autosave": {
 				"header": "Auto Save settings",


### PR DESCRIPTION
- added SelectOnTarget to force-update Selection when Target is changed (observed by SelectManager)
- added PresetsOnActiveActor which updates preset visibility based on configured ActiveStateType
- added DimOverlayForInactiveActors, ActiveStateType, and InactiveOpacity to control a bone+skeleton opacity multiplier to be applied on any actors who are not considered primary/active in the scene
  - active state can be chosen from whether an actor is Targeted, Selected, or Either/Both

thanks primu+beef