### PR TITLE
ObjectTable / Init Hooks fixes

### DIFF
--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -296,16 +296,16 @@ public class ActorModule : SceneModule {
 		Ktisis.Log.Verbose("[Initialize] New Character? {0:X}", (nint) thisPtr);
 		
 		try {
-			_initializeHook.OriginalDisposeSafe(thisPtr);
+			this._initializeHook.OriginalDisposeSafe(thisPtr);
 		} catch (Exception e) {
 			Ktisis.Log.Error(e, "Error on Initialize");
 		}
 		
 		if (!this.CheckValid()) return;
 		
-		_framework.RunOnTick(() => {
+		this._framework.RunOnTick(() => {
 			this.Add(thisPtr);
-		}, delayTicks: 1); //delayed to allow internal code to handle 
+		}, delayTicks: 5); // delayed to allow internal code to handle, wait a bunch of ticks in case of chicanery
 	}
 	
 	private unsafe GameObject* Destructor(Character* thisPtr, byte freeFlags) {
@@ -355,21 +355,23 @@ public class ActorModule : SceneModule {
 
 	private unsafe void Add(Character* character) {
 		var gameObject = this._actors.GetAddress((nint)character);
-		if (gameObject is null || gameObject.ObjectIndex < 200) {
-			Ktisis.Log.Verbose("Unable to find gameobject, or below 200 for {0:X} ({1})", (nint)character, gameObject?.ObjectIndex);
-
+		if (gameObject is null) {
+			Ktisis.Log.Verbose($"GameObject is null for {(nint)character:X}");
+			return;
+		} if (gameObject.ObjectIndex <= 200) {
+			Ktisis.Log.Verbose($"GameObject at index {gameObject.ObjectIndex} is not in ClientObjectManager expected range, skipping");
+			return;
+		} if (!gameObject.IsValid()) {
+			Ktisis.Log.Verbose($"GameObject {gameObject.ObjectIndex} is currently invalid, skipping");
 			return;
 		}
 
-		// TODO: flaky?
-		// if (!gameObject.IsDrawing()) {
-		// 	Ktisis.Log.Debug("Actor[{0:X} / {1}] Actor not drawing, not adding", (nint)character, gameObject.ObjectIndex);
-		// 	return;
-		// }
-
 		var entity = this.Scene.GetEntityForActor(gameObject);
-
 		if (entity is not null) {
+			Ktisis.Log.Verbose($"GameObject already exists in workspace as {entity.Name}!");
+			return;
+		} if (gameObject.ObjectIndex == this._spawner.ExpectedIndex) {
+			Ktisis.Log.Verbose($"Spawner is already expecting a dispatched spawn for this actor at index {this._spawner.ExpectedIndex}");
 			return;
 		}
 
@@ -383,7 +385,7 @@ public class ActorModule : SceneModule {
 
 #endregion
 
-	
+
 	// Disposal
 
 	public override void Dispose() {

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -32,6 +33,7 @@ public class ActorModule : SceneModule {
 	private readonly GroupPoseModule _gpose;
 	
 	private readonly ActorSpawner _spawner;
+	private readonly HashSet<nint> _enqueuedChars;
 	
 	//Creation/Destruction hooks.
 	private readonly Hook<Character.Delegates.Terminate> _terminateHook;
@@ -51,6 +53,7 @@ public class ActorModule : SceneModule {
 		this._objectTable = objectTable;
 		this._framework = framework;
 		this._gpose = gpose;
+		this._enqueuedChars = [];
 		this._spawner = hook.Create<ActorSpawner>();
 		
 		_terminateHook = hooks.HookFromAddress<Character.Delegates.Terminate>((nint)Character.StaticVirtualTablePointer->Terminate, Terminate);
@@ -293,7 +296,8 @@ public class ActorModule : SceneModule {
 #region Creation/Destroy hooks
 
 	private unsafe void InitializeHook(Character* thisPtr) {
-		Ktisis.Log.Verbose("[Initialize] New Character? {0:X}", (nint) thisPtr);
+		var addr = (nint)thisPtr;
+		Ktisis.Log.Verbose($"[Initialize] New Character? {addr:X}");
 		
 		try {
 			this._initializeHook.OriginalDisposeSafe(thisPtr);
@@ -302,14 +306,16 @@ public class ActorModule : SceneModule {
 		}
 		
 		if (!this.CheckValid()) return;
-		
+
+		this._enqueuedChars.Add(addr);
 		this._framework.RunOnTick(() => {
 			this.Add(thisPtr);
-		}, delayTicks: 5); // delayed to allow internal code to handle, wait a bunch of ticks in case of chicanery
+			this._enqueuedChars.Remove(addr);
+		}, delayTicks: 1 + this._enqueuedChars.Count); // delayed to allow internal code to handle - stagger tick timings so that these can resolve in order of appearance
 	}
 	
 	private unsafe GameObject* Destructor(Character* thisPtr, byte freeFlags) {
-		Remove(thisPtr);
+		this.Remove(thisPtr);
 
 		try {
 			return _destroyHook.OriginalDisposeSafe(thisPtr, freeFlags);
@@ -320,7 +326,7 @@ public class ActorModule : SceneModule {
 	}
 	
 	private unsafe void Terminate(Character* character) {
-		Remove(character);
+		this.Remove(character);
 		
 		try {
 			_terminateHook.OriginalDisposeSafe(character);
@@ -331,7 +337,7 @@ public class ActorModule : SceneModule {
 
 	private unsafe void Remove(Character* character) {
 		try {
-			Ktisis.Log.Debug("Trying to remove actor {0:x}", (nint) character);
+			Ktisis.Log.Debug("Trying to remove actor {0:X}", (nint) character);
 			var gameObject = this._actors.GetAddress((nint)character);
 			if (gameObject is null) {
 				Ktisis.Log.Verbose("Unable to find gameobject for {0:X}", (nint)character);
@@ -356,27 +362,27 @@ public class ActorModule : SceneModule {
 	private unsafe void Add(Character* character) {
 		var gameObject = this._actors.GetAddress((nint)character);
 		if (gameObject is null) {
-			Ktisis.Log.Verbose($"GameObject is null for {(nint)character:X}");
+			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject is null");
 			return;
 		} if (gameObject.ObjectIndex <= 200) {
-			Ktisis.Log.Verbose($"GameObject at index {gameObject.ObjectIndex} is not in ClientObjectManager expected range, skipping");
+			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject at index {gameObject.ObjectIndex} is not in ClientObjectManager expected range, skipping");
 			return;
 		} if (!gameObject.IsValid()) {
-			Ktisis.Log.Verbose($"GameObject {gameObject.ObjectIndex} is currently invalid, skipping");
+			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject {gameObject.ObjectIndex} is currently invalid, skipping");
 			return;
 		}
 
 		var entity = this.Scene.GetEntityForActor(gameObject);
 		if (entity is not null) {
-			Ktisis.Log.Verbose($"GameObject already exists in workspace as {entity.Name}!");
+			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject already exists in workspace as {entity.Name}!");
 			return;
 		} if (gameObject.ObjectIndex == this._spawner.ExpectedIndex) {
-			Ktisis.Log.Verbose($"Spawner is already expecting a dispatched spawn for this actor at index {this._spawner.ExpectedIndex}");
+			Ktisis.Log.Verbose($"{(nint)character:X} - Spawner is already expecting a dispatched spawn for this actor at index {this._spawner.ExpectedIndex}");
 			return;
 		}
 
 		try {
-			Ktisis.Log.Info("Trying to add actor {0:X}", (nint)character);
+			Ktisis.Log.Info($"{(nint)character:X} - Trying to add actor from index {gameObject.ObjectIndex}");
 			this.AddActor((nint)character, false);
 		} catch (Exception e) {
 			Ktisis.Log.Error(e, "Error on Remove");
@@ -391,6 +397,6 @@ public class ActorModule : SceneModule {
 	public override void Dispose() {
 		base.Dispose();
 		this._spawner.Dispose();
-		GC.SuppressFinalize(this); 
+		GC.SuppressFinalize(this);
 	}
 }

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -306,8 +306,9 @@ public class ActorModule : SceneModule {
 		}
 		
 		if (!this.CheckValid()) return;
+		var added = this._enqueuedChars.Add(addr);
+		if (!added) return; // back out if we've already enqueued for this ptr
 
-		this._enqueuedChars.Add(addr);
 		this._framework.RunOnTick(() => {
 			this.Add(thisPtr);
 			this._enqueuedChars.Remove(addr);

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -364,7 +364,7 @@ public class ActorModule : SceneModule {
 		if (gameObject is null) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject is null");
 			return;
-		} else if (gameObject.ObjectIndex <= 200) {
+		} else if (gameObject.ObjectIndex is <= 200 or > 440) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject at index {gameObject.ObjectIndex} is not in ClientObjectManager expected range, skipping");
 			return;
 		} else if (!gameObject.IsValid()) {

--- a/Ktisis/Scene/Modules/Actors/ActorModule.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorModule.cs
@@ -364,10 +364,10 @@ public class ActorModule : SceneModule {
 		if (gameObject is null) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject is null");
 			return;
-		} if (gameObject.ObjectIndex <= 200) {
+		} else if (gameObject.ObjectIndex <= 200) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject at index {gameObject.ObjectIndex} is not in ClientObjectManager expected range, skipping");
 			return;
-		} if (!gameObject.IsValid()) {
+		} else if (!gameObject.IsValid()) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject {gameObject.ObjectIndex} is currently invalid, skipping");
 			return;
 		}
@@ -376,7 +376,7 @@ public class ActorModule : SceneModule {
 		if (entity is not null) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - GameObject already exists in workspace as {entity.Name}!");
 			return;
-		} if (gameObject.ObjectIndex == this._spawner.ExpectedIndex) {
+		} else if (gameObject.ObjectIndex == this._spawner.ExpectedIndex) {
 			Ktisis.Log.Verbose($"{(nint)character:X} - Spawner is already expecting a dispatched spawn for this actor at index {this._spawner.ExpectedIndex}");
 			return;
 		}

--- a/Ktisis/Scene/Modules/Actors/ActorSpawner.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorSpawner.cs
@@ -21,6 +21,7 @@ public class ActorSpawner : HookModule {
 	
 	private readonly IObjectTable _objectTable;
 	private readonly IFramework _framework;
+	internal uint? ExpectedIndex;
 	
 	public ActorSpawner(
 		IHookMediator hook,
@@ -91,18 +92,20 @@ public class ActorSpawner : HookModule {
 		IGameObject original,
 		CancellationToken token
 	) {
-
 		var index = await this._framework.RunOnFrameworkThread(() => {
 			if (!this.TryDispatch(original, out var index)) {
 				Ktisis.Log.Error("Object table is full.");
+				this.ExpectedIndex = null;
 				return 0xFFFFFFFF;
 			}
-				
+
 			return index;
 		});
 
-		if (index == 0xFFFFFFFF)
+		if (index == 0xFFFFFFFF) {
+			this.ExpectedIndex = null;
 			return nint.Zero;
+		}
 
 		while (!token.IsCancellationRequested) {
 			var result = await this._framework.RunOnFrameworkThread(
@@ -112,12 +115,15 @@ public class ActorSpawner : HookModule {
 				}
 			);
 
-			if (result != nint.Zero)
+			if (result != nint.Zero) {
+				this.ExpectedIndex = null;
 				return result;
-			
+			}
+
 			await Task.Delay(10, CancellationToken.None);
 		}
-		
+
+		this.ExpectedIndex = null;
 		throw new TaskCanceledException($"Actor spawn at index {index} timed out.");
 	}
 
@@ -126,8 +132,9 @@ public class ActorSpawner : HookModule {
 		index = (uint)id;
 		if (id == -1) return false;
 
-		index += 200; //ClientObjectManager starts at 200
+		index += 200; // ClientObjectManager starts at 200
 		Ktisis.Log.Info($"Dispatching, expecting spawn on {index}");
+		this.ExpectedIndex = index; // flag that we're currently expecting an actor on this index, only remove the flag when we've finished or failed CreateActor
 		this.DispatchSpawn(original);
 		return true;
 	}

--- a/Ktisis/Scene/Modules/Actors/ActorSpawner.cs
+++ b/Ktisis/Scene/Modules/Actors/ActorSpawner.cs
@@ -122,12 +122,10 @@ public class ActorSpawner : HookModule {
 	}
 
 	private unsafe bool TryDispatch(IGameObject original, out uint index) {
-		int id;
-		unchecked {
-			id = (int)FFXIVClientStructs.FFXIV.Client.Game.Object.ClientObjectManager.Instance()->CalculateNextAvailableIndex();
-			index = (uint)id;
-		}
+		var id = FFXIVClientStructs.FFXIV.Client.Game.Object.ClientObjectManager.Instance()->CalculateNextAvailableIndex(false);
+		index = (uint)id;
 		if (id == -1) return false;
+
 		index += 200; //ClientObjectManager starts at 200
 		Ktisis.Log.Info($"Dispatching, expecting spawn on {index}");
 		this.DispatchSpawn(original);


### PR DESCRIPTION
- adds ExpectedIndex to ActorModule: this indicates the currently-anticipated spawn on the object table, and is checked by ActorModule.Add to make sure we don't add an actor via initialize when we've pressed the button to create them ourselves.
  - this should fix issues where a duplicate actor using the PC's name could be spawned when manually pressing Add Actor or when loading a ktscene
- dynamically staggers ActorModule.Add runs by the count of encountered characters we've yet to process
  - this should aid the above issue (by slowing the possible race condition that causes Module and Spawner to collide)
  - this should also fix cases where Actor 202 ends up in the Workspace above Actor 201 - this was occurring when 200, 201, and 202 would be fired sequentially, but the framework tick they were all scheduled on would pick them up in different orders. with the stagger in place, 202 will now be guaranteed to fire one tick later than 201 if they were enqueued on the same frame, ensuring that they're first in the scenetree's ienumerable
  - this will matter less when we finish Folders work for reordering/dynamically sorting the scenetree
- un-obsoletes CalculateNextAvailableIndex