### PR TITLE
fix gizmo + globalscale math

### DIFF
--- a/Ktisis/Interface/Overlay/OverlayWindow.cs
+++ b/Ktisis/Interface/Overlay/OverlayWindow.cs
@@ -104,7 +104,7 @@ public class OverlayWindow : KtisisWindow {
 		if (view == null || proj == null || this.Size == null)
 			return false;
 
-		var size = this.Size.Value;
+		var size = this.Size.Value * ImGuiHelpers.GlobalScale;
 		this._gizmo.SetMatrix(view.Value, proj.Value);
 		this._gizmo.BeginFrame(this.Position!.Value, size);
 
@@ -156,7 +156,7 @@ public class OverlayWindow : KtisisWindow {
 		this._gizmoGaze.AllowAxisFlip = cfg.AllowAxisFlip;
 		this._gizmoGaze.ScaleFactor = 0.075f;
 
-		var size = this.Size.Value;
+		var size = this.Size.Value * ImGuiHelpers.GlobalScale;
 		this._gizmoGaze.SetMatrix(view.Value, proj.Value);
 
 		// set target to decomposed position for ActorPropertyList to consume


### PR DESCRIPTION
reported here https://discord.com/channels/975894364020686878/1004373141000290395/1530061493679423679

regression from #339, gizmo frames' sizes for full-screen overlays need to be modified by the GlobalScale var to prevent drifting off model