### PR TITLE
TitleBarButtons

### DIFF
--- a/Ktisis/Interface/Types/KtisisWindow.cs
+++ b/Ktisis/Interface/Types/KtisisWindow.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Numerics;
 
 using Dalamud.Interface.Windowing;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Dalamud.Interface.Utility.Raii;
 
+using Ktisis.Common.Utility;
 using Ktisis.Events;
 
 namespace Ktisis.Interface.Types; 
@@ -18,6 +22,7 @@ public abstract class KtisisWindow : Window {
 
 	internal string _localeWindowName;
 	internal string _windowId;
+
 	protected KtisisWindow(
 		string localeWindowName,
 		ImGuiWindowFlags flags = ImGuiWindowFlags.None,
@@ -28,9 +33,10 @@ public abstract class KtisisWindow : Window {
 		this._windowId = windowId;
 		this.RespectCloseHotkey = false;
 		Ktisis.Locale.LocaleChanged += this.ChangeWindowLocale;
+
+		this.SetTitleBarButtons();
 	}
-	
-	
+
 	public void Open() => this.IsOpen = true;
 
 	public void Close() {
@@ -42,15 +48,31 @@ public abstract class KtisisWindow : Window {
 		}
 	}
 
-	private void ChangeWindowLocale() {
-		this.WindowName = Ktisis.Locale.Translate($"{this._localeWindowName}") + this._windowId;
-	}
-
 	public virtual void OnCreate() { }
 
 	public override void OnClose() {
 		Ktisis.Locale.LocaleChanged -= this.ChangeWindowLocale;
 		this._closedEvent.Invoke(this);
 	}
-	
+
+	private void ChangeWindowLocale() {
+		this.WindowName = Ktisis.Locale.Translate($"{this._localeWindowName}") + this._windowId;
+		this.SetTitleBarButtons();
+	}
+
+	private void SetTitleBarButtons() {
+		// used to append a number of TBBs to the top of each Ktisis window
+		this.TitleBarButtons.Clear();
+
+		// docs/wiki link
+		this.TitleBarButtons.Add(new TitleBarButton {
+			Icon = FontAwesomeIcon.QuestionCircle,
+			IconOffset = new Vector2(2.0f, 1.0f),
+			ShowTooltip = () => {
+				using var _ = ImRaii.Tooltip();
+				ImGui.Text(Ktisis.Locale.Translate("titlebar.help"));
+			},
+			Click = _ => GuiHelpers.OpenBrowser(Ktisis.Locale.Translate("titlebar.helpLinkout"))
+		});
+	}
 }

--- a/Ktisis/Interface/Windows/ToolbarWindow.cs
+++ b/Ktisis/Interface/Windows/ToolbarWindow.cs
@@ -44,7 +44,7 @@ public class ToolbarWindow : KtisisWindow {
 		this._ctx = ctx;
 		this._gui = gui;
 		this._workspace = new WorkspaceState(ctx);
-		this.Flags = this.Flags | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse;
+		this.Flags = this.Flags | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse;
 		this._buttons = new() {
 			new(this.DrawWorkspaceWindow, FontAwesomeIcon.PersonThroughWindow, Ktisis.Locale.Translate("toolbar.buttons.workspace"), typeof(Workspace)),
 			new(this.DrawObjectWindow, FontAwesomeIcon.ArrowsAlt, Ktisis.Locale.Translate("toolbar.buttons.object"), typeof(ObjectWindow)),

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -958,6 +958,11 @@
 		}
 	},
 
+	"titlebar": {
+		"help": "Help - Ktisis Docs",
+		"helpLinkout": "https://docs.ktisis.tools/"
+	},
+
 	"migrator": {
 		"title": "Ktisis v0.4 Setup",
 		"mainWindow": {


### PR DESCRIPTION
- added a Docs link to TBB based on concept from #270; this skips the contextual bells-and-whistles, though, since we don't have indiv. docs pages for every window/ui component
- restored toolbar minimize per https://discord.com/channels/975894364020686878/1482895772650438943/1530200051777798344

<img width="335" height="278" alt="image" src="https://github.com/user-attachments/assets/508fc62b-d1e8-4552-a92c-474dc29c0d1f" />
