### PR TITLE
Import pose fixes

### DIFF
--- a/Ktisis/Data/Config/Sections/FileConfig.cs
+++ b/Ktisis/Data/Config/Sections/FileConfig.cs
@@ -11,6 +11,7 @@ public class FileConfig {
 	
 	public SaveModes ImportCharaModes = SaveModes.All;
 	public bool ImportNpcApplyOnSelect = false;
+	public bool ImportPoseApplyOnSelect = false;
 	
 	public bool ImportPoseSelectedBones = false;
 	public bool SelectedBonesIncludeDescendants = false;

--- a/Ktisis/Interface/Components/Files/FileSelect.cs
+++ b/Ktisis/Interface/Components/Files/FileSelect.cs
@@ -38,7 +38,7 @@ public class FileSelect<T> where T : notnull {
 	// Draw UI
 
 	public void Draw() {
-		string defaultText = Ktisis.Locale.Translate("file.select");
+		string defaultText = Ktisis.Locale.Translate("file.select") ;
 		
 		var path = this.Selected?.Name ?? defaultText;
 		ImGui.InputText("##FileSelectPath", ref path, 256, ImGuiInputTextFlags.ReadOnly);

--- a/Ktisis/Interface/Components/Files/FileSelect.cs
+++ b/Ktisis/Interface/Components/Files/FileSelect.cs
@@ -38,7 +38,7 @@ public class FileSelect<T> where T : notnull {
 	// Draw UI
 
 	public void Draw() {
-		string defaultText = Ktisis.Locale.Translate("file.select") ;
+		string defaultText = Ktisis.Locale.Translate("file.select");
 		
 		var path = this.Selected?.Name ?? defaultText;
 		ImGui.InputText("##FileSelectPath", ref path, 256, ImGuiInputTextFlags.ReadOnly);

--- a/Ktisis/Interface/Components/Files/FileSelect.cs
+++ b/Ktisis/Interface/Components/Files/FileSelect.cs
@@ -15,7 +15,9 @@ public class FileSelect<T> where T : notnull {
 	// Events
 
 	public OpenDialogHandler? OnOpenDialog;
+	public SelectedFileHandler? OnSelectedFile;
 	public delegate void OpenDialogHandler(FileSelect<T> sender);
+	public delegate void SelectedFileHandler(FileSelect<T> sender);
 	
 	// State
 	
@@ -28,6 +30,7 @@ public class FileSelect<T> where T : notnull {
 			Path = path,
 			File = file
 		};
+		this.OnSelectedFile?.Invoke(this);
 	}
 
 	public void Clear() => this.Selected = null;

--- a/Ktisis/Interface/KTK/PreviewNode.cs
+++ b/Ktisis/Interface/KTK/PreviewNode.cs
@@ -32,6 +32,7 @@ namespace Ktisis.Interface.KTK;
 public unsafe class PreviewNode : OverlayNode {
 	public override OverlayLayer OverlayLayer => OverlayLayer.BehindUserInterface;
 	public override bool HideWithNativeUi => false;
+	public override bool HideWithUiToggled => false;
 	public override bool IsVisible { get; set; } = false;
 	protected override void OnUpdate() { }
 

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -33,11 +33,21 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 	) {
 		this._select = select;
 		select.OnOpenDialog = this.OnFileDialogOpen;
+		select.OnSelectedFile = this.OnFileSelected;
 	}
 
 	private void OnFileDialogOpen(FileSelect<PoseFile> sender) {
 		this.Context.Scene.Overlay.ToggleCharaViewTexture(this.Context, this.Target);
 		this.Context.Interface.OpenPoseFile(sender.SetFile);
+	}
+
+	private void OnFileSelected(FileSelect<PoseFile> sender) {
+		if (!this.Context.Config.File.ImportPoseApplyOnSelect) return;
+
+		var isSelectBones = this.Target.Recurse()
+			.Where(child => child is SkeletonNode)
+			.Any(child => child.IsSelected);
+		this.ApplyPoseFile(isSelectBones);
 	}
 
 	// Draw UI
@@ -72,6 +82,8 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 			.Where(child => child is SkeletonNode)
 			.Any(child => child.IsSelected);
 		
+		ImGui.Checkbox(Ktisis.Locale.Translate("file.pose.apply"), ref this.Context.Config.File.ImportPoseApplyOnSelect);
+		ImGui.Spacing();
 		this.DrawTransformSelect();
 		ImGui.Spacing();
 		this.DrawApplyModes(isSelectBones);

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -90,8 +90,15 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 		ImGui.Spacing();
 		ImGui.Spacing();
 
-		if (ImGui.Button(Ktisis.Locale.Translate("pose_import.apply")))
-			this.ApplyPoseFile(isSelectBones);
+		using (ImRaii.Disabled(!this.Context.Posing.IsEnabled)) {
+			if (ImGui.Button(Ktisis.Locale.Translate("pose_import.apply")))
+				this.ApplyPoseFile(isSelectBones);
+
+			if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
+				using var _ = ImRaii.Tooltip();
+				ImGui.Text(Ktisis.Locale.Translate("file.pose.posemode_warn"));
+			}
+		}
 	}
 
 	private void DrawTransformSelect() {

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -65,6 +65,13 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 		this.PreDraw();
 		if (!this.Context.IsValid) return; // despite closing in predraw, we might continue to later draw funcs, so stop drawing here
 		using var _id = ImRaii.PushId($"PoseEmbed_{this.GetHashCode():X}");
+		if (!this.Context.Posing.IsEnabled) {
+			Icons.DrawIcon(FontAwesomeIcon.ExclamationTriangle, ColorHelpers.RgbaVector4ToUint(ImGuiColors.DalamudYellow));
+			ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+			ImGui.Text(Ktisis.Locale.Translate("pose_import.posemode_warn"));
+			ImGui.Spacing();
+		}
+		using var _disabled = ImRaii.Disabled(!this.Context.Posing.IsEnabled);
 
 		this._select.Draw();
 		
@@ -76,8 +83,6 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 	// Pose application
 
 	private void DrawPoseApplication() {
-		//using var _ = ImRaii.Disabled(!this._select.IsFileOpened);
-		
 		var isSelectBones = this.Target.Recurse()
 			.Where(child => child is SkeletonNode)
 			.Any(child => child.IsSelected);

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -42,7 +42,7 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 	}
 
 	private void OnFileSelected(FileSelect<PoseFile> sender) {
-		if (!this.Context.Config.File.ImportPoseApplyOnSelect) return;
+		if (!this.Context.Config.File.ImportPoseApplyOnSelect || !this.Context.Posing.IsEnabled) return;
 
 		var isSelectBones = this.Target.Recurse()
 			.Where(child => child is SkeletonNode)

--- a/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
+++ b/Ktisis/Interface/Windows/Import/PoseImportDialog.cs
@@ -90,15 +90,8 @@ public class PoseImportDialog : EntityEditWindow<ActorEntity> {
 		ImGui.Spacing();
 		ImGui.Spacing();
 
-		using (ImRaii.Disabled(!this.Context.Posing.IsEnabled)) {
-			if (ImGui.Button(Ktisis.Locale.Translate("pose_import.apply")))
-				this.ApplyPoseFile(isSelectBones);
-
-			if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
-				using var _ = ImRaii.Tooltip();
-				ImGui.Text(Ktisis.Locale.Translate("file.pose.posemode_warn"));
-			}
-		}
+		if (ImGui.Button(Ktisis.Locale.Translate("pose_import.apply")))
+			this.ApplyPoseFile(isSelectBones);
 	}
 
 	private void DrawTransformSelect() {

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -109,6 +109,7 @@
 		},
 		"pose": {
 			"name": "Pose File (.pose)",
+			"apply": "Apply on selection",
 			"ctx_import": "Import pose...",
 			"ctx_import.group": "Import group...",
 			"ctx_import.select": "Import selected...",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -110,6 +110,7 @@
 		"pose": {
 			"name": "Pose File (.pose)",
 			"apply": "Apply on selection",
+			"posemode_warn": "Must be in Pose Mode to apply a pose file!",
 			"ctx_import": "Import pose...",
 			"ctx_import.group": "Import group...",
 			"ctx_import.select": "Import selected...",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -110,7 +110,6 @@
 		"pose": {
 			"name": "Pose File (.pose)",
 			"apply": "Apply on selection",
-			"posemode_warn": "Must be in Pose Mode to apply a pose file!",
 			"ctx_import": "Import pose...",
 			"ctx_import.group": "Import group...",
 			"ctx_import.select": "Import selected...",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -670,6 +670,7 @@
 		"title": "Import Pose",
 		"header": "Importing pose for",
 		"apply": "Apply",
+		"posemode_warn": "Pose Mode must be enabled to load poses!",
 		"transforms.header": "Transforms:",
 		"modes": {
 			"header": "Modes:",


### PR DESCRIPTION
- prevent PreviewNode from hiding when game UI is toggled off
- add ApplyOnSelect similar to NPC imports to Pose Imports; this depends on an event from FileSelect that, when seen in PoseImportDialog, will automatically apply the pose without the user needing to hit the button
- disabled the Apply button if the user is not in posemode