### PR TITLE
Add missing translation key for Scene Editor on Toolbar

### DIFF
--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -43,6 +43,7 @@
 		"Toolbar_ToggleEnv": "Switch to the Environment Editor",
 		"Toolbar_ToggleCamera": "Switch to the Camera Editor",
 		"Toolbar_ToggleConfig": "Switch to the Configuration Window",
+		"Toolbar_ToggleScene": "Switch to the Scene Editor",
 		"Scene_RefreshEntities": "Refresh scene entities"
 	},
 	


### PR DESCRIPTION
Before:
<img width="527" height="39" alt="T78Mv1c4Gi" src="https://github.com/user-attachments/assets/ae34def3-d64a-44e9-8283-c44670adb320" />
After:
<img width="526" height="36" alt="uInADyImIA" src="https://github.com/user-attachments/assets/55f935fb-8460-4985-b68b-4f924cf8be1d" />
