### PR TITLE
Multitarget fixes

### DIFF
--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -151,7 +151,7 @@ public class SelectManager : ISelectManager {
 	}
 
 	public void Select(SceneEntity entity) {
-		var removed = this.Selected.Remove(entity);
+		this.Selected.Remove(entity);
 		this.Selected.Add(entity);
 		this.InvokeChanged(false);
 	}

--- a/Ktisis/Editor/Selection/SelectManager.cs
+++ b/Ktisis/Editor/Selection/SelectManager.cs
@@ -21,7 +21,7 @@ public enum SelectMode {
 	Force
 }
 
-public delegate void SelectChangedHandler(ISelectManager sender);
+public delegate void SelectChangedHandler(ISelectManager sender, bool multi);
 
 public interface ISelectManager {
 	public event SelectChangedHandler Changed;
@@ -48,7 +48,7 @@ public class SelectManager : ISelectManager {
 	private readonly IEditorContext _context;
 	private readonly GPoseService _gpose;
 
-	private readonly Event<Action<ISelectManager>> _changed = new();
+	private readonly Event<Action<ISelectManager, bool>> _changed = new();
 	public event SelectChangedHandler Changed {
 		add => this._changed.Add(value.Invoke);
 		remove => this._changed.Remove(value.Invoke);
@@ -71,7 +71,7 @@ public class SelectManager : ISelectManager {
 	public void Update() {
 		// remove any invalid entities and flag selection changed if we do
 		var remove = this.Selected.RemoveAll(item => !item.IsValid);
-		if (remove > 0) this.InvokeChanged();
+		if (remove > 0) this.InvokeChanged(remove > 1);
 
 		// check SelectOnTarget and update selection if we should
 		if (this._context.Config.Editor.SelectOnTarget && this.Targeted is not null && this._gpose.GPoseTarget is not null && !this.Targeted.Equals(this._gpose.GPoseTarget)) {
@@ -151,9 +151,9 @@ public class SelectManager : ISelectManager {
 	}
 
 	public void Select(SceneEntity entity) {
-		this.Selected.Remove(entity);
+		var removed = this.Selected.Remove(entity);
 		this.Selected.Add(entity);
-		this.InvokeChanged();
+		this.InvokeChanged(false);
 	}
 
 	public void Select(SceneEntity entity, SelectMode mode) {
@@ -162,7 +162,7 @@ public class SelectManager : ISelectManager {
 				return;
 			this.Selected.Clear();
 			this.Selected.Add(entity);
-			this.InvokeChanged();
+			this.InvokeChanged(false);
 			return;
 		}
 		
@@ -177,24 +177,25 @@ public class SelectManager : ISelectManager {
 		else
 			this.Selected.Remove(entity);
 		
-		this.InvokeChanged();
+		this.InvokeChanged(this.Selected.Count > 1 || modeMulti);
 	}
 
 	public void Unselect(SceneEntity entity) {
 		if (this.Selected.Remove(entity))
-			this.InvokeChanged();
+			this.InvokeChanged(false);
 	}
 
 	public void Clear() {
+		var count = this.Selected.Count;
 		this.Selected.Clear();
-		this.InvokeChanged();
+		this.InvokeChanged(count > 1);
 	}
 	
 	// Event invocation
 
-	private void InvokeChanged() {
+	private void InvokeChanged(bool multi) {
 		try {
-			this._changed.Invoke(this);
+			this._changed.Invoke(this, multi);
 		} catch (Exception err) {
 			Ktisis.Log.Error(err.ToString());
 		}

--- a/Ktisis/Editor/Transforms/TransformHandler.cs
+++ b/Ktisis/Editor/Transforms/TransformHandler.cs
@@ -32,7 +32,7 @@ public class TransformHandler : ITransformHandler {
 	
 	public ITransformTarget? Target { get; private set; }
 
-	private void OnSelectionChanged(ISelectManager sender) {
+	private void OnSelectionChanged(ISelectManager sender, bool multi) {
 		var selected = this._select.GetSelected()
 			.Where(entity => entity is { IsValid: true });
 		

--- a/Ktisis/Interface/Components/Workspace/WorkspaceState.cs
+++ b/Ktisis/Interface/Components/Workspace/WorkspaceState.cs
@@ -159,12 +159,12 @@ public class WorkspaceState {
 			}
 		));
 
-		var targets = transform.Target!.Targets.Where(tar => tar.Name != name).ToList();
+		var targets = transform.Target!.Targets.Except([target.Primary!]).ToList();
 		if (ImGui.IsItemHovered()) {
 			using var _ = ImRaii.Tooltip();
 
-			for (int i = 0; i < count; i++)
-				ImGui.Text($"{targets[i].Name}");
+			foreach (var t in targets)
+				ImGui.Text(t.Name);
 		}
 	}
 

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -62,14 +62,16 @@ public class EditorInterface : IEditorInterface {
 		).Open();
 	}
 
-	private void OnSelectChanged(ISelectManager sender) {
+	private void OnSelectChanged(ISelectManager sender, bool multi) {
 		if (!this._ctx.Config.Editor.ToggleEditorOnSelect ) return;
 
 		var open = sender.Count > 0;
-		
+
 		var editor = this._gui.Get<ObjectWindow>();
 		if (editor == null) {
-			if (open) this.OpenObjectEditor();
+			// open Object Editor if >=1 object is still selected
+			// DON'T do this if we're in toolbar mode and more than one object was modified in the action (e.g. clear, multiselect) or if it was ModeMulti with 1 selection
+			if (open && !(this._ctx.Config.Editor.UseToolbar && multi)) this.OpenObjectEditor();
 			return;
 		}
 


### PR DESCRIPTION
from issue https://discord.com/channels/975894364020686878/1529681751419654184

- fixed naive same-name matching on the DrawTargetLabel for workspace's selection list causing an imgui break
- updated toolbar-exclusive behavior for ToggleEditorOnSelect; if the action was multi-mode, it now will not open the object editor with every indiv. addition to the group selection