### PR TITLE
Disable actor renaming if incognito is active

### DIFF
--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Game.ClientState.Objects.Enums;
 
 using FFXIVClientStructs;
 
@@ -78,7 +79,9 @@ public class SceneEntityMenuBuilder {
 		if (this._entity is IAttachable attach && attach.IsAttached())
 			menu.Separator().Action(Ktisis.Locale.Translate("workspace.entity_menu.base.detach"), () => this._ctx.Posing.Attachments.Detach(attach));
 
-		menu.Separator().Action(Ktisis.Locale.Translate("workspace.entity_menu.base.rename"), () => this.Ui.OpenRenameEntity(this._entity));
+		menu.Separator()
+			.Action(Ktisis.Locale.Translate("workspace.entity_menu.base.rename"), () => this.Ui.OpenRenameEntity(this._entity))
+			.WithDisabled(() => this._entity is ActorEntity { Actor.ObjectKind: ObjectKind.Pc } && this._ctx.Config.Editor.IncognitoPlayerNames);
 
 		if (this._entity is IDeletable deletable) {
 			menu.Separator();


### PR DESCRIPTION
* Requires ktisis-tools/GLib@ba9205541292f1667a4f0fb0d3f902f725a3890f via ktisis-tools/GLib#7

<img width="401" height="453" alt="image" src="https://github.com/user-attachments/assets/17c83eca-24a0-412d-b478-ed12338ca3cf" />

*While incognito is active. Unsure if this is the intended solution, but could also add a note or tooltip somewhere here about incognito being active.*