### PR TITLE
remove globalscale dependency on 2d gizmo size

### DIFF
--- a/Ktisis/Interface/Components/Transforms/Gizmo2D.cs
+++ b/Ktisis/Interface/Components/Transforms/Gizmo2D.cs
@@ -68,7 +68,7 @@ public class Gizmo2D {
 		var cursorPos = ImGui.GetCursorScreenPos();
 		var innerSize = ImGui.GetContentRegionAvail();
 		ImGui.SetNextWindowPos(ImGui.GetMainViewport().Pos);
-		ImGui.SetNextWindowSize(ImGui.GetMainViewport().Size / ImGuiHelpers.GlobalScale);
+		ImGui.SetNextWindowSize(ImGui.GetMainViewport().Size);
 		
 		ImGui.Begin($"##Gizmo2D{nameAppend}", ImGuiWindowFlags.ChildWindow | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoDecoration);
 		


### PR DESCRIPTION
reported here https://discord.com/channels/975894364020686878/1004373141000290395/1530985901969117204

unintentional regression from #339 (my fault), 2d gizmo viewport size should not account for globalscale. if we divide this way, it gets cut off at certain positions on the screen (since the window itself can float around the whole interface, rather than being locked to the top-left corner like other overlays)