### PR TITLE
Multi-Monitor/Windowed Overlay Fix

### DIFF
--- a/Ktisis/Interface/Overlay/SelectableGui.cs
+++ b/Ktisis/Interface/Overlay/SelectableGui.cs
@@ -260,6 +260,7 @@ public class SelectableGui {
 
 	public static List<ImRect> WindowOverlaps() {
 		var windowList = new List<ImRect>();
+		var viewport = ImGui.GetMainViewport();
 
 		foreach (var window in ImGui.GetCurrentContext().Windows.Where(w => w.WasActive)) {
 			if (window.Pos != Vector2.Zero)
@@ -269,7 +270,9 @@ public class SelectableGui {
 	}
 
 	public static bool CheckPosClip(Vector2 position, List<ImRect> clipRects) {
-		foreach (var rect in clipRects.Where(w => w.Min != Vector2.Zero)) {
+		// compare windows against both 0,0 min and viewport Pos+Size to determine if they're fullscreen overlays that should not block posclipping
+		var viewport = ImGui.GetMainViewport();
+		foreach (var rect in clipRects.Where(w => w.Min != Vector2.Zero && !(w.Min == viewport.Pos && w.Max == viewport.Pos + viewport.Size))) {
 			var imRect = rect;
 			if (imRect.Contains(position))
 				return true;

--- a/Ktisis/Interface/Overlay/SelectableGui.cs
+++ b/Ktisis/Interface/Overlay/SelectableGui.cs
@@ -260,7 +260,6 @@ public class SelectableGui {
 
 	public static List<ImRect> WindowOverlaps() {
 		var windowList = new List<ImRect>();
-		var viewport = ImGui.GetMainViewport();
 
 		foreach (var window in ImGui.GetCurrentContext().Windows.Where(w => w.WasActive)) {
 			if (window.Pos != Vector2.Zero)


### PR DESCRIPTION
SelectableGui was busted on multi-monitor/windowed setups due to an assumption that only windows whose minimum rect coordinates matched 0,0 should be excluded from rect collision checking.

When multi-monitor is on (or windowed mode is active), it's possible for our Overlay windows or those provided by other tools (Gizmo and KtisisOverlay) to have their minimum coordinate at the Viewport's current screen position, and their maximum coordinate as the sum of screen pos and screen size.

this adds a second layer of filtering to CheckPosClip to exclude both 0,0-coord windows and windows whose min+max align exactly with the viewport's min&max values, wherever the game is on-screen. this allows both World Nodes and PrimDots/IconDots to be clicked/scrollwheeled as expected in any resolution