### PR TITLE
Automatically make it so the toolbar bottom cannot escape the bottom of the screen

### DIFF
--- a/Ktisis/Interface/Windows/ToolbarModules/Workspace.cs
+++ b/Ktisis/Interface/Windows/ToolbarModules/Workspace.cs
@@ -34,7 +34,14 @@ public class Workspace : WorkspaceWindow  {
 		this._workspace.DrawCompact();
 
 		var botHeight = (UiBuilder.DefaultFontSizePx + (style.ItemSpacing.Y + style.ItemInnerSpacing.Y) * 2) * ImGuiHelpers.GlobalScale;
-		var treeHeight = ((ImGui.GetTextLineHeightWithSpacing() + 5) * (Math.Max(10, this._editorContext.Scene.Children.Count())+ 5)) - botHeight; //TODO: would prefer sizing based upon expanded nodes but this will do for now
+		var treeHeight = ((ImGui.GetTextLineHeightWithSpacing() + 5) * (Math.Max(10, this._editorContext.Scene.Children.Count()) + 5)) - botHeight; //TODO: would prefer sizing based upon expanded nodes but this will do for now
+		var viewportSize = ImGui.GetIO().DisplaySize;
+		var calculatedEnd = ImGui.GetCursorScreenPos().Y + treeHeight + botHeight;
+
+		if (calculatedEnd > viewportSize.Y) {
+			treeHeight -=  calculatedEnd - viewportSize.Y; //reduce to stay on screen.
+		}
+
 		this._sceneTree.Draw(treeHeight);
 
 		ImGui.Spacing();

--- a/Ktisis/Interface/Windows/ToolbarModules/Workspace.cs
+++ b/Ktisis/Interface/Windows/ToolbarModules/Workspace.cs
@@ -36,10 +36,10 @@ public class Workspace : WorkspaceWindow  {
 		var botHeight = (UiBuilder.DefaultFontSizePx + (style.ItemSpacing.Y + style.ItemInnerSpacing.Y) * 2) * ImGuiHelpers.GlobalScale;
 		var treeHeight = ((ImGui.GetTextLineHeightWithSpacing() + 5) * (Math.Max(10, this._editorContext.Scene.Children.Count()) + 5)) - botHeight; //TODO: would prefer sizing based upon expanded nodes but this will do for now
 		var viewportSize = ImGui.GetIO().DisplaySize;
-		var calculatedEnd = ImGui.GetCursorScreenPos().Y + treeHeight + botHeight;
+		var calculatedEnd = ImGui.GetCursorScreenPos().Y + treeHeight + botHeight + ImGui.GetStyle().WindowPadding.Y;
 
 		if (calculatedEnd > viewportSize.Y) {
-			treeHeight -=  calculatedEnd - viewportSize.Y; //reduce to stay on screen.
+			treeHeight = Math.Clamp(treeHeight - (calculatedEnd - viewportSize.Y), ImGui.GetTextLineHeightWithSpacing() * 5, float.MaxValue); //reduce to stay on screen.
 		}
 
 		this._sceneTree.Draw(treeHeight);


### PR DESCRIPTION
Initially reported here: https://discord.com/channels/975894364020686878/1004373141000290395/1531201909183217705

https://github.com/user-attachments/assets/1b81af87-bb12-4508-9130-834b8589e7b4

