### PR TITLE
reinstate v3 LightWindow legacy option

### DIFF
--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -242,7 +242,13 @@ public class EditorInterface : IEditorInterface {
 				actor.Select(SelectMode.Force);
 		}
 	}
-	public void OpenLightEditor(LightEntity light) => this.OpenObjectEditor(light, true);
+	public void OpenLightEditor(LightEntity light) {
+		if (this._ctx.Config.Editor.UseLegacyLightEditor) {
+			this.OpenEditor<LightWindow, LightEntity>(light);
+			return;
+		}
+		this.OpenObjectEditor(light, true);
+	}
 
 	public bool OpenEditor<T, TA>(TA entity) where T : EntityEditWindow<TA> where TA : SceneEntity {
 		var editor = this._gui.GetOrCreate<T>(this._ctx);

--- a/Ktisis/Interface/Editor/Properties/LightPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/LightPropertyList.cs
@@ -19,202 +19,30 @@ using Ktisis.Scene.Entities;
 using Ktisis.Scene.Entities.World;
 using Ktisis.Structs.Lights;
 using Ktisis.Editor.Context.Types;
+using Ktisis.Interface.Windows.Editors;
 using Ktisis.Scene.Modules.Lights;
 
 namespace Ktisis.Interface.Editor.Properties;
 
 public class LightPropertyList : ObjectPropertyList {
 	private readonly IEditorContext _ctx;
-	private readonly ITextureProvider _tex;
-	private readonly LocaleManager _locale;
-	private readonly GoboSchema _goboSchema;
-	private readonly PopupList<GoboEntry> _goboPopup;
-	private GoboEntry? Gobo;
+	private readonly GuiManager _gui;
 
 	public LightPropertyList(
 		IEditorContext ctx,
-		ITextureProvider tex,
-		LocaleManager locale
+		GuiManager gui
 	) {
 		this._ctx = ctx;
-		this._tex = tex;
-		this._locale = locale;
-		this._goboSchema = SchemaReader.ReadGobos();
-		this._goboPopup = new PopupList<GoboEntry>(
-			"##GoboPopup",
-			this.DrawGoboRow
-		).WithSearch(GoboSearchPredicate);
+		this._gui = gui;
 	}
 	
 	public unsafe override void Invoke(IPropertyListBuilder builder, SceneEntity entity) {
 		if (entity is not LightEntity light)
 			return;
 		
-		builder.AddHeader(Ktisis.Locale.Translate("object_edit.light.headers.light"), () => this.DrawLightTab(light));
-		builder.AddHeader(Ktisis.Locale.Translate("object_edit.light.headers.shadow"), () => this.DrawShadowsTab(light));
-	}
-
-	private unsafe void DrawLightTab(LightEntity entity) {
-		var sceneLight = entity.GetObject();
-		var light = sceneLight != null ? sceneLight->RenderLight : null;
-		if (light == null) return;
-		
-		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.light.reflection"), light, LightFlags.Reflection);
-		ImGui.Spacing();
-		
-		// Light type
-		
-		var lightTypePreview = this._locale.Translate($"lightType.{light->LightType}");
-		if (ImGui.BeginCombo(Ktisis.Locale.Translate("object_edit.light.light.type"), lightTypePreview)) {
-			foreach (var value in Enum.GetValues<LightType>()) {
-				var valueLabel = this._locale.Translate($"lightType.{value}");
-				if (ImGui.Selectable(valueLabel, light->LightType == value)) {
-					if (value is not (LightType.SpotLight or LightType.AreaLight))
-						entity.RemoveGobo();
-					light->LightType = value;
-				}
-			}
-			ImGui.EndCombo();
-		}
-		
-		switch (light->LightType) {
-			case LightType.SpotLight:
-				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.spot.angle")}##LightAngle", ref light->LightAngle, 0.0f, 180.0f, "%0.0f deg");
-				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.spot.falloff")}##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
-				break;
-			case LightType.AreaLight:
-				var angleSpace = ImGui.GetStyle().ItemInnerSpacing.X;
-				var angleWidth = ImGui.CalcItemWidth() / 2 - angleSpace;
-				using (var _ = ImRaii.ItemWidth(angleWidth)) {
-					ImGui.SliderAngle("##AngleX", ref light->AreaAngle.X, -90, 90);
-					ImGui.SameLine(0, angleSpace);
-					ImGui.SliderAngle($"{Ktisis.Locale.Translate("object_edit.light.light.area.angle")}##AngleY", ref light->AreaAngle.Y, -90, 90);
-				}
-				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.area.falloff")}##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
-				break;
-			
-		}
-		
-		ImGui.Spacing();
-		
-		// Falloff
-		
-		var falloffPreview = this._locale.Translate($"lightFalloff.{light->FalloffType}");
-		if (ImGui.BeginCombo(Ktisis.Locale.Translate("object_edit.light.light.falloff.type"), falloffPreview)) {
-			foreach (var value in Enum.GetValues<FalloffType>()) {
-				var valueLabel = this._locale.Translate($"lightFalloff.{value}");
-				if (ImGui.Selectable(valueLabel, light->FalloffType == value))
-					light->FalloffType = value;
-			}
-			ImGui.EndCombo();
-		}
-
-		ImGui.DragFloat($"{Ktisis.Locale.Translate("object_edit.light.light.falloff.power")}##FalloffPower", ref light->Falloff, 0.01f, 0.0f, 1000.0f);
-		
-		// Base light settings
-		
-		ImGui.Spacing();
-		var color = light->Color.RGB;
-		if (ImGui.ColorEdit3(Ktisis.Locale.Translate("object_edit.light.light.color"), ref color, ImGuiColorEditFlags.Hdr | ImGuiColorEditFlags.Uint8))
-			light->Color.RGB = color;
-		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.light.intensity"), ref light->Color.Intensity, 0.01f, 0.0f, 100.0f);
-		if (ImGui.DragFloat($"{Ktisis.Locale.Translate("object_edit.light.light.range")}##LightRange", ref light->Range, 0.1f, 0, 999))
-			entity.Flags |= LightEntityFlags.Update;
-
-		// RenderLight projection settings
-		ImGui.Spacing();
-		ImGui.AlignTextToFramePadding();
-		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
-		if (ImGui.IsItemHovered()) {
-			using var _ = ImRaii.Tooltip();
-			ImGui.Text(Ktisis.Locale.Translate("object_edit.light.light.gobos.info"));
-		}
-		ImGui.SameLine();
-		using (ImRaii.Disabled(light->LightType is (LightType.Directional or LightType.PointLight))) {
-			var tooltip = Ktisis.Locale.Translate("object_edit.light.light.gobos.choose");
-			if (entity.Gobo != null)
-				tooltip += Ktisis.Locale.Translate("object_edit.light.light.gobos.remove");
-			if (Buttons.IconButtonTooltip(FontAwesomeIcon.Image, tooltip))
-				this._goboPopup.Open();
-			if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-				entity.RemoveGobo();
-
-			ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-			ImGui.Text($"{Ktisis.Locale.Translate("object_edit.light.light.gobos.current")} {(entity.Gobo == null ? "N/A" : entity.Gobo.Name)}");
-		}
-
-		ImGui.Spacing();
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.FileImport, Ktisis.Locale.Translate("object_edit.light.light.import")))
-			this._ctx.Interface.OpenLightFile((path, file) => this._ctx.Scene.ApplyLightFile(entity, file));
-
-		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Save, Ktisis.Locale.Translate("object_edit.light.light.export")))
-			this._ctx.Interface.OpenLightExport(entity);
-
-		this.DrawGoboPopup(entity);
-	}
-
-	private unsafe void DrawShadowsTab(LightEntity entity) {
-		var sceneLight = entity.GetObject();
-		var light = sceneLight != null ? sceneLight->RenderLight : null;
-		if (light == null) return;
-		
-		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.dynamic"), light, LightFlags.Dynamic);
-		ImGui.Spacing();
-		
-		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.chara"), light, LightFlags.CharaShadow);
-		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.object"), light, LightFlags.ObjectShadow);
-
-		ImGui.Spacing();
-		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.range"), ref light->CharaShadowRange, 0.1f, 0.0f, 1000.0f);
-		ImGui.Spacing();
-		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.near"), ref light->ShadowNear, 0.01f, 0.0f, 1000.0f);
-		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.far"), ref light->ShadowFar, 0.01f, 0.0f, 1000.0f);
-	}
-
-	private unsafe void DrawGoboPopup(LightEntity entity) {
-		if (!this._goboPopup.IsOpen) return;
-		if (!this._goboPopup.Draw(this._goboSchema.Gobos, this._goboSchema.Gobos.Count, out var selected, CalcItemHeight())) return;
-
-		entity.SetGobo(selected!);
-	}
-
-	private static float CalcItemHeight() => (ImGui.GetTextLineHeight() + ImGui.GetStyle().ItemInnerSpacing.Y) * 2;
-	private bool DrawGoboRow(GoboEntry gobo, bool isFocus) {
-		var height = CalcItemHeight();
-		var space = ImGui.GetStyle().ItemInnerSpacing.X;
-		var cursor = ImGui.GetCursorPosX();
-		var result = ImGui.Button(string.Empty, new Vector2(ImGui.GetContentRegionAvail().X, height));
-		ImGui.SameLine(cursor, height+space);
-		ImGui.Text(gobo.Name);
-
-		ImGui.SameLine(cursor, height+space);
-		ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetTextLineHeight());
-		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.Text).SetAlpha(0xAF)))
-			ImGui.Text(gobo.Path);
-
-		ImGui.SameLine(cursor);
-		var size = new Vector2(height, height);
-		ISharedImmediateTexture? img = null;
-		try {
-			img = this._tex.GetFromGame(gobo.Path);
-		} catch {
-			Ktisis.Log.Error($"[LightPropertyList] Couldn't resolve ITextureProvider path for gobo!\n{gobo.Name} @ {gobo.Path}");
-		}
-		if (img != null)
-			ImGui.Image(img.GetWrapOrEmpty().Handle, size);
-		else
-			ImGui.Dummy(size);
-
-		return result;
-	}
-
-	private static bool GoboSearchPredicate(GoboEntry gobo, string query)
-		=> gobo.Name.Contains(query, StringComparison.OrdinalIgnoreCase) || gobo.Path.Contains(query, StringComparison.OrdinalIgnoreCase);
-	
-	private unsafe void DrawLightFlag(string label, RenderLight* light, LightFlags flag) {
-		var active = light->Flags.HasFlag(flag);
-		if (ImGui.Checkbox(label, ref active))
-			light->Flags ^= flag;
+		var embedEditor = this._gui.GetOrCreate<LightWindow>(this._ctx);
+		embedEditor.SetTarget(light);
+		builder.AddHeader(Ktisis.Locale.Translate("object_edit.light.headers.light"), () => embedEditor.DrawLightTab(light));
+		builder.AddHeader(Ktisis.Locale.Translate("object_edit.light.headers.shadow"), () => embedEditor.DrawShadowsTab(light));
 	}
 }

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -263,6 +263,8 @@ public class ConfigWindow : KtisisWindow {
 		if (ImGui.CollapsingHeader(this.Locale.Translate("config.workspace.windowHeader"))) {
 			ImGui.Checkbox(this.Locale.Translate("config.workspace.toggleOpenWindows"), ref this.Config.Editor.ToggleOpenWindows);
 			ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyPoseTabs"), ref this.Config.Editor.UseLegacyPoseViewTabs);
+			ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyLightEditor"), ref this.Config.Editor.UseLegacyLightEditor);
+			this.DrawHint("config.workspace.legacyLightHint");
 			ImGui.Checkbox(this.Locale.Translate("config.workspace.editOnSelect"), ref this.Config.Editor.ToggleEditorOnSelect);
 			ImGui.Checkbox(this.Locale.Translate("config.workspace.AutoResizeObjectEditor"), ref this.Config.Editor.AutoResizeObjectEditor);
 			this.DrawHint("config.workspace.hint_AutoResizeObj");

--- a/Ktisis/Interface/Windows/Editors/LightWindow.cs
+++ b/Ktisis/Interface/Windows/Editors/LightWindow.cs
@@ -4,8 +4,17 @@ using System.Numerics;
 
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Textures;
 using Dalamud.Interface.Windowing;
+using Dalamud.Plugin.Services;
 
+using GLib.Popups;
+using GLib.Widgets;
+
+using Ktisis.Common.Extensions;
+using Ktisis.Data.Config.Gobos;
+using Ktisis.Data.Serialization;
 using Ktisis.Editor.Context;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Types;
@@ -17,12 +26,23 @@ namespace Ktisis.Interface.Windows.Editors;
 
 public class LightWindow : EntityEditWindow<LightEntity> {
 	private readonly LocaleManager _locale;
+	private readonly ITextureProvider _tex;
+	private readonly GoboSchema _goboSchema;
+	private readonly PopupList<GoboEntry> _goboPopup;
+	private GoboEntry? Gobo;
 
 	public LightWindow(
 		IEditorContext ctx,
+		ITextureProvider tex,
 		LocaleManager locale
 	) : base("Light Editor", ctx, windowId:"###KtisisLightEditor") {
+		this._tex = tex;
 		this._locale = locale;
+		this._goboSchema = SchemaReader.ReadGobos();
+		this._goboPopup = new PopupList<GoboEntry>(
+			"##GoboPopup",
+			this.DrawGoboRow
+		).WithSearch(GoboSearchPredicate);
 	}
 
 	// Draw handlers
@@ -47,7 +67,7 @@ public class LightWindow : EntityEditWindow<LightEntity> {
 
 		var entity = this.Target;
 		
-		ImGui.Text($"{entity.Name}:");
+		ImGui.Text($"Editing Light: {entity.Name}");
 		ImGui.Spacing();
 
 		using var _ = ImRaii.TabBar("##LightEditTabs");
@@ -64,42 +84,45 @@ public class LightWindow : EntityEditWindow<LightEntity> {
 	
 	// Light Tab
 
-	private unsafe void DrawLightTab(LightEntity entity) {
+	internal unsafe void DrawLightTab(LightEntity entity) {
 		var sceneLight = entity.GetObject();
 		var light = sceneLight != null ? sceneLight->RenderLight : null;
 		if (light == null) return;
 		
-		ImGui.Spacing();
-		this.DrawLightFlag("Enable reflections", light, LightFlags.Reflection);
+		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.light.reflection"), light, LightFlags.Reflection);
 		ImGui.Spacing();
 		
 		// Light type
 		
 		var lightTypePreview = this._locale.Translate($"lightType.{light->LightType}");
-		if (ImGui.BeginCombo("Light Type", lightTypePreview)) {
+		if (ImGui.BeginCombo(Ktisis.Locale.Translate("object_edit.light.light.type"), lightTypePreview)) {
 			foreach (var value in Enum.GetValues<LightType>()) {
 				var valueLabel = this._locale.Translate($"lightType.{value}");
-				if (ImGui.Selectable(valueLabel, light->LightType == value))
+				if (ImGui.Selectable(valueLabel, light->LightType == value)) {
+					if (value is not (LightType.SpotLight or LightType.AreaLight))
+						entity.RemoveGobo();
 					light->LightType = value;
+				}
 			}
 			ImGui.EndCombo();
 		}
 		
 		switch (light->LightType) {
 			case LightType.SpotLight:
-				ImGui.SliderFloat("Cone Angle##LightAngle", ref light->LightAngle, 0.0f, 180.0f, "%0.0f deg");
-				ImGui.SliderFloat("Falloff Angle##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
+				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.spot.angle")}##LightAngle", ref light->LightAngle, 0.0f, 180.0f, "%0.0f deg");
+				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.spot.falloff")}##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
 				break;
 			case LightType.AreaLight:
 				var angleSpace = ImGui.GetStyle().ItemInnerSpacing.X;
 				var angleWidth = ImGui.CalcItemWidth() / 2 - angleSpace;
-				using (ImRaii.ItemWidth(angleWidth)) {
+				using (var _ = ImRaii.ItemWidth(angleWidth)) {
 					ImGui.SliderAngle("##AngleX", ref light->AreaAngle.X, -90, 90);
 					ImGui.SameLine(0, angleSpace);
-					ImGui.SliderAngle("Light Angle##AngleY", ref light->AreaAngle.Y, -90, 90);
+					ImGui.SliderAngle($"{Ktisis.Locale.Translate("object_edit.light.light.area.angle")}##AngleY", ref light->AreaAngle.Y, -90, 90);
 				}
-				ImGui.SliderFloat("Falloff Angle##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
+				ImGui.SliderFloat($"{Ktisis.Locale.Translate("object_edit.light.light.area.falloff")}##LightAngle", ref light->FalloffAngle, 0.0f, 180.0f, "%0.0f deg");
 				break;
+			
 		}
 		
 		ImGui.Spacing();
@@ -107,7 +130,7 @@ public class LightWindow : EntityEditWindow<LightEntity> {
 		// Falloff
 		
 		var falloffPreview = this._locale.Translate($"lightFalloff.{light->FalloffType}");
-		if (ImGui.BeginCombo("Falloff Type", falloffPreview)) {
+		if (ImGui.BeginCombo(Ktisis.Locale.Translate("object_edit.light.light.falloff.type"), falloffPreview)) {
 			foreach (var value in Enum.GetValues<FalloffType>()) {
 				var valueLabel = this._locale.Translate($"lightFalloff.{value}");
 				if (ImGui.Selectable(valueLabel, light->FalloffType == value))
@@ -116,42 +139,108 @@ public class LightWindow : EntityEditWindow<LightEntity> {
 			ImGui.EndCombo();
 		}
 
-		ImGui.DragFloat("Falloff Power##FalloffPower", ref light->Falloff, 0.01f, 0.0f, 1000.0f);
+		ImGui.DragFloat($"{Ktisis.Locale.Translate("object_edit.light.light.falloff.power")}##FalloffPower", ref light->Falloff, 0.01f, 0.0f, 1000.0f);
 		
 		// Base light settings
 		
 		ImGui.Spacing();
-		
 		var color = light->Color.RGB;
-		if (ImGui.ColorEdit3("Color", ref color, ImGuiColorEditFlags.Hdr | ImGuiColorEditFlags.Uint8))
+		if (ImGui.ColorEdit3(Ktisis.Locale.Translate("object_edit.light.light.color"), ref color, ImGuiColorEditFlags.Hdr | ImGuiColorEditFlags.Uint8))
 			light->Color.RGB = color;
-		ImGui.DragFloat("Intensity", ref light->Color.Intensity, 0.01f, 0.0f, 100.0f);
-		if (ImGui.DragFloat("Range##LightRange", ref light->Range, 0.1f, 0, 999))
+		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.light.intensity"), ref light->Color.Intensity, 0.01f, 0.0f, 100.0f);
+		if (ImGui.DragFloat($"{Ktisis.Locale.Translate("object_edit.light.light.range")}##LightRange", ref light->Range, 0.1f, 0, 999))
 			entity.Flags |= LightEntityFlags.Update;
-	}
-	
-	// Shadows tab
 
-	private unsafe void DrawShadowsTab(LightEntity entity) {
+		// RenderLight projection settings
+		ImGui.Spacing();
+		ImGui.AlignTextToFramePadding();
+		Icons.DrawIcon(FontAwesomeIcon.QuestionCircle);
+		if (ImGui.IsItemHovered()) {
+			using var _ = ImRaii.Tooltip();
+			ImGui.Text(Ktisis.Locale.Translate("object_edit.light.light.gobos.info"));
+		}
+		ImGui.SameLine();
+		using (ImRaii.Disabled(light->LightType is (LightType.Directional or LightType.PointLight))) {
+			var tooltip = Ktisis.Locale.Translate("object_edit.light.light.gobos.choose");
+			if (entity.Gobo != null)
+				tooltip += Ktisis.Locale.Translate("object_edit.light.light.gobos.remove");
+			if (Buttons.IconButtonTooltip(FontAwesomeIcon.Image, tooltip))
+				this._goboPopup.Open();
+			if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+				entity.RemoveGobo();
+
+			ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+			ImGui.Text($"{Ktisis.Locale.Translate("object_edit.light.light.gobos.current")} {(entity.Gobo == null ? "N/A" : entity.Gobo.Name)}");
+		}
+
+		ImGui.Spacing();
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.FileImport, Ktisis.Locale.Translate("object_edit.light.light.import")))
+			this.Context.Interface.OpenLightFile((path, file) => this.Context.Scene.ApplyLightFile(entity, file));
+
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Save, Ktisis.Locale.Translate("object_edit.light.light.export")))
+			this.Context.Interface.OpenLightExport(entity);
+
+		this.DrawGoboPopup(entity);
+	}
+
+	internal unsafe void DrawShadowsTab(LightEntity entity) {
 		var sceneLight = entity.GetObject();
 		var light = sceneLight != null ? sceneLight->RenderLight : null;
 		if (light == null) return;
 		
-		ImGui.Spacing();
-		this.DrawLightFlag("Dynamic shadows", light, LightFlags.Dynamic);
+		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.dynamic"), light, LightFlags.Dynamic);
 		ImGui.Spacing();
 		
-		this.DrawLightFlag("Cast character shadows", light, LightFlags.CharaShadow);
-		this.DrawLightFlag("Cast object shadows", light, LightFlags.ObjectShadow);
+		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.chara"), light, LightFlags.CharaShadow);
+		this.DrawLightFlag(Ktisis.Locale.Translate("object_edit.light.shadow.object"), light, LightFlags.ObjectShadow);
 
 		ImGui.Spacing();
-		ImGui.DragFloat("Shadow Range", ref light->CharaShadowRange, 0.1f, 0.0f, 1000.0f);
+		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.range"), ref light->CharaShadowRange, 0.1f, 0.0f, 1000.0f);
 		ImGui.Spacing();
-		ImGui.DragFloat("Shadow Near", ref light->ShadowNear, 0.01f, 0.0f, 1000.0f);
-		ImGui.DragFloat("Shadow Far", ref light->ShadowFar, 0.01f, 0.0f, 1000.0f);
+		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.near"), ref light->ShadowNear, 0.01f, 0.0f, 1000.0f);
+		ImGui.DragFloat(Ktisis.Locale.Translate("object_edit.light.shadow.far"), ref light->ShadowFar, 0.01f, 0.0f, 1000.0f);
 	}
-	
-	// Utility
+
+	private unsafe void DrawGoboPopup(LightEntity entity) {
+		if (!this._goboPopup.IsOpen) return;
+		if (!this._goboPopup.Draw(this._goboSchema.Gobos, this._goboSchema.Gobos.Count, out var selected, CalcItemHeight())) return;
+
+		entity.SetGobo(selected!);
+	}
+
+	private static float CalcItemHeight() => (ImGui.GetTextLineHeight() + ImGui.GetStyle().ItemInnerSpacing.Y) * 2;
+	private bool DrawGoboRow(GoboEntry gobo, bool isFocus) {
+		var height = CalcItemHeight();
+		var space = ImGui.GetStyle().ItemInnerSpacing.X;
+		var cursor = ImGui.GetCursorPosX();
+		var result = ImGui.Button(string.Empty, new Vector2(ImGui.GetContentRegionAvail().X, height));
+		ImGui.SameLine(cursor, height+space);
+		ImGui.Text(gobo.Name);
+
+		ImGui.SameLine(cursor, height+space);
+		ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetTextLineHeight());
+		using (var _ = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.Text).SetAlpha(0xAF)))
+			ImGui.Text(gobo.Path);
+
+		ImGui.SameLine(cursor);
+		var size = new Vector2(height, height);
+		ISharedImmediateTexture? img = null;
+		try {
+			img = this._tex.GetFromGame(gobo.Path);
+		} catch {
+			Ktisis.Log.Error($"[LightPropertyList] Couldn't resolve ITextureProvider path for gobo!\n{gobo.Name} @ {gobo.Path}");
+		}
+		if (img != null)
+			ImGui.Image(img.GetWrapOrEmpty().Handle, size);
+		else
+			ImGui.Dummy(size);
+
+		return result;
+	}
+
+	private static bool GoboSearchPredicate(GoboEntry gobo, string query)
+		=> gobo.Name.Contains(query, StringComparison.OrdinalIgnoreCase) || gobo.Path.Contains(query, StringComparison.OrdinalIgnoreCase);
 	
 	private unsafe void DrawLightFlag(string label, RenderLight* light, LightFlags flag) {
 		var active = light->Flags.HasFlag(flag);

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -780,7 +780,7 @@
 			"toggleOpenWindows": "UI buttons toggle windows open & closed",
 			"toolbar": "Use Ktisis Toolbar",
 			"hintToolbar": "Experimental: This is an alternate UI which puts all of Ktisis' editors into one window.\nPlease provide any feedback, as this option is actively under development!",
-			"editOnSelect": "Open object editor when selecting from the workspace",
+			"editOnSelect": "Open object editor on selection",
 			"closeOnDeselect": "Close object editor when nothing is selected",
 			"incognitoPlayerNames": "Incognito Mode",
 			"hintIncognito": "Censors all player names from actor list and GPose window",


### PR DESCRIPTION
- re-added LightWindow and related Legacy config option to Window Behavior Settings (reverting light changes from [1a71b8ce5a6ed4dbd362194623d5458f9081e783](https://github.com/ktisis-tools/Ktisis/commit/1a71b8ce5a6ed4dbd362194623d5458f9081e783))
- moved Light/Shadow tab logic out of LightPropertyList and into LightWindow as the sole source of draw commands
- embedded LightWindow use to LightPropertyList following the approach taken for Pose/Actor import dialogs in their respective property lists
- ensured LightWindow can use the new gobo options and performs fine in both normal and toolbar modes
- verbiage tweak for `ToggleEditorOnSelect` in Window Behavior settings

see: https://discord.com/channels/975894364020686878/1528914028162842704