### PR TITLE
add utility to regenerate default presets

### DIFF
--- a/Ktisis/Interface/Components/Config/PresetEditor.cs
+++ b/Ktisis/Interface/Components/Config/PresetEditor.cs
@@ -47,16 +47,28 @@ public class PresetEditor {
 		ImGui.Spacing();
 
 		using var tablePad = ImRaii.PushStyle(ImGuiStyleVar.CellPadding, new Vector2(10, 10));
-		using var table = ImRaii.Table("##PresetsTable", 2, ImGuiTableFlags.Resizable);
-		
-		if (!table.Success) return;
-			
-		ImGui.TableSetupColumn("PresetList");
-		ImGui.TableSetupColumn("PresetOptions", ImGuiTableColumnFlags.WidthStretch);
-		ImGui.TableNextRow();
+		using (var table = ImRaii.Table("##PresetsTable", 2, ImGuiTableFlags.Resizable)) {
+			if (!table.Success) return;
+			ImGui.TableSetupColumn("PresetList");
+			ImGui.TableSetupColumn("PresetOptions", ImGuiTableColumnFlags.WidthStretch);
+			ImGui.TableNextRow();
 
-		this.DrawPresetList();
-		this.DrawPresetConfig();
+			this.DrawPresetList();
+			this.DrawPresetConfig();
+		}
+
+		ImGui.Spacing();
+		using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModShift) || !ImGui.IsKeyDown(ImGuiKey.ModCtrl))) {
+			if (ImGui.Button(this._locale.Translate("config.presets.regen"))) {
+				this._cfg.GenerateDefaultPresets(this._cfg.File);
+				this._cfg.Save();
+			}
+
+			if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
+				using var _ = ImRaii.Tooltip();
+				ImGui.Text(this._locale.Translate("config.presets.regen_tooltip"));
+			}
+		}
 	}
 	
 	private void DrawPresetList() {

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -135,6 +135,7 @@ public class ConfigWindow : KtisisWindow {
 
 		ImGui.SameLine();
 		using var _frame = ImRaii.Group();
+		using var _id = ImRaii.PushId($"##ConfigContents"); // try to resolve ImGui Empty ID ## root assertion
 		var (_, drawFn) = this.Tabs[this._tabIndex];
 		drawFn();
 	}

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -328,7 +328,7 @@
 				"hinges.max": "Maximum",
 				"hinges.axis": "Axis"
 			}
-		},
+		}
 	},
 	
 	"preset_edit": {
@@ -880,7 +880,9 @@
 			"defaults": "Right click any preset to mark it as Default. Default presets will be initially enabled for any GPose actors.",
 			"delete_tooltip": "Hold shift to delete",
 			"delete": "Delete",
-			"rename": "Rename"
+			"rename": "Rename",
+			"regen": "Regenerate Defaults",
+			"regen_tooltip": "Force generates Ktisis' default presets (Body, Arms, etc.)\nHold Ctrl+Shift to use"
 		},
 		"poseview": {
 			"title": "Pose View",


### PR DESCRIPTION
reported via DM

- adds a `Regenerate Defaults` button to the PresetEditor to backfill any missing presets when used

<img width="796" height="452" alt="image" src="https://github.com/user-attachments/assets/ae092272-a196-4f28-85f9-538b4ebcf58d" />
