### PR TITLE
Add side swap for PreviewNode.cs

### DIFF
--- a/Ktisis/Interface/KTK/PreviewNode.cs
+++ b/Ktisis/Interface/KTK/PreviewNode.cs
@@ -166,7 +166,7 @@ public unsafe class PreviewNode : OverlayNode {
 		}
 
 		this.IsVisible = true;
-		var offset = this._fileWindow.Pos.X + this._fileWindow.Size.X + this.Border.Size.X > ImGui.GetIO().DisplaySize.X
+		var offset = this._fileWindow.Pos.X + this._fileWindow.Size.X + this.Border.Size.X > ImGui.GetMainViewport().Size.X
 			? -this.Border.Size.X : this._fileWindow.Size.X;
 		this.Position = new Vector2(this._fileWindow.Pos.X + offset, this._fileWindow.Pos.Y);
 

--- a/Ktisis/Interface/KTK/PreviewNode.cs
+++ b/Ktisis/Interface/KTK/PreviewNode.cs
@@ -166,7 +166,9 @@ public unsafe class PreviewNode : OverlayNode {
 		}
 
 		this.IsVisible = true;
-		this.Position = new Vector2(this._fileWindow.Pos.X + this._fileWindow.Size.X, this._fileWindow.Pos.Y);
+		var offset = this._fileWindow.Pos.X + this._fileWindow.Size.X + this.Border.Size.X > ImGui.GetIO().DisplaySize.X
+			? -this.Border.Size.X : this._fileWindow.Size.X;
+		this.Position = new Vector2(this._fileWindow.Pos.X + offset, this._fileWindow.Pos.Y);
 
 		if (this.NeedsUpdate() && this._currentPose != null) {
 			this._ctx.Posing.ApplyReferencePose(_actor.Pose);

--- a/Ktisis/Interface/KTK/PreviewNode.cs
+++ b/Ktisis/Interface/KTK/PreviewNode.cs
@@ -168,7 +168,7 @@ public unsafe class PreviewNode : OverlayNode {
 		this.IsVisible = true;
 		var offset = this._fileWindow.Pos.X + this._fileWindow.Size.X + this.Border.Size.X > ImGui.GetMainViewport().Size.X
 			? -this.Border.Size.X : this._fileWindow.Size.X;
-		this.Position = new Vector2(this._fileWindow.Pos.X + offset, this._fileWindow.Pos.Y);
+		this.Position = new Vector2(this._fileWindow.Pos.X + offset, this._fileWindow.Pos.Y) - ImGui.GetMainViewport().Pos;
 
 		if (this.NeedsUpdate() && this._currentPose != null) {
 			this._ctx.Posing.ApplyReferencePose(_actor.Pose);


### PR DESCRIPTION
Model preview will move to the left of FileDialog if it does not have enough space to render on the right.

https://github.com/user-attachments/assets/49b8831a-21f2-48e6-80f9-8955c159e0eb

