### PR TITLE
Object Spawning - P1 Draft

### DIFF
--- a/Ktisis/Data/Config/Sections/OverlayConfig.cs
+++ b/Ktisis/Data/Config/Sections/OverlayConfig.cs
@@ -1,4 +1,6 @@
-﻿using Ktisis.Structs.Objects;
+﻿using System;
+
+using Ktisis.Structs.Objects;
 
 namespace Ktisis.Data.Config.Sections;
 
@@ -29,6 +31,7 @@ public class OverlayConfig {
 	public uint ActorNodeColor = 0xFFFF006D;
 	public uint LightNodeColor = 0xFF00DEFF;
 	public OutlineChoice WorldOutlineColor = OutlineChoice.Yellow;
+	public WorldFilters ActiveWorldFilters = WorldFilters.Objects | WorldFilters.Actors | WorldFilters.Lights;
 	public float WorldCameraRange = 30.0f;
 }
 
@@ -36,4 +39,12 @@ public enum ActiveState {
 	Target,
 	Selection,
 	Both
+}
+
+[Flags]
+public enum WorldFilters {
+	None = 0,
+	Objects = 1,
+	Actors = 2,
+	Lights = 4,
 }

--- a/Ktisis/Data/Files/SceneFile.cs
+++ b/Ktisis/Data/Files/SceneFile.cs
@@ -30,6 +30,7 @@ public class SceneFile : JsonFile {
 	public List<CameraInfo> Cameras  { get; set; } = new List<CameraInfo>();
 	public EnvironmentInfo Environment { get; set; } = new EnvironmentInfo();
 	public List<OverlayInfo> Overlays { get; set; } = new List<OverlayInfo>();
+	public List<ObjectInfo> Objects { get; set; } = new List<ObjectInfo>();
 	
 	[Serializable]
 	public struct ActorInfo {
@@ -136,5 +137,13 @@ public class SceneFile : JsonFile {
 	public struct AttachInfo {
 		public ushort ParentIndex { get; set; }
 		public string NodeName { get; set; }
+	}
+	
+	[Serializable]
+	public struct ObjectInfo {
+		public string Path { get; set; }
+		public string Name { get; set; }
+		public Transform Transform { get; set; }
+		public bool IsHidden { get; set; }
 	}
 }

--- a/Ktisis/Editor/Context/ContextBuilder.cs
+++ b/Ktisis/Editor/Context/ContextBuilder.cs
@@ -68,7 +68,7 @@ public class ContextBuilder {
 		IPluginContext state
 	) {
 		var context = new EditorContext(this._gpose, state);
-		
+
 		var scope = this._interop.CreateScope();
 
 		var input = new InputManager(context, scope, this._keyState);
@@ -79,20 +79,18 @@ public class ContextBuilder {
 		this._sceneData = new SceneDataService(context, this._objectTable, this._framework);
 		var autoSave = new PoseAutoSave(context, this._framework, this._format, this._sceneData );
 
-
-		
 		var editor = new EditorState(context, scope) {
 			Actions = actions,
 			Animation = new AnimationManager(context, scope, this._data, this._framework),
 			Cameras = new CameraManager(context, scope),
 			Characters = new CharacterManager(context, this._objectTable, scope, this._framework, this._mcdf),
-			Interface = new EditorInterface(context, state.Gui),
+			Interface = new EditorInterface(context, this._data, state.Gui),
 			Posing = new PosingManager(context, scope, this._framework, attach, autoSave),
 			Scene = new SceneManager(context, scope, this._framework, factory, this._objectTable, this._sceneData, this._overlay, this._world),
 			Selection = select,
 			Transform = new TransformHandler(context, actions, select)
 		};
-		
+
 		context.Setup(editor);
 		return context;
 	}

--- a/Ktisis/Interface/Components/Objects/PropertyEditor.cs
+++ b/Ktisis/Interface/Components/Objects/PropertyEditor.cs
@@ -36,6 +36,7 @@ public class PropertyEditor {
 			.Create<OverlayPropertyList>(ctx)
 			.Create<ImagePropertyList>(ctx)
 			.Create<WeaponPropertyList>()
+			.Create<ObjectEntityPropertyList>(ctx)
 			.Create<PresetPropertyList>(ctx);
 	}
 

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -95,6 +95,7 @@ public class SceneEntityMenuBuilder {
 		}
 		if (this._entity is ObjectEntity obj) {
 			menu.Separator();
+			menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.duplicate"), () => this.DuplicateObject(obj));
 			if (obj.Object is not null) {
 				menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.reset"), () => obj.Reset());
 				menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.untrack"), () => obj.Remove());
@@ -255,5 +256,28 @@ public class SceneEntityMenuBuilder {
 			newStatus.StatusText = oldStatus.StatusText;
 			newStatus.StatusType = oldStatus.StatusType;
 		}
+	}
+
+	private unsafe void DuplicateObject(ObjectEntity obj) {
+		var transform = obj.GetTransform();
+		if (transform is null) {
+			Ktisis.WarningNotification($"Could not duplicate object with null transform");
+			return;
+		}
+
+		var path = obj.GetPath();
+		var ptr = this._ctx.Scene.World.BuildObject(path);
+		if (ptr is null) {
+			Ktisis.WarningNotification($"Could not duplicate object with path: {path}");
+			return;
+		}
+
+		var name = obj.Name + " (Copy)";
+		var entity = this._ctx.Scene.Factory
+			.BuildObject()
+			.SetName(name)
+			.SetAddress(ptr)
+			.Add();
+		entity.SetTransform(transform);
 	}
 }

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -95,8 +95,12 @@ public class SceneEntityMenuBuilder {
 		}
 		if (this._entity is ObjectEntity obj) {
 			menu.Separator();
-			menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.reset"), () => obj.Reset());
-			menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.untrack"), () => obj.Remove());
+			if (obj.Object is not null) {
+				menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.reset"), () => obj.Reset());
+				menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.untrack"), () => obj.Remove());
+			} else {
+				menu.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.delete"), () => obj.Remove());
+			}
 		}
 	}
 	

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -212,6 +212,8 @@ public class EditorInterface : IEditorInterface {
 	public void OpenAssignCProfile(ActorEntity entity) => this._gui.CreatePopup<ActorCProfilePopup>(this._ctx, entity).Open();
 
 	public void OpenOverworldActorList() => this._gui.CreatePopup<OverworldActorPopup>(this._ctx).Open();
+
+	public void OpenObjectCreate() => this._gui.CreatePopup<SpawnObjectPopup>(this._ctx).Open();
 	
 	public void RefreshSceneEntities() {
 		this._ctx.Scene.GetModule<ActorModule>().RefreshGPoseActors();

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -219,7 +219,9 @@ public class EditorInterface : IEditorInterface {
 	public void OpenOverworldActorList() => this._gui.CreatePopup<OverworldActorPopup>(this._ctx).Open();
 
 	public void OpenObjectCreate() => this._gui.CreatePopup<SpawnObjectPopup>(this._ctx, this._data).Open();
-	
+
+	public void OpenWorldFilters() => this._gui.CreatePopup<WorldFilterPopup>(this._ctx).Open();
+
 	public void RefreshSceneEntities() {
 		this._ctx.Scene.GetModule<ActorModule>().RefreshGPoseActors();
 		this._ctx.Scene.GetModule<LightModule>().RefreshLightEntities();

--- a/Ktisis/Interface/Editor/EditorInterface.cs
+++ b/Ktisis/Interface/Editor/EditorInterface.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Dalamud.Bindings.ImGui;
+using Dalamud.Plugin.Services;
+
 using GLib.Popups.ImFileDialog;
 
 using Ktisis.Data.Files;
@@ -30,15 +32,18 @@ namespace Ktisis.Interface.Editor;
 
 public class EditorInterface : IEditorInterface {
 	private readonly IEditorContext _ctx;
+	private readonly IDataManager _data;
 	private readonly GuiManager _gui;
 
 	private readonly GizmoManager _gizmo;
 	
 	public EditorInterface(
 		IEditorContext ctx,
+		IDataManager data,
 		GuiManager gui
 	) {
 		this._ctx = ctx;
+		this._data = data;
 		this._gui = gui;
 		this._gizmo = new(ctx.Config);
 	}
@@ -213,7 +218,7 @@ public class EditorInterface : IEditorInterface {
 
 	public void OpenOverworldActorList() => this._gui.CreatePopup<OverworldActorPopup>(this._ctx).Open();
 
-	public void OpenObjectCreate() => this._gui.CreatePopup<SpawnObjectPopup>(this._ctx).Open();
+	public void OpenObjectCreate() => this._gui.CreatePopup<SpawnObjectPopup>(this._ctx, this._data).Open();
 	
 	public void RefreshSceneEntities() {
 		this._ctx.Scene.GetModule<ActorModule>().RefreshGPoseActors();

--- a/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
@@ -5,13 +5,9 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Utility;
 
-using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
-
 using Ktisis.Common.Utility;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Types;
-using Ktisis.Scene.Entities.World;
-using Ktisis.Structs.Objects;
 
 namespace Ktisis.Interface.Editor.Popup;
 
@@ -22,14 +18,19 @@ public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPo
 		ImGui.Text("Spawn Object");
 		using (ImRaii.Disabled()) {
 			ImGui.Text("Enter a valid .mdl path below to spawn a new BgObject.");
-			ImGui.TextWrapped("File paths can be sourced from Pathfinder, Textools, Brio, and Ktisis' world objects.");
+			ImGui.Text("File paths can be sourced from Pathfinder, Textools, Brio, and Ktisis' world objects.");
 		}
 
 		ImGui.Spacing();
-		ImGui.InputText("Path:", ref this.ModelPath);
+		ImGui.Text("Path:");
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+
+		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+		ImGui.InputText("##spawnerinputtext", ref this.ModelPath);
 		ImGui.Spacing();
+
 		using (ImRaii.Disabled(this.ModelPath.IsNullOrEmpty()))
-			if (ImGui.Button("Load"))
+			if (ImGui.Button("Spawn"))
 				this.Confirm();
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		if (ImGui.Button("Close"))

--- a/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+
+using Dalamud.Interface.Utility.Raii;
+
+using Dalamud.Bindings.ImGui;
+using Dalamud.Utility;
+
+using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
+
+using Ktisis.Common.Utility;
+using Ktisis.Editor.Context.Types;
+using Ktisis.Interface.Types;
+using Ktisis.Scene.Entities.World;
+using Ktisis.Structs.Objects;
+
+namespace Ktisis.Interface.Editor.Popup;
+
+public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPopup", ImGuiWindowFlags.Modal) {
+	private string ModelPath = "";
+
+	protected override void OnDraw() {
+		ImGui.Text("Spawn Object");
+		using (ImRaii.Disabled()) {
+			ImGui.Text("Enter a valid .mdl path below to spawn a new BgObject.");
+			ImGui.TextWrapped("File paths can be sourced from Pathfinder, Textools, Brio, and Ktisis' world objects.");
+		}
+
+		ImGui.Spacing();
+		ImGui.InputText("Path:", ref this.ModelPath);
+		ImGui.Spacing();
+		using (ImRaii.Disabled(this.ModelPath.IsNullOrEmpty()))
+			if (ImGui.Button("Load"))
+				this.Confirm();
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+		if (ImGui.Button("Close"))
+			this.Close();
+	}
+
+	private unsafe void Confirm() {
+		var ptr = ctx.Scene.World.BuildObject(this.ModelPath);
+		if (ptr is null) {
+			Ktisis.WarningNotification($"Could not create object with path: {this.ModelPath}");
+			this.Close();
+		}
+
+		var name = this.ModelPath.Split("/").Last().Split(".").First();
+		var entity = ctx.Scene.Factory
+			.BuildObject()
+			.SetName(name)
+			.SetAddress(ptr)
+			.Add();
+		entity.SetTransform(new Transform(ctx.Scene.GetSceneOrigin()));
+		this.Close();
+	}
+}

--- a/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
@@ -3,16 +3,20 @@ using System.Linq;
 using Dalamud.Interface.Utility.Raii;
 
 using Dalamud.Bindings.ImGui;
+using Dalamud.Plugin.Services;
 using Dalamud.Utility;
 
 using Ktisis.Common.Utility;
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Types;
 
+using Lumina.Data.Files;
+
 namespace Ktisis.Interface.Editor.Popup;
 
-public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPopup", ImGuiWindowFlags.Modal) {
+public class SpawnObjectPopup(IEditorContext ctx, IDataManager data) : KtisisPopup("##SpawnObjectPopup", ImGuiWindowFlags.Modal) {
 	private string ModelPath = "";
+	private bool Valid;
 
 	protected override void OnDraw() {
 		ImGui.Text(Ktisis.Locale.Translate("popups.spawn_obj.header"));
@@ -26,15 +30,21 @@ public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPo
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-		ImGui.InputText("##spawnerinputtext", ref this.ModelPath);
+		if (ImGui.InputText("##spawnerinputtext", ref this.ModelPath))
+			this.Validate();
 		ImGui.Spacing();
 
-		using (ImRaii.Disabled(this.ModelPath.IsNullOrEmpty()))
+		using (ImRaii.Disabled(this.ModelPath.IsNullOrEmpty() || !this.Valid))
 			if (ImGui.Button(Ktisis.Locale.Translate("popups.spawn_obj.spawn")))
 				this.Confirm();
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		if (ImGui.Button(Ktisis.Locale.Translate("popups.spawn_obj.close")))
 			this.Close();
+	}
+
+	private void Validate() {
+		this.Valid = data.GetFile<MdlFile>(this.ModelPath) != null;
+		Ktisis.Log.Verbose($"Path: {this.ModelPath}\nValid: {this.Valid}");
 	}
 
 	private unsafe void Confirm() {

--- a/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/SpawnObjectPopup.cs
@@ -15,14 +15,14 @@ public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPo
 	private string ModelPath = "";
 
 	protected override void OnDraw() {
-		ImGui.Text("Spawn Object");
+		ImGui.Text(Ktisis.Locale.Translate("popups.spawn_obj.header"));
 		using (ImRaii.Disabled()) {
-			ImGui.Text("Enter a valid .mdl path below to spawn a new BgObject.");
-			ImGui.Text("File paths can be sourced from Pathfinder, Textools, Brio, and Ktisis' world objects.");
+			ImGui.Text(Ktisis.Locale.Translate("popups.spawn_obj.explain_1"));
+			ImGui.Text(Ktisis.Locale.Translate("popups.spawn_obj.explain_2"));
 		}
 
 		ImGui.Spacing();
-		ImGui.Text("Path:");
+		ImGui.Text($"{Ktisis.Locale.Translate("popups.spawn_obj.path")}:");
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
@@ -30,10 +30,10 @@ public class SpawnObjectPopup(IEditorContext ctx) : KtisisPopup("##SpawnObjectPo
 		ImGui.Spacing();
 
 		using (ImRaii.Disabled(this.ModelPath.IsNullOrEmpty()))
-			if (ImGui.Button("Spawn"))
+			if (ImGui.Button(Ktisis.Locale.Translate("popups.spawn_obj.spawn")))
 				this.Confirm();
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		if (ImGui.Button("Close"))
+		if (ImGui.Button(Ktisis.Locale.Translate("popups.spawn_obj.close")))
 			this.Close();
 	}
 

--- a/Ktisis/Interface/Editor/Popup/WorldFilterPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/WorldFilterPopup.cs
@@ -1,0 +1,26 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility.Raii;
+
+using Ktisis.Data.Config.Sections;
+using Ktisis.Editor.Context.Types;
+using Ktisis.Interface.Types;
+
+namespace Ktisis.Interface.Editor.Popup;
+
+public class WorldFilterPopup(IEditorContext ctx) : KtisisPopup("##WorldFilterPopup") {
+	protected override void OnDraw() {
+		var objects = ctx.Config.Overlay.ActiveWorldFilters.HasFlag(WorldFilters.Objects);
+		var actors = ctx.Config.Overlay.ActiveWorldFilters.HasFlag(WorldFilters.Actors);
+		var lights = ctx.Config.Overlay.ActiveWorldFilters.HasFlag(WorldFilters.Lights);
+
+		using (ImRaii.PushColor(ImGuiCol.Text, ctx.Config.Overlay.WorldNodeColor))
+			if (ImGui.Checkbox(Ktisis.Locale.Translate("popups.world_filters.objects"), ref objects))
+				ctx.Config.Overlay.ActiveWorldFilters ^= WorldFilters.Objects;
+		using (ImRaii.PushColor(ImGuiCol.Text, ctx.Config.Overlay.ActorNodeColor))
+			if (ImGui.Checkbox(Ktisis.Locale.Translate("popups.world_filters.actors"), ref actors))
+				ctx.Config.Overlay.ActiveWorldFilters ^= WorldFilters.Actors;
+		using (ImRaii.PushColor(ImGuiCol.Text, ctx.Config.Overlay.LightNodeColor))
+			if (ImGui.Checkbox(Ktisis.Locale.Translate("popups.world_filters.lights"), ref lights))
+				ctx.Config.Overlay.ActiveWorldFilters ^= WorldFilters.Lights;
+	}
+}

--- a/Ktisis/Interface/Editor/Popup/WorldObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/WorldObjectPopup.cs
@@ -15,25 +15,25 @@ public class WorldObjectPopup(WorldObject obj, float distance, IEditorContext ct
 	public WorldObject WorldObj;
 	protected override void OnDraw() {
 		this.WorldObj = obj;
-		ImGui.Text($"Object Details");
+		ImGui.Text(Ktisis.Locale.Translate("popups.world_obj.header"));
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		using (ImRaii.Disabled())
-			ImGui.Text($"\tAddress: {obj.Address:X}");
+			ImGui.Text($"\t{Ktisis.Locale.Translate("popups.world_obj.addr")}: {obj.Address:X}");
 
 		ImGui.Separator();
-		ImGui.Text($"Model path: {obj.Path}");
-		ImGui.Text($"Distance: {distance:0.00}y");
+		ImGui.Text($"{Ktisis.Locale.Translate("popups.world_obj.path")}: {obj.Path}");
+		ImGui.Text($"{Ktisis.Locale.Translate("popups.world_obj.dist")}: {distance:0.00}y");
 
 		ImGui.Spacing();
-		if (ImGui.Button("Add"))
+		if (ImGui.Button(Ktisis.Locale.Translate("popups.world_obj.add")))
 			this.Confirm();
 
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		if (ImGui.Button("Hide"))
+		if (ImGui.Button(Ktisis.Locale.Translate("popups.world_obj.hide")))
 			this.ConfirmAndHide();
 
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
-		if (ImGui.Button("Cancel"))
+		if (ImGui.Button(Ktisis.Locale.Translate("popups.world_obj.cancel")))
 			this.Close();
 	}
 

--- a/Ktisis/Interface/Editor/Popup/WorldObjectPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/WorldObjectPopup.cs
@@ -3,6 +3,9 @@ using System.Linq;
 using Dalamud.Interface.Utility.Raii;
 
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+
+using GLib.Widgets;
 
 using Ktisis.Editor.Context.Types;
 using Ktisis.Interface.Types;
@@ -21,6 +24,9 @@ public class WorldObjectPopup(WorldObject obj, float distance, IEditorContext ct
 			ImGui.Text($"\t{Ktisis.Locale.Translate("popups.world_obj.addr")}: {obj.Address:X}");
 
 		ImGui.Separator();
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Clipboard, Ktisis.Locale.Translate("object_edit.object.copy_path")))
+			ImGui.SetClipboardText(obj.Path);
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		ImGui.Text($"{Ktisis.Locale.Translate("popups.world_obj.path")}: {obj.Path}");
 		ImGui.Text($"{Ktisis.Locale.Translate("popups.world_obj.dist")}: {distance:0.00}y");
 

--- a/Ktisis/Interface/Editor/Properties/ObjectEntityPropertyList.cs
+++ b/Ktisis/Interface/Editor/Properties/ObjectEntityPropertyList.cs
@@ -1,0 +1,61 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Utility.Raii;
+
+using GLib.Widgets;
+
+using Ktisis.Editor.Context.Types;
+using Ktisis.Interface.Editor.Properties.Types;
+using Ktisis.Scene.Entities;
+using Ktisis.Scene.Entities.World;
+
+namespace Ktisis.Interface.Editor.Properties;
+
+public class ObjectEntityPropertyList : ObjectPropertyList {
+	private readonly IEditorContext _ctx;
+
+	public ObjectEntityPropertyList(
+		IEditorContext ctx
+	) {
+		this._ctx = ctx;
+	}
+
+	public override void Invoke(IPropertyListBuilder builder, SceneEntity entity) {
+		if (entity is not ObjectEntity obj) return;
+		builder.AddHeader(Ktisis.Locale.Translate("object_edit.object.header"), () => this.DrawTab(obj), priority: -1);
+	}
+
+	private void DrawTab(ObjectEntity obj) {
+		var name = obj.Name;
+		if (ImGui.InputText(Ktisis.Locale.Translate("object_edit.object.rename"), ref name, 100))
+			obj.Name = name;
+
+		Separators.SeparatorText(Ktisis.Locale.Translate("object_edit.object.title"), textColor:ImGui.GetColorU32(ImGuiCol.Header));
+
+		// diagnostics
+		ImGui.Spacing();
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Clipboard, Ktisis.Locale.Translate("object_edit.object.copy_path")))
+			ImGui.SetClipboardText(obj.GetPath());
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+		ImGui.Text($"{Ktisis.Locale.Translate("object_edit.object.path")}: {obj.GetPath()}");
+
+		ImGui.Spacing();
+		ImGui.Text($"{Ktisis.Locale.Translate("object_edit.object.type")}: {(obj.IsWorldObject() ? Ktisis.Locale.Translate("object_edit.object.type.world") : Ktisis.Locale.Translate("object_edit.object.type.spawned"))}");
+		using (ImRaii.Disabled())
+			ImGui.Text($"{Ktisis.Locale.Translate("object_edit.object.addr")}: {obj.Address:X}");
+
+		// buttons
+		ImGui.Spacing();
+		if (obj.IsWorldObject()) {
+			if (ImGui.Button(Ktisis.Locale.Translate("workspace.entity_menu.base.reset")))
+				obj.Reset();
+
+			ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+			if (ImGui.Button(Ktisis.Locale.Translate("workspace.entity_menu.base.untrack")))
+				obj.Remove();
+		} else {
+			if (ImGui.Button(Ktisis.Locale.Translate("workspace.entity_menu.base.delete")))
+				obj.Remove();
+		}
+	}
+}

--- a/Ktisis/Interface/Editor/Types/IEditorInterface.cs
+++ b/Ktisis/Interface/Editor/Types/IEditorInterface.cs
@@ -39,6 +39,7 @@ public interface IEditorInterface {
 	public void OpenAssignCProfile(ActorEntity entity);
 	public void OpenOverworldActorList();
 	public void OpenObjectCreate();
+	public void OpenWorldFilters();
 	
 	public void RefreshSceneEntities();
 	public void SelectAllEntities();

--- a/Ktisis/Interface/Editor/Types/IEditorInterface.cs
+++ b/Ktisis/Interface/Editor/Types/IEditorInterface.cs
@@ -38,6 +38,7 @@ public interface IEditorInterface {
 	public void OpenApplyDesign(ActorEntity entity);
 	public void OpenAssignCProfile(ActorEntity entity);
 	public void OpenOverworldActorList();
+	public void OpenObjectCreate();
 	
 	public void RefreshSceneEntities();
 	public void SelectAllEntities();

--- a/Ktisis/Interface/Overlay/SceneDraw.cs
+++ b/Ktisis/Interface/Overlay/SceneDraw.cs
@@ -77,9 +77,12 @@ public class SceneDraw {
 			this._isHoveringActor = false;
 			this._isHoveringLight = false;
 
-			this.DrawWorldObjects();
-			this.DrawWorldActors();
-			this.DrawWorldLights();
+			if (this.Config.ActiveWorldFilters.HasFlag(WorldFilters.Objects))
+				this.DrawWorldObjects();
+			if (this.Config.ActiveWorldFilters.HasFlag(WorldFilters.Actors))
+				this.DrawWorldActors();
+			if (this.Config.ActiveWorldFilters.HasFlag(WorldFilters.Lights))
+				this.DrawWorldLights();
 
 			if (!this._isHoveringWorld)
 				this.SetHovered(null);

--- a/Ktisis/Interface/Windows/Editors/SceneWindow.cs
+++ b/Ktisis/Interface/Windows/Editors/SceneWindow.cs
@@ -43,7 +43,7 @@ public class SceneWindow : KtisisWindow {
 	private ISharedImmediateTexture? _texture;
 	private Map _source;
 	private SceneMCDFModal? _popupWindow;
-	private bool _includeActors, _includeLights, _includeCameras, _includeEnv, _includeOverlays, _preserveActors;
+	private bool _includeActors, _includeLights, _includeCameras, _includeEnv, _includeOverlays, _includeObjects,  _preserveActors;
 	
 	public SceneWindow(
 		IEditorContext ctx,
@@ -57,7 +57,7 @@ public class SceneWindow : KtisisWindow {
 		this._sceneFile = null;
 		this._dataManager = dataManager;
 		this._textureProvider = textureProvider;
-		this._includeActors = this._includeCameras = this._includeLights = this._includeEnv = this._includeOverlays  = true;
+		this._includeActors = this._includeCameras = this._includeLights = this._includeEnv = this._includeOverlays = this._includeObjects = true;
 		this._preserveActors = false;
 	}
 	
@@ -97,19 +97,21 @@ public class SceneWindow : KtisisWindow {
 		this.MapStuff();
 		var iconSize = UiBuilder.DefaultFontSizePx * ImGuiHelpers.GlobalScale * 2;
 		var iconBtnSize = new Vector2(iconSize, iconSize);
-		int cameras, actors, lights, overlays;
+		int cameras, actors, lights, overlays, objects;
 		bool envOver;
 		if (this._sceneFile != null) {
 			actors = this._sceneFile.Actors.Count;
 			cameras = this._sceneFile.Cameras.Count;
 			lights = this._sceneFile.Lights.Count;
 			overlays = this._sceneFile.Overlays.Count;
+			objects = this._sceneFile.Objects.Count;
 			envOver = this._sceneFile.Environment.Override > 0;
 		} else {
 			actors = this._ctx.Scene.Children.Count(entity => entity is CharaEntity);
 			lights = this._ctx.Scene.Children.Count(entity => entity is LightEntity);
 			overlays = this._ctx.Scene.Children.Count(entity => entity is OverlayEntity);
 			cameras = this._ctx.Cameras.GetCameras().Count();
+			objects = this._ctx.Scene.Children.Count(entity => entity is ObjectEntity);
 			envOver = this._ctx.Scene.GetModule<EnvModule>().Override > 0;
 		}
 		
@@ -119,7 +121,7 @@ public class SceneWindow : KtisisWindow {
 		
 		using(ImRaii.Disabled(this._sceneFile != null))
 			if (Buttons.IconButtonTooltip(FontAwesomeIcon.Save, $"{(this._sceneFile == null? "Save Scene file" : "Unload current Scene before saving" )}", iconBtnSize*1.5f))
-				this._ctx.Interface.ExportSceneFile((this._ctx.Scene.Data.Save(this._includeActors, this._includeLights, this._includeCameras, this._includeEnv, this._includeOverlays)));
+				this._ctx.Interface.ExportSceneFile((this._ctx.Scene.Data.Save(this._includeActors, this._includeLights, this._includeCameras, this._includeEnv, this._includeOverlays, this._includeObjects)));
 
 		if (this._sceneFile != null) {
 			ImGui.SetCursorPosY(ImGui.GetWindowHeight()  + ImGui.GetStyle().ItemSpacing.Y - (((iconBtnSize.Y * 1.5f + ImGui.GetStyle().ItemSpacing.Y) * 3f ) + ImGui.GetStyle().WindowPadding.Y));  //space for 2 buttons?
@@ -128,7 +130,7 @@ public class SceneWindow : KtisisWindow {
 			if (Buttons.IconButtonTooltip(this._autosave ? FontAwesomeIcon.Globe : FontAwesomeIcon.HouseChimney, $"Choose coordinate type\nCurrently: {(this._autosave ? "World space" : "Local space")}", iconBtnSize*1.5f))
 				this._autosave = !this._autosave;
 			if (Buttons.IconButtonTooltip(FontAwesomeIcon.Check, "Apply Scene", iconBtnSize*1.5f)) {
-				this._sceneDataService.Load(this._sceneFile, this._autosave, this._includeActors, this._includeLights, this._includeCameras, this._includeEnv,  this._includeOverlays, this._preserveActors);
+				this._sceneDataService.Load(this._sceneFile, this._autosave, this._includeActors, this._includeLights, this._includeCameras, this._includeEnv,  this._includeOverlays, this._includeObjects, this._preserveActors);
 				this._sceneFile = null;
 			}
 		}
@@ -242,7 +244,23 @@ public class SceneWindow : KtisisWindow {
 						}
 						ImGui.Unindent();
 					}
-				
+				if (objects > 0)
+					if (ImGui.CollapsingHeader($"Objects {objects}")) {
+						if (this._sceneFile is { Objects.Count: > 0 }) {
+							ImGui.Checkbox("Load Objects", ref this._includeObjects);
+							ImGui.Indent();
+							foreach (var objectInfo in this._sceneFile!.Objects) {
+								ImGui.TextUnformatted($"{objectInfo.Name}");
+							}
+						} else {
+							ImGui.Checkbox("Save Objects", ref this._includeObjects);
+							ImGui.Indent();
+							foreach (var objectInfo in this._ctx.Scene.Children.Where(entity => entity is ObjectEntity)) {
+								ImGui.TextUnformatted($"{objectInfo.Name}");
+							}
+						}
+						ImGui.Unindent();
+					}
 				if (envOver)
 					if (ImGui.CollapsingHeader($"Environment")) {
 						if (this._sceneFile != null) {

--- a/Ktisis/Interface/Windows/WorkspaceWindow.cs
+++ b/Ktisis/Interface/Windows/WorkspaceWindow.cs
@@ -188,6 +188,12 @@ public class WorkspaceWindow : KtisisWindow {
 		if (!this._ctx.ShowWorldObjects) return;
 
 		ImGui.Spacing(); // newline for overlay controls
+		// filter popup
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Filter, this._ctx.Locale.Translate("workspace.overlay.world_filters")))
+			this.Interface.OpenWorldFilters();
+		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+
+		// range slider
 		ImGui.Text(this._ctx.Locale.Translate("workspace.overlay.range"));
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);

--- a/Ktisis/Interface/Windows/WorkspaceWindow.cs
+++ b/Ktisis/Interface/Windows/WorkspaceWindow.cs
@@ -74,6 +74,9 @@ public class WorkspaceWindow : KtisisWindow {
 		this._workspace.Draw();
 
 		var botHeight = (UiBuilder.DefaultFontSizePx + (style.ItemSpacing.Y + style.ItemInnerSpacing.Y) * 2) * ImGuiHelpers.GlobalScale;
+		if (this._ctx.ShowWorldObjects)
+			botHeight *= 2; // draw another row at the bottom if we're showing the overlay range+filters buttons
+
 		var treeHeight = Math.Max(ImGui.GetContentRegionAvail().Y, ImGui.GetTextLineHeightWithSpacing()*10) - botHeight;
 		this._sceneTree.Draw(treeHeight);
 
@@ -148,6 +151,7 @@ public class WorkspaceWindow : KtisisWindow {
 	// Scene tree buttons
 
 	protected private void DrawSceneTreeButtons() {
+		// actor button
 		if (Buttons.IconButtonDropdown(FontAwesomeIcon.PeopleGroup, this.Interface.OpenActorCreateMenu))
 			this._ctx.Scene.Factory.CreateActor().Spawn();
 		if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
@@ -156,6 +160,7 @@ public class WorkspaceWindow : KtisisWindow {
 		}
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
+		// light button
 		if (Buttons.IconButtonDropdown(FontAwesomeIcon.Lightbulb, this.Interface.OpenLightCreateMenu))
 			this._ctx.Scene.Factory.CreateLight().Spawn();
 		if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
@@ -165,19 +170,24 @@ public class WorkspaceWindow : KtisisWindow {
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
 
+		// dialog button
 		if (Buttons.IconButtonTooltip(FontAwesomeIcon.CommentDots, this._ctx.Locale.Translate("workspace.create_overlay")))
 			this.Interface.OpenOverlayCreateMenu();
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 
-		// world overlay
+		// object spawner
+		if (Buttons.IconButtonTooltip(FontAwesomeIcon.Cube, this._ctx.Locale.Translate("workspace.create_object")))
+			this.Interface.OpenObjectCreate();
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+
+		// world overlay
 		using (ImRaii.PushColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive), this._ctx.ShowWorldObjects)) {
 			if (Buttons.IconButtonTooltip(FontAwesomeIcon.Mountain, this._ctx.Locale.Translate("workspace.overlay.world_toggle")))
 				this._ctx.ShowWorldObjects = !this._ctx.ShowWorldObjects;
 		}
 		if (!this._ctx.ShowWorldObjects) return;
 
-		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
+		ImGui.Spacing(); // newline for overlay controls
 		ImGui.Text(this._ctx.Locale.Translate("workspace.overlay.range"));
 		ImGui.SameLine(0, ImGui.GetStyle().ItemInnerSpacing.X);
 		ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -527,6 +527,17 @@
 				"tex": "Texture:",
 				"tex_hint": "Choose an icon for this status"
 			}
+		},
+		"object": {
+			"header": "Object",
+			"title": "Object Info",
+			"rename": "Name",
+			"copy_path": "Copy Path",
+			"path": "Model Path",
+			"type": "Object Type",
+			"type.world": "World Object",
+			"type.spawned": "Spawned Object",
+			"addr": "Address"
 		}
 	},
 	

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -692,6 +692,26 @@
 		}
 	},
 
+	"popups": {
+		"world_obj": {
+			"header": "Object Details",
+			"addr": "Address",
+			"path": "Model Path",
+			"dist": "Distance",
+			"add": "Add",
+			"hide": "Hide",
+			"cancel": "Cancel"
+		},
+		"spawn_obj": {
+			"header": "Spawn Object",
+			"explain_1": "Enter a valid .mdl path below to spawn a new BgObject.",
+			"explain_2": "File paths can be sourced from Pathfinder, Textools, Brio, and Ktisis' world objects.",
+			"path": "Path",
+			"spawn": "Spawn",
+			"close": "Close"
+		}
+	},
+
 	"config": {
 		"title": "Ktisis Settings",
 		"categories": {

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -240,6 +240,7 @@
 		"create_actor": "Create Actor\nDrop-down for options...",
 		"create_light": "Create Light\nDrop-down for options...",
 		"create_overlay": "Create Overlay",
+		"create_object": "[Alpha] Create Object from Path",
 		"refresh_entities": "Refresh scene entities",
 		"edit_mode.hint": "Select editing mode",
 		"overlay.hide": "Hide Ktisis overlay",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -246,6 +246,7 @@
 		"overlay.hide": "Hide Ktisis overlay",
 		"overlay.show": "Show Ktisis overlay",
 		"overlay.world_toggle": "Toggle world object overlay",
+		"overlay.world_filters": "World filters",
 		"overlay.range": "Range:"
 	},
 
@@ -710,6 +711,11 @@
 			"path": "Path",
 			"spawn": "Spawn",
 			"close": "Close"
+		},
+		"world_filters": {
+			"objects": "Objects",
+			"actors": "Actors",
+			"lights": "Lights"
 		}
 	},
 

--- a/Ktisis/Scene/Entities/World/ObjectEntity.cs
+++ b/Ktisis/Scene/Entities/World/ObjectEntity.cs
@@ -39,6 +39,7 @@ public class ObjectEntity : WorldEntity, IHideable {
 		if (obj->ModelResourceHandle->LoadState == 7) {
 			obj->UpdateCulling();
 			obj->UpdateRender();
+			obj->UpdateMaterials();
 			this.NeedsCulling = false;
 		}
 	}

--- a/Ktisis/Scene/Entities/World/ObjectEntity.cs
+++ b/Ktisis/Scene/Entities/World/ObjectEntity.cs
@@ -60,6 +60,18 @@ public class ObjectEntity : WorldEntity, IHideable {
 				drawPtr->IsVisible = !drawPtr->IsVisible;
 		}
 	}
+
+	public unsafe string GetPath() {
+		if (this.Object is not null)
+			return this.Object.Value.Path;
+
+		var obj = (BgObject*)this.Address;
+		if (obj is null || obj->ModelResourceHandle is null) return "N/A";
+		return obj->ModelResourceHandle->FileName.ToString();
+	}
+
+	public bool IsWorldObject() => this.Object is not null;
+
 	public void ToggleHidden() => this.IsHidden = !this.IsHidden;
 
 	public unsafe void Reset() {

--- a/Ktisis/Scene/Entities/World/ObjectEntity.cs
+++ b/Ktisis/Scene/Entities/World/ObjectEntity.cs
@@ -10,7 +10,8 @@ using DrawObject = FFXIVClientStructs.FFXIV.Client.Graphics.Scene.DrawObject;
 namespace Ktisis.Scene.Entities.World;
 
 public class ObjectEntity : WorldEntity, IHideable {
-	public WorldObject Object;
+	public WorldObject? Object;
+	public bool NeedsCulling;
 
 	public ObjectEntity(
 		ISceneManager scene,
@@ -21,9 +22,31 @@ public class ObjectEntity : WorldEntity, IHideable {
 		this.Visible = true;
 	}
 
+	public ObjectEntity(
+		ISceneManager scene
+	) : base(scene) {
+		this.Type = EntityType.Model;
+		this.Visible = true;
+	}
+
+	public unsafe override void Update() {
+		base.Update();
+		if (this.Object != null && !this.NeedsCulling) return;
+
+		// for spawned objects, check loadstate and resourcehandle, then update culling+render
+		var obj = (BgObject*)this.Address;
+		if (obj is null || obj->ModelResourceHandle is null) return;
+		if (obj->ModelResourceHandle->LoadState == 7) {
+			obj->UpdateCulling();
+			obj->UpdateRender();
+			this.NeedsCulling = false;
+		}
+	}
+
 	public override void SetTransform(Transform trans) {
 		base.SetTransform(trans);
-		this.Object.Update();
+		this.Object?.Update();
+		this.NeedsCulling = true;
 	}
 
 	public unsafe bool IsHidden {
@@ -40,17 +63,29 @@ public class ObjectEntity : WorldEntity, IHideable {
 	public void ToggleHidden() => this.IsHidden = !this.IsHidden;
 
 	public unsafe void Reset() {
-		this.SetTransform(this.Object.InitialTransform);
+		if (this.Object is null) return;
+		this.SetTransform(this.Object.Value.InitialTransform);
 
-		if (this.Object.ObjectType != ObjectType.BgObject || this.Object.InitialFlags == null) return;
+		if (this.Object.Value.ObjectType != ObjectType.BgObject || this.Object.Value.InitialFlags == null) return;
 
 		var drawPtr = (DrawObject*)this.Address;
-		drawPtr->Flags = this.Object.InitialFlags.Value;
+		drawPtr->Flags = this.Object.Value.InitialFlags.Value;
+	}
+
+	public unsafe bool Despawn() {
+		if (this.Object is not null) return false;
+
+		var obj = (BgObject*)this.Address;
+		obj->CleanupRender();
+		obj->Dtor(1);
+
+		return true;
 	}
 
 	public override void Remove() {
 		try {
 			this.Reset();
+			this.Despawn();
 		} finally {
 			base.Remove();
 		}

--- a/Ktisis/Scene/Entities/World/ObjectEntity.cs
+++ b/Ktisis/Scene/Entities/World/ObjectEntity.cs
@@ -40,6 +40,7 @@ public class ObjectEntity : WorldEntity, IHideable {
 			obj->UpdateCulling();
 			obj->UpdateRender();
 			obj->UpdateMaterials();
+			obj->UpdateTransforms(false);
 			this.NeedsCulling = false;
 		}
 	}

--- a/Ktisis/Scene/Factory/Builders/ObjectBuilder.cs
+++ b/Ktisis/Scene/Factory/Builders/ObjectBuilder.cs
@@ -91,8 +91,10 @@ public sealed class ObjectBuilder : EntityBuilder<WorldEntity, IObjectBuilder>, 
 
 	private ObjectEntity BuildWorldObject() {
 		var obj = this.Scene.World.Objects.Where(w => w.Address == this.Address).FirstOrNull();
+
+		// if we're building a non-world object, create using no WorldObject
 		if (obj == null)
-			throw new Exception($"Attempted to build BgObject not present in WorldService.\nAddress: {this.Address:X}");
+			return new ObjectEntity(this.Scene);
 
 		return new ObjectEntity(this.Scene, obj.Value);
 	}

--- a/Ktisis/Services/Data/SceneDataService.cs
+++ b/Ktisis/Services/Data/SceneDataService.cs
@@ -84,7 +84,12 @@ public class SceneDataService {
 			Ktisis.Log.Warning("Failed to write Scene file");
 		}
 	}
-	public unsafe SceneFile Save(bool saveActors = true, bool saveLights = true, bool saveCameras = true, bool saveEnv = true, bool saveOverlays = true) {
+	public unsafe SceneFile Save(bool saveActors = true,
+		bool saveLights = true,
+		bool saveCameras = true,
+		bool saveEnv = true,
+		bool saveOverlays = true,
+		bool saveObjects = true) {
 
 
 			var scene = new SceneFile();
@@ -102,6 +107,9 @@ public class SceneDataService {
 				.ToList();
 		
 			var overlays = this.Scene.Children.OfType<OverlayEntity>()
+				.ToList();
+			
+			var objects = this.Scene.Children.OfType<ObjectEntity>()
 				.ToList();
 
 			Ktisis.Log.Debug("Collected all entity lists");
@@ -224,6 +232,11 @@ public class SceneDataService {
 					scene.Overlays.Add(file);
 				}
 			
+			if (saveObjects) {
+				foreach (var obj in objects) {
+					scene.Objects.Add(new SceneFile.ObjectInfo(){IsHidden = obj.IsHidden, Name = obj.Name, Path = obj.GetPath(), Transform = obj.GetTransform()});
+				}
+			}
 			
 			//Environment info 
 			if (saveEnv) {
@@ -254,7 +267,15 @@ public class SceneDataService {
 			return scene!;
 	}
 	
-	public async Task Load(SceneFile scene, bool autoSaveLoading = true, bool loadActors = true, bool loadLights = true, bool loadCameras = true, bool loadEnv = true, bool loadOverlays = true, bool preserveExistingActors = false) {
+	public async Task Load(SceneFile scene,
+		bool autoSaveLoading = true,
+		bool loadActors = true,
+		bool loadLights = true,
+		bool loadCameras = true,
+		bool loadEnv = true,
+		bool loadOverlays = true,
+		bool loadObjects = true,
+		bool preserveExistingActors = false) {
 		
 			this._idMap	= new Dictionary<ushort, ActorEntity>();
 
@@ -378,6 +399,18 @@ public class SceneDataService {
 						}
 
 					});
+				}
+			}
+			
+			if (loadObjects) {
+				unsafe {
+					foreach (var obj in scene.Objects) {
+						var ptr = this._ctx!.Scene.World.BuildObject(obj.Path);
+						var entity = this._ctx!.Scene.Factory.BuildObject().SetAddress(ptr).SetName(obj.Name).Add();
+						entity.Visible = obj.IsHidden;
+						entity.SetTransform(obj.Transform);
+						entity.Update();
+					}
 				}
 			}
 			

--- a/Ktisis/Services/Game/WorldService.cs
+++ b/Ktisis/Services/Game/WorldService.cs
@@ -7,6 +7,8 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using Ktisis.Core.Attributes;
 using Ktisis.Structs.Objects;
 
+using Object = FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Object;
+
 namespace Ktisis.Services.Game;
 
 [Singleton]
@@ -27,6 +29,11 @@ public class WorldService : IDisposable {
 	private void OnGPoseEvent(object sender, bool active) {
 		this.Clean();
 		if (active) this.BuildWorld();
+	}
+
+	public unsafe Object* BuildObject(string modelPath) {
+		var objectPtr = BgObject.Create(modelPath, "ktisis", null);
+		return (Object*)objectPtr;
 	}
 
 	public void Refresh() {

--- a/Ktisis/Structs/Objects/WorldObject.cs
+++ b/Ktisis/Structs/Objects/WorldObject.cs
@@ -49,6 +49,7 @@ public struct WorldObject : IEquatable<WorldObject> {
 			bgPtr->UpdateCulling();
 			bgPtr->UpdateRender();
 			bgPtr->UpdateMaterials();
+			bgPtr->UpdateTransforms(false);
 		}
 	}
 

--- a/Ktisis/Structs/Objects/WorldObject.cs
+++ b/Ktisis/Structs/Objects/WorldObject.cs
@@ -47,6 +47,8 @@ public struct WorldObject : IEquatable<WorldObject> {
 		if (this.Pointer.Value->GetObjectType() == ObjectType.BgObject) {
 			var bgPtr = (BgObject*)this.Address;
 			bgPtr->UpdateCulling();
+			bgPtr->UpdateRender();
+			bgPtr->UpdateMaterials();
 		}
 	}
 


### PR DESCRIPTION
first-draft of BgObject spawning per the `Spawn From Path` previews pitch https://discord.com/channels/975894364020686878/1413501837134397471/1529671101830135868

- Added WorldFilters to hide objects/actors/lights from the World Overlay
- updated WorkspaceWindow to separate World Range/Filters inputs to a newline when active
- added Create Object from Path button to Workspace creation bar; opening the SpawnObjectPopup
  - popup validates copy/pasted or manually-typed paths to ensure they point to a valid MdlFile using lumina/datamanger
- updated backend for ObjectEntities to support nullable WorldObjects; if WorldObject is null, we treat the ObjectEntity as a spawned object and will update/delete it differently than world-created ones
- added ObjectEntityPropertyList to surface diagnostic data & interaction buttons on World/Spawned objects
- added Duplication for ObjectEntities from workspace context menu
- added Copy to Clipboard on the WorldObjectPopup and propertylist path display to facilitate easier sharing/saving
- localization updates


https://github.com/user-attachments/assets/217d0be5-5d0e-4f03-8da7-c2cf4f36dc7a