### PR TITLE
Persistent siblink + Bone Parenting

### DIFF
--- a/Ktisis/Data/Config/Sections/EditorConfig.cs
+++ b/Ktisis/Data/Config/Sections/EditorConfig.cs
@@ -19,6 +19,7 @@ public class EditorConfig {
 	public bool ToggleEditorOnSelect = true;
 	public bool CloseEditorOnDeselect = false;
 	public bool SelectOnTarget = false;
+	public bool PersistentSiblingLink = false;
 
 	public bool IncognitoPlayerNames = false;
 

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -172,11 +172,14 @@ public class SelectManager : ISelectManager {
 		if (!modeMulti)
 			this.Selected.Clear();
 
-		if (!isSelect || !modeMulti && isMulti)
+		if (!isSelect || !modeMulti && isMulti) {
 			this.Selected.Add(entity);
-		else
+			this.TrySiblingSelect(entity, true);
+		} else {
 			this.Selected.Remove(entity);
-		
+			this.TrySiblingSelect(entity, false);
+		}
+
 		this.InvokeChanged();
 	}
 
@@ -188,6 +191,22 @@ public class SelectManager : ISelectManager {
 	public void Clear() {
 		this.Selected.Clear();
 		this.InvokeChanged();
+	}
+
+	private void TrySiblingSelect(SceneEntity entity, bool select) {
+		if (!this._context.Config.Editor.PersistentSiblingLink) return;
+		if (entity is not BoneNode bone) return;
+
+		var sibling = bone.Pose.TryResolveSibling(bone);
+		if (sibling is null) return;
+
+		this.Selected.Add(sibling);
+	}
+
+	private static BoneNode? TryGetSibling(SceneEntity entity) {
+		if (entity is not BoneNode bone) return null;
+		var sibling = bone.Pose.TryResolveSibling(bone);
+		return sibling;
 	}
 	
 	// Event invocation

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -202,20 +202,29 @@ public class SelectManager : ISelectManager {
 		this.InvokeChanged();
 	}
 
-	// called whenever a selection is added or removed to update its paired sibling if necessary
+	// called whenever a selection is added or removed to update its paired sibling(s) if necessary
 	private void TrySiblingSelect(SceneEntity entity, bool select) {
 		if (!this._context.Config.Editor.PersistentSiblingLink) return;
-		if (entity is not BoneNode bone) return;
+		List<BoneNode> bones = [];
+		switch (entity) {
+			case BoneNode bone:
+				bones.Add(bone);
+				break;
+			case SkeletonGroup group:
+				bones.AddRange(group.GetIndividualBones());
+				break;
+		}
 
-		var sibling = bone.Pose.TryResolveSibling(bone);
-		if (sibling is null) return;
-		if (select && this.Selected.Contains(sibling)) return; // break if trying to add when already present
-		if (!select && !this.Selected.Contains(sibling)) return; // break if trying to remove when not present
+		foreach (var sibling in bones.Select(bone => bone.Pose.TryResolveSibling(bone))) {
+			if (sibling is null) return;
+			if (select && this.Selected.Contains(sibling)) return; // break if trying to add when already present
+			if (!select && !this.Selected.Contains(sibling)) return; // break if trying to remove when not present
 
-		if (select)
-			this.Selected.Add(sibling);
-		else
-			this.Selected.Remove(sibling);
+			if (select)
+				this.Selected.Add(sibling);
+			else
+				this.Selected.Remove(sibling);
+		}
 	}
 	
 	// Event invocation

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -42,6 +42,7 @@ public interface ISelectManager {
 	public void Unselect(SceneEntity entity);
 	
 	public void Clear();
+	public void TryUpdateSelectedSiblings();
 }
 
 public class SelectManager : ISelectManager {
@@ -193,20 +194,28 @@ public class SelectManager : ISelectManager {
 		this.InvokeChanged();
 	}
 
+	public void TryUpdateSelectedSiblings() {
+		var entities = this.GetSelected().ToList(); // copy to local var to avoid changing list mid-enumeration
+		foreach (var entity in entities)
+			this.TrySiblingSelect(entity, true);
+
+		this.InvokeChanged();
+	}
+
+	// called whenever a selection is added or removed to update its paired sibling if necessary
 	private void TrySiblingSelect(SceneEntity entity, bool select) {
 		if (!this._context.Config.Editor.PersistentSiblingLink) return;
 		if (entity is not BoneNode bone) return;
 
 		var sibling = bone.Pose.TryResolveSibling(bone);
 		if (sibling is null) return;
+		if (select && this.Selected.Contains(sibling)) return; // break if trying to add when already present
+		if (!select && !this.Selected.Contains(sibling)) return; // break if trying to remove when not present
 
-		this.Selected.Add(sibling);
-	}
-
-	private static BoneNode? TryGetSibling(SceneEntity entity) {
-		if (entity is not BoneNode bone) return null;
-		var sibling = bone.Pose.TryResolveSibling(bone);
-		return sibling;
+		if (select)
+			this.Selected.Add(sibling);
+		else
+			this.Selected.Remove(sibling);
 	}
 	
 	// Event invocation

--- a/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/PosePropertyList.cs
@@ -53,9 +53,6 @@ public class PosePropertyList : ObjectPropertyList {
 	private async void DrawPoseTab(EntityPose pose) {
 		var spacing = ImGui.GetStyle().ItemInnerSpacing.X;
 		
-		// Parenting toggle
-		ImGui.Checkbox(this._locale.Translate("transform_edit.transforms.parenting"), ref this._ctx.Config.Gizmo.ParentBones);
-		
 		// Import/export when ActorEntity is being drawn for
 		var actor = pose.Parent;
 		if (actor is not ActorEntity) return;

--- a/Ktisis/Interface/Windows/ObjectWindow.cs
+++ b/Ktisis/Interface/Windows/ObjectWindow.cs
@@ -9,6 +9,8 @@ using Dalamud.Bindings.ImGuizmo;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 
+using FFXIVClientStructs;
+
 using GLib.Widgets;
 
 using Ktisis.Common.Utility;
@@ -189,44 +191,19 @@ public class ObjectWindow : KtisisWindow {
 		ImGui.SameLine(0, spacing);
 
 		// Sibling Link selector
-		// if we have a selection & target's primary entity is a bone node, draw the button
-		// if we have >1 bonenodes selected or no sibling, disable the button
-		// if we have 1 bonenode selected that has a sibling, enable the button
-		// if right-clicked; enable persistent sibling link - whenever a bone is selected, check and attempt to sibling-select if possible
-		var selected = target?.Primary;
-		var selectionCount = target?.Targets.Count();
-		if (selectionCount != 0 && selected != null && selected is BoneNode bNode) {
-			var siblingNode = bNode.Pose.TryResolveSibling(bNode);
-			var siblingAvailable = siblingNode != null;
-			var siblingKey = siblingAvailable ? (selectionCount == 1 ? "available" : "multiple") : "unavailable";
-			var siblingHint = this._ctx.Locale.Translate(
-				$"transform_edit.sibling.{siblingKey}",
-				new Dictionary<string, string> {
-						{ "bone", siblingAvailable ? siblingNode.Name : bNode.Name }
-				}
-			);
+		// 7-20-26 - switched from 1x sibling button to an always-visible toggle. on enable, try forcing sibling selections if any are already chosen
+		// if enabled, SelectManager handles auto-multi-selecting (and deselecting) Siblings (L/R paired bone names) whenever applicable
 
-			unsafe {
-				using var _ = ImRaii.Disabled(!siblingAvailable || selectionCount != 1); // disable if current bone has no sibling or if multiple selections
-				if (Buttons.IconButtonTooltip(
-					FontAwesomeIcon.PeopleArrows,
-					siblingHint,
-					iconBtnSize,
-					this._ctx.Config.Editor.PersistentSiblingLink ? *ImGui.GetStyleColorVec4(ImGuiCol.TabActive) : *ImGui.GetStyleColorVec4(ImGuiCol.Text)
-				))
-					this._ctx.Selection.Select(siblingNode, SelectMode.Multiple); // if a sibling exists, select it assuming SelectMode.Multiple
-				if (ImGui.IsItemClicked(ImGuiMouseButton.Right)) {
-					this._ctx.Config.Editor.PersistentSiblingLink = !this._ctx.Config.Editor.PersistentSiblingLink; // toggle persistent links on right-click
-					if (this._ctx.Config.Editor.PersistentSiblingLink)
-						this._ctx.Selection.Select(siblingNode, SelectMode.Multiple); // if we enable persistence, sibling select at the same time
-				}
+		var linked = this._ctx.Config.Editor.PersistentSiblingLink;
+		using (ImRaii.PushColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive), linked)) {
+			var label = linked ? "transform_edit.sibling.linkDisable" : "transform_edit.sibling.linkEnable";
+			if (Buttons.IconButtonTooltip(FontAwesomeIcon.PeopleArrows, Ktisis.Locale.Translate(label), iconBtnSize)) {
+				this._ctx.Config.Editor.PersistentSiblingLink = !this._ctx.Config.Editor.PersistentSiblingLink;
+				if (this._ctx.Config.Editor.PersistentSiblingLink)
+					this._ctx.Selection.TryUpdateSelectedSiblings();
 			}
-
-			ImGui.SameLine(0, spacing);
-		} else {
-			ImGui.Dummy(iconBtnSize);
-			ImGui.SameLine(0, spacing);
 		}
+		ImGui.SameLine(0, spacing);
 
 		var avail = ImGui.GetContentRegionAvail().X - (this._ctx.Config.Editor.UseToolbar ? 3f : 0);
 		if (avail > iconSize)

--- a/Ktisis/Interface/Windows/ObjectWindow.cs
+++ b/Ktisis/Interface/Windows/ObjectWindow.cs
@@ -156,6 +156,8 @@ public class ObjectWindow : KtisisWindow {
 		var iconSize = UiBuilder.DefaultFontSizePx * ImGuiHelpers.GlobalScale * 2;
 		var iconBtnSize = new Vector2(iconSize, iconSize);
 
+		// Gizmo Global/Local
+
 		var mode = this._ctx.Config.Gizmo.Mode;
 		var modeIcon = mode == ImGuizmoMode.World ? FontAwesomeIcon.Globe : FontAwesomeIcon.Home;
 		var modeKey = mode == ImGuizmoMode.World ? "world" : "local";
@@ -165,6 +167,8 @@ public class ObjectWindow : KtisisWindow {
 		
 		ImGui.SameLine(0, spacing);
 
+		// Gizmo Visibility
+
 		var visible = this._ctx.Config.Gizmo.Visible;
 		var visIcon = visible ? FontAwesomeIcon.Eye : FontAwesomeIcon.EyeSlash;
 		var visHint = this._ctx.Locale.Translate("actions.Gizmo_Toggle");
@@ -172,6 +176,8 @@ public class ObjectWindow : KtisisWindow {
 			this._ctx.Config.Gizmo.Visible = !visible;
 
 		ImGui.SameLine(0, spacing);
+
+		// Mirror Modes
 
 		var mirrorState = this._ctx.Config.Gizmo.MirrorRotation;
 		var flagIcon = FontAwesomeIcon.GripLines;
@@ -190,20 +196,33 @@ public class ObjectWindow : KtisisWindow {
 
 		ImGui.SameLine(0, spacing);
 
+		// Bone Parenting
+
+		var parenting = this._ctx.Config.Gizmo.ParentBones;
+		using (ImRaii.PushColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive), !parenting)) {
+			var pLabel = parenting ? "transform_edit.transforms.parentingDisable" : "transform_edit.transforms.parenting";
+			var icon = parenting ? FontAwesomeIcon.Link : FontAwesomeIcon.Unlink;
+			if (Buttons.IconButtonTooltip(icon, Ktisis.Locale.Translate(pLabel), iconBtnSize))
+				this._ctx.Config.Gizmo.ParentBones = !parenting;
+		}
+		ImGui.SameLine(0, spacing);
+
 		// Sibling Link selector
 		// 7-20-26 - switched from 1x sibling button to an always-visible toggle. on enable, try forcing sibling selections if any are already chosen
 		// if enabled, SelectManager handles auto-multi-selecting (and deselecting) Siblings (L/R paired bone names) whenever applicable
 
 		var linked = this._ctx.Config.Editor.PersistentSiblingLink;
 		using (ImRaii.PushColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive), linked)) {
-			var label = linked ? "transform_edit.sibling.linkDisable" : "transform_edit.sibling.linkEnable";
-			if (Buttons.IconButtonTooltip(FontAwesomeIcon.PeopleArrows, Ktisis.Locale.Translate(label), iconBtnSize)) {
-				this._ctx.Config.Editor.PersistentSiblingLink = !this._ctx.Config.Editor.PersistentSiblingLink;
+			var sLabel = linked ? "transform_edit.sibling.linkDisable" : "transform_edit.sibling.linkEnable";
+			if (Buttons.IconButtonTooltip(FontAwesomeIcon.PeopleArrows, Ktisis.Locale.Translate(sLabel), iconBtnSize)) {
+				this._ctx.Config.Editor.PersistentSiblingLink = !linked;
 				if (this._ctx.Config.Editor.PersistentSiblingLink)
 					this._ctx.Selection.TryUpdateSelectedSiblings();
 			}
 		}
 		ImGui.SameLine(0, spacing);
+
+		// jump to right-boundary for TransformEditor show/hide caret
 
 		var avail = ImGui.GetContentRegionAvail().X - (this._ctx.Config.Editor.UseToolbar ? 3f : 0);
 		if (avail > iconSize)

--- a/Ktisis/Interface/Windows/ObjectWindow.cs
+++ b/Ktisis/Interface/Windows/ObjectWindow.cs
@@ -192,6 +192,7 @@ public class ObjectWindow : KtisisWindow {
 		// if we have a selection & target's primary entity is a bone node, draw the button
 		// if we have >1 bonenodes selected or no sibling, disable the button
 		// if we have 1 bonenode selected that has a sibling, enable the button
+		// if right-clicked; enable persistent sibling link - whenever a bone is selected, check and attempt to sibling-select if possible
 		var selected = target?.Primary;
 		var selectionCount = target?.Targets.Count();
 		if (selectionCount != 0 && selected != null && selected is BoneNode bNode) {
@@ -205,9 +206,21 @@ public class ObjectWindow : KtisisWindow {
 				}
 			);
 
-			using var _ = ImRaii.Disabled(!siblingAvailable || selectionCount != 1); // disable if current bone has no sibling or if multiple selections
-			if (Buttons.IconButtonTooltip(FontAwesomeIcon.PeopleArrows, siblingHint, iconBtnSize))
-				this._ctx.Selection.Select(siblingNode, SelectMode.Multiple); // if a sibling exists, select it assuming SelectMode.Multiple
+			unsafe {
+				using var _ = ImRaii.Disabled(!siblingAvailable || selectionCount != 1); // disable if current bone has no sibling or if multiple selections
+				if (Buttons.IconButtonTooltip(
+					FontAwesomeIcon.PeopleArrows,
+					siblingHint,
+					iconBtnSize,
+					this._ctx.Config.Editor.PersistentSiblingLink ? *ImGui.GetStyleColorVec4(ImGuiCol.TabActive) : *ImGui.GetStyleColorVec4(ImGuiCol.Text)
+				))
+					this._ctx.Selection.Select(siblingNode, SelectMode.Multiple); // if a sibling exists, select it assuming SelectMode.Multiple
+				if (ImGui.IsItemClicked(ImGuiMouseButton.Right)) {
+					this._ctx.Config.Editor.PersistentSiblingLink = !this._ctx.Config.Editor.PersistentSiblingLink; // toggle persistent links on right-click
+					if (this._ctx.Config.Editor.PersistentSiblingLink)
+						this._ctx.Selection.Select(siblingNode, SelectMode.Multiple); // if we enable persistence, sibling select at the same time
+				}
+			}
 
 			ImGui.SameLine(0, spacing);
 		} else {
@@ -215,7 +228,7 @@ public class ObjectWindow : KtisisWindow {
 			ImGui.SameLine(0, spacing);
 		}
 
-		var avail = ImGui.GetContentRegionAvail().X - (this._ctx.Config.Editor.UseToolbar? 3f: 0);
+		var avail = ImGui.GetContentRegionAvail().X - (this._ctx.Config.Editor.UseToolbar ? 3f : 0);
 		if (avail > iconSize)
 			ImGui.SetCursorPosX(ImGui.GetCursorPosX() + avail - iconSize);
 

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -279,7 +279,7 @@
 			"reflect": "Gizmo Mode: Mirror Transform"
 		},
 		"sibling": {
-			"available": "Multi-select sibling bone: %bone%",
+			"available": "Multi-select sibling bone: %bone%\nRight-click to toggle persistent sibling links",
 			"unavailable": "Bone %bone% has no sibling",
 			"multiple": "Multi-select sibling bone: %bone%\nCan only select sibling when 1 bone is selected!"
 		},

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -289,6 +289,7 @@
 		"transforms": {
 			"title": "Bone Transforms",
 			"parenting": "Enable bone parenting",
+			"parentingDisable": "Disable bone parenting",
 			"relative": "Relative rotation"
 		},
 		"ik": {
@@ -318,7 +319,7 @@
 				"hinges.max": "Maximum",
 				"hinges.axis": "Axis"
 			}
-		}
+		},
 	},
 	
 	"preset_edit": {

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -279,9 +279,8 @@
 			"reflect": "Gizmo Mode: Mirror Transform"
 		},
 		"sibling": {
-			"available": "Multi-select sibling bone: %bone%\nRight-click to toggle persistent sibling links",
-			"unavailable": "Bone %bone% has no sibling",
-			"multiple": "Multi-select sibling bone: %bone%\nCan only select sibling when 1 bone is selected!"
+			"linkDisable": "Disable Sibling Links",
+			"linkEnable": "Enable Sibling Links\nWhen a L/R bone is selected, its sibling will be automatically multi-selected."
 		},
 		"gizmo": {
 			"show": "Show rotation gizmo",


### PR DESCRIPTION
- converts the Sibling Select Object Editor button to a on/off toggle for Persistent Sibling Links
- when enabled, any siblings of selected bones are automatically multi-selected
- while active, any time a bone is selected or deselected, we evaluate potential siblings and perform the same operation to them
- adds Bone Parenting to the Object Editor's top bar; default state is considered On
  - parenting is removed from the PosePropertyList bc of this

introduced as part of v2 feedback and an improvement to the previous first-draft Sibling Select function. the one-off selection hotkey remains in place for those who don't want the automatic behavior, but do still like to snappily select L/R bones when they need it